### PR TITLE
cleanup

### DIFF
--- a/packages/iframe-wallet-poc/src/iframe/user.ts
+++ b/packages/iframe-wallet-poc/src/iframe/user.ts
@@ -71,7 +71,7 @@ export class User
       this.address
     );
     this.store = new CommitmentStore();
-    this.io.ackMethod = this.instructionExecutor.startAck.bind(
+    this.io.ackMethod = this.instructionExecutor.receiveClientActionMessageAck.bind(
       this.instructionExecutor
     );
     this.registerMiddlewares();

--- a/packages/iframe-wallet-poc/src/iframe/wallet.ts
+++ b/packages/iframe-wallet-poc/src/iframe/wallet.ts
@@ -116,9 +116,11 @@ export class IFrameWallet implements cf.legacy.node.ResponseSink {
   public async runProtocol(
     msg: cf.legacy.node.ClientActionMessage
   ): Promise<cf.legacy.node.WalletResponse> {
-    const promise = new Promise<cf.legacy.node.WalletResponse>((resolve, reject) => {
-      this.requests[msg.requestId] = resolve;
-    });
+    const promise = new Promise<cf.legacy.node.WalletResponse>(
+      (resolve, reject) => {
+        this.requests[msg.requestId] = resolve;
+      }
+    );
     this.currentUser.instructionExecutor.receiveClientActionMessage(msg);
     return promise;
   }

--- a/packages/iframe-wallet-poc/src/iframe/wallet.ts
+++ b/packages/iframe-wallet-poc/src/iframe/wallet.ts
@@ -116,12 +116,10 @@ export class IFrameWallet implements cf.legacy.node.ResponseSink {
   public async runProtocol(
     msg: cf.legacy.node.ClientActionMessage
   ): Promise<cf.legacy.node.WalletResponse> {
-    const promise = new Promise<cf.legacy.node.WalletResponse>(
-      (resolve, reject) => {
-        this.requests[msg.requestId] = resolve;
-      }
-    );
-    this.currentUser.instructionExecutor.receive(msg);
+    const promise = new Promise<cf.node.WalletResponse>((resolve, reject) => {
+      this.requests[msg.requestId] = resolve;
+    });
+    this.currentUser.instructionExecutor.receiveClientActionMessage(msg);
     return promise;
   }
 

--- a/packages/iframe-wallet-poc/src/iframe/wallet.ts
+++ b/packages/iframe-wallet-poc/src/iframe/wallet.ts
@@ -116,7 +116,7 @@ export class IFrameWallet implements cf.legacy.node.ResponseSink {
   public async runProtocol(
     msg: cf.legacy.node.ClientActionMessage
   ): Promise<cf.legacy.node.WalletResponse> {
-    const promise = new Promise<cf.node.WalletResponse>((resolve, reject) => {
+    const promise = new Promise<cf.legacy.node.WalletResponse>((resolve, reject) => {
       this.requests[msg.requestId] = resolve;
     });
     this.currentUser.instructionExecutor.receiveClientActionMessage(msg);

--- a/packages/machine/src/action.ts
+++ b/packages/machine/src/action.ts
@@ -69,8 +69,7 @@ export class ActionExecution {
     this.results = results;
   }
 
-  // Public only for test purposes
-  public createInternalMessage(): InternalMessage {
+  private createInternalMessage(): InternalMessage {
     const op = this.action.instructions[this.instructionPointer];
     return new InternalMessage(
       this.action.name,
@@ -80,7 +79,7 @@ export class ActionExecution {
     );
   }
 
-  public createContext(): Context {
+  private createContext(): Context {
     return {
       results: this.results,
       instructionPointer: this.instructionPointer,
@@ -91,7 +90,7 @@ export class ActionExecution {
     };
   }
 
-  public async next(): Promise<{ done: boolean; value: number }> {
+  private async next(): Promise<{ done: boolean; value: number }> {
     if (this.instructionPointer === this.action.instructions.length) {
       return { done: true, value: 0 };
     }

--- a/packages/machine/src/action.ts
+++ b/packages/machine/src/action.ts
@@ -69,7 +69,7 @@ export class ActionExecution {
     this.results = results;
   }
 
-  private createInternalMessage(): InternalMessage {
+  public createInternalMessage(): InternalMessage {
     const op = this.action.instructions[this.instructionPointer];
     return new InternalMessage(
       this.action.name,
@@ -79,7 +79,7 @@ export class ActionExecution {
     );
   }
 
-  private createContext(): Context {
+  public createContext(): Context {
     return {
       results: this.results,
       instructionPointer: this.instructionPointer,

--- a/packages/machine/src/instruction-executor.ts
+++ b/packages/machine/src/instruction-executor.ts
@@ -61,7 +61,7 @@ export class InstructionExecutor implements Observable {
   /**
    * @returns all unfinished protocol executions read from the db.
    */
-  private buildExecutionsFromLog(log: Log): ActionExecution[] {
+  public buildExecutionsFromLog(log: Log): ActionExecution[] {
     return Object.keys(log).map(key => {
       const entry = log[key];
       const action = new Action(

--- a/packages/machine/src/instruction-executor.ts
+++ b/packages/machine/src/instruction-executor.ts
@@ -82,7 +82,9 @@ export class InstructionExecutor implements Observable {
     });
   }
 
-  public receiveClientActionMessageAck(msg: cf.legacy.node.ClientActionMessage) {
+  public receiveClientActionMessageAck(
+    msg: cf.legacy.node.ClientActionMessage
+  ) {
     this.execute(new Action(msg.requestId, msg.action, msg, true));
   }
 

--- a/packages/machine/src/instruction-executor.ts
+++ b/packages/machine/src/instruction-executor.ts
@@ -61,7 +61,7 @@ export class InstructionExecutor implements Observable {
   /**
    * @returns all unfinished protocol executions read from the db.
    */
-  public buildExecutionsFromLog(log: Log): ActionExecution[] {
+  private buildExecutionsFromLog(log: Log): ActionExecution[] {
     return Object.keys(log).map(key => {
       const entry = log[key];
       const action = new Action(
@@ -82,29 +82,12 @@ export class InstructionExecutor implements Observable {
     });
   }
 
-  public startAck(message: cf.legacy.node.ClientActionMessage) {
-    this.execute(new Action(message.requestId, message.action, message, true));
+  public receiveClientActionMessageAck(msg: cf.legacy.node.ClientActionMessage) {
+    this.execute(new Action(msg.requestId, msg.action, msg, true));
   }
 
-  public receive(
-    msg: cf.legacy.node.ClientActionMessage
-  ): cf.legacy.node.WalletResponse {
-    if (!this.validateMessage(msg)) {
-      throw new Error("Cannot receive invalid message");
-    }
-
-    const action = new Action(msg.requestId, msg.action, msg);
-    this.execute(action);
-
-    return new cf.legacy.node.WalletResponse(
-      action.requestId,
-      cf.legacy.node.ResponseStatus.STARTED
-    );
-  }
-
-  public validateMessage(msg: cf.legacy.node.ClientActionMessage) {
-    // TODO;
-    return true;
+  public receiveClientActionMessage(msg: cf.legacy.node.ClientActionMessage) {
+    this.execute(new Action(msg.requestId, msg.action, msg, false));
   }
 
   public async execute(action: Action) {

--- a/packages/machine/src/middleware/middleware.ts
+++ b/packages/machine/src/middleware/middleware.ts
@@ -75,7 +75,7 @@ export class Middleware {
 
     async function callback() {
       if (counter === middlewares[opCode].length - 1) {
-        return Promise.resolve(null);
+        return null;
       }
       // This is hacky, prevents next from being called more than once
       counter += 1;

--- a/packages/machine/test/integration/test-response-sink.ts
+++ b/packages/machine/test/integration/test-response-sink.ts
@@ -115,8 +115,8 @@ export class TestResponseSink implements cf.legacy.node.ResponseSink {
    * the protocol has completed execution.
    */
   public async runProtocol(
-    msg: cf.node.ClientActionMessage
-  ): Promise<cf.node.WalletResponse> {
+    msg: cf.legacy.node.ClientActionMessage
+  ): Promise<cf.legacy.node.WalletResponse> {
     const promise = new Promise<cf.legacy.node.WalletResponse>((resolve, reject) => {
       this.requests[msg.requestId] = resolve;
     });

--- a/packages/machine/test/integration/test-response-sink.ts
+++ b/packages/machine/test/integration/test-response-sink.ts
@@ -66,7 +66,7 @@ export class TestResponseSink implements cf.legacy.node.ResponseSink {
 
     // TODO: Document why this is needed.
     // https://github.com/counterfactual/monorepo/issues/108
-    this.io.ackMethod = this.instructionExecutor.startAck.bind(
+    this.io.ackMethod = this.instructionExecutor.receiveClientActionMessageAck.bind(
       this.instructionExecutor
     );
 
@@ -115,14 +115,12 @@ export class TestResponseSink implements cf.legacy.node.ResponseSink {
    * the protocol has completed execution.
    */
   public async runProtocol(
-    msg: cf.legacy.node.ClientActionMessage
-  ): Promise<cf.legacy.node.WalletResponse> {
-    const promise = new Promise<cf.legacy.node.WalletResponse>(
-      (resolve, reject) => {
-        this.requests[msg.requestId] = resolve;
-      }
-    );
-    this.instructionExecutor.receive(msg);
+    msg: cf.node.ClientActionMessage
+  ): Promise<cf.node.WalletResponse> {
+    const promise = new Promise<cf.legacy.node.WalletResponse>((resolve, reject) => {
+      this.requests[msg.requestId] = resolve;
+    });
+    this.instructionExecutor.receiveClientActionMessage(msg);
     return promise;
   }
 

--- a/packages/machine/test/unit/write-ahead-log.spec.ts
+++ b/packages/machine/test/unit/write-ahead-log.spec.ts
@@ -21,8 +21,8 @@ describe("Write ahead log", () => {
     const log1 = new WriteAheadLog(db, "test-unique-id");
 
     makeExecutions(instructionExecutor).forEach(execution => {
-      const internalMessage = execution.createInternalMessage();
-      const context = execution.createContext();
+      const internalMessage = execution["createInternalMessage"](); // access private method
+      const context = execution["createContext"](); // access private method
       log1.write(internalMessage, context);
     });
 

--- a/packages/machine/test/unit/write-ahead-log.spec.ts
+++ b/packages/machine/test/unit/write-ahead-log.spec.ts
@@ -21,8 +21,8 @@ describe("Write ahead log", () => {
     const log1 = new WriteAheadLog(db, "test-unique-id");
 
     makeExecutions(instructionExecutor).forEach(execution => {
-      const internalMessage = execution["createInternalMessage"](); // access private method
-      const context = execution["createContext"](); // access private method
+      const internalMessage = execution.createInternalMessage();
+      const context = execution.createContext();
       log1.write(internalMessage, context);
     });
 


### PR DESCRIPTION
- rename `startAck` and `receive` methods of `InstructionExecutor`
- privatize the `next` method
- delete `validateMessage` (empty code)
- do not return from `receive`