### PR TITLE
[cf.js][wallet] get the iife build working correctly again

### DIFF
--- a/packages/cf.js/rollup.config.js
+++ b/packages/cf.js/rollup.config.js
@@ -22,7 +22,7 @@ export default {
     },
     {
       file: pkg.iife,
-      name: "ci",
+      name: "cf",
       format: "iife",
       sourcemap: true,
       globals: globals

--- a/packages/cf.js/src/legacy/client.ts
+++ b/packages/cf.js/src/legacy/client.ts
@@ -1,5 +1,3 @@
-import { v1 as uuid } from "uuid";
-
 import { Channel } from "./channel";
 import { applyMixins } from "./mixins/apply";
 import { NotificationType, Observable } from "./mixins/observable";
@@ -59,7 +57,14 @@ export class Client implements Observable {
   }
 
   public requestId(): string {
-    return uuid();
+    // TODO: use uuids when one of the following conditions is met:
+    // 1) we no longer need to support ethmo/iframe wallet
+    // 2) `node-uuid` has a working browser-ready version:
+    //    https://github.com/kelektiv/node-uuid/issues/176
+    // until, we just use Math.random so that the iife build works without
+    // depending on a global uuid moddule
+
+    return Math.random().toString();
   }
 
   public async queryUser(): Promise<UserDataClientResponse> {

--- a/packages/iframe-wallet-poc/iframe-wallet/index.html
+++ b/packages/iframe-wallet-poc/iframe-wallet/index.html
@@ -26,9 +26,9 @@
 </body>
 <script type="text/javascript" src="https://cdn.jsdelivr.net/npm/lodash@4.17.11/lodash.min.js"></script>
 <script charset="utf-8" type="text/javascript" src="../../../node_modules/ethers/dist/ethers.js"></script>
+<script id="ci_src" type="text/javascript" src="../../../node_modules/@counterfactual/cf.js/dist/index-iife.js"></script>
 <script id="machine_src" type="text/javascript" src="../../../node_modules/@counterfactual/machine/dist/index-iife.js"></script>
 <script id="counterfactualWallet_src" type="text/javascript" src="../../../node_modules/@counterfactual/wallet/dist/index-iife.js"></script>
-<script id="ci_src" type="text/javascript" src="../../../node_modules/@counterfactual/cf.js/dist/index-iife.js"></script>
 <script id="wa_src" type="text/javascript" src="index.js"></script>
 
 </html>


### PR DESCRIPTION
Currently, the iframe wallet is breaking for a few reasons. To get it working again, we needed to rename the cf.js rollup build to `cf`, which the other packages are expecting as a global. We need to load it before the other packages as well, as they depend on it. And we also have to temporarily remove its dependency on `uuid`, unless we can find a way to inject it as a global.