### PR TITLE
[cf.js] Adds stoppable iteration for Client.removeObserver()

### DIFF
--- a/packages/cf.js/src/client.ts
+++ b/packages/cf.js/src/client.ts
@@ -172,11 +172,16 @@ export class Client implements Observable {
   ): Promise<ClientResponse> {
     let observerId;
 
-    this.observerCallbacks.forEach((value: Function, key: string) => {
+    const entries = this.observerCallbacks.entries();
+    let entry: IteratorResult<[string, Function]>;
+
+    while ((entry = entries.next())) {
+      const [key, value] = entry.value;
       if (value === callback) {
         observerId = key;
+        break;
       }
-    });
+    }
 
     if (!observerId) {
       throw Error(`unable to find observer for ${notificationType}`);


### PR DESCRIPTION
Instead of doing a `.forEach` for every observer to lookup an observerID by its callback, we can do a while-block using `.entries()` and stop as soon as we find what we're looking for.