### PR TITLE
Enforce `onlyWhenChannelClosed` modifier on `getResolution`

### DIFF
--- a/packages/contracts/contracts/AppInstance.sol
+++ b/packages/contracts/contracts/AppInstance.sol
@@ -146,7 +146,12 @@ contract AppInstance {
 
   /// @notice A getter function for the resolution if one is set
   /// @return A `Transfer.Transaction` object representing the resolution of the channel
-  function getResolution() public view returns (Transfer.Transaction) {
+  function getResolution()
+      public
+      view
+      onlyWhenChannelClosed
+      returns (Transfer.Transaction)
+  {
     return resolution;
   }
 


### PR DESCRIPTION
### Description

Before this PR, an open channel would return a default resolution (one where all fields was 0).
