### PR TITLE
[cf.js] Implements Cf.requestId() with UUID

### DIFF
--- a/packages/cf.js/package.json
+++ b/packages/cf.js/package.json
@@ -21,8 +21,9 @@
   },
   "devDependencies": {
     "@counterfactual/contracts": "0.0.2",
-    "jest": "^23.6.0",
     "@types/lodash": "^4.14.116",
+    "@types/uuid": "^3.4.4",
+    "jest": "^23.6.0",
     "rollup": "^0.66.4",
     "rollup-plugin-typescript2": "^0.17.1",
     "tslint": "^5.11.0",
@@ -31,7 +32,8 @@
   "dependencies": {
     "ethers": "^4.0.4",
     "lodash": "^4.17.10",
-    "rollup-plugin-json": "^3.1.0"
+    "rollup-plugin-json": "^3.1.0",
+    "uuid": "^3.3.2"
   },
   "jest": {
     "verbose": false,

--- a/packages/cf.js/src/client.ts
+++ b/packages/cf.js/src/client.ts
@@ -1,3 +1,5 @@
+import { v1 as uuid } from "uuid";
+
 import { Channel } from "./channel";
 import { applyMixins } from "./mixins/apply";
 import { NotificationType, Observable } from "./mixins/observable";
@@ -57,7 +59,7 @@ export class Client implements Observable {
   }
 
   public requestId(): string {
-    return Math.random().toString();
+    return uuid();
   }
 
   public async queryUser(): Promise<UserDataClientResponse> {

--- a/yarn.lock
+++ b/yarn.lock
@@ -691,6 +691,13 @@
   resolved "https://registry.yarnpkg.com/@types/qs/-/qs-6.5.1.tgz#a38f69c62528d56ba7bd1f91335a8004988d72f7"
   integrity sha512-mNhVdZHdtKHMMxbqzNK3RzkBcN1cux3AvuCYGTvjEIQT2uheH3eCAyYsbMbh2Bq8nXkeOWs1kyDiF7geWRFQ4Q==
 
+"@types/uuid@^3.4.4":
+  version "3.4.4"
+  resolved "https://registry.yarnpkg.com/@types/uuid/-/uuid-3.4.4.tgz#7af69360fa65ef0decb41fd150bf4ca5c0cefdf5"
+  integrity sha512-tPIgT0GUmdJQNSHxp0X2jnpQfBSTfGxUMc/2CXBU2mnyTFVYVa2ojpoQ74w0U2yn2vw3jnC640+77lkFFpdVDw==
+  dependencies:
+    "@types/node" "*"
+
 JSONStream@^1.0.4, JSONStream@^1.3.4:
   version "1.3.5"
   resolved "https://registry.yarnpkg.com/JSONStream/-/JSONStream-1.3.5.tgz#3208c1f08d3a4d99261ab64f92302bc15e111ca0"


### PR DESCRIPTION
`Math.random()` isn't collision-safe to use its values as request IDs. Inspired on HTTP request IDs, this PR replaces the random value ID with a UUID-v1-compliant value, linked to a timestamp. Eventually, should there be any logging operations for debugging purposes, a UUID-v1 is timestamp-based, so requests occured within a small time period will have "near" request IDs.