### PR TITLE
[machine] replace `Context::results` array by an explicitly keyed `intermediateResults` object

### DIFF
--- a/packages/machine/src/middleware/protocol-operation/op-generator.ts
+++ b/packages/machine/src/middleware/protocol-operation/op-generator.ts
@@ -2,10 +2,8 @@ import * as cf from "@counterfactual/cf.js";
 import { ethers } from "ethers";
 
 import { Context } from "../../instruction-executor";
-import { Opcode } from "../../instructions";
 import { Node } from "../../node";
 import { InternalMessage } from "../../types";
-import { getFirstResult, OpGenerator } from "../middleware";
 
 import { OpInstall } from "./op-install";
 import { OpSetState } from "./op-set-state";
@@ -14,22 +12,16 @@ import { OpUninstall } from "./op-uninstall";
 import { ProtocolOperation } from "./types";
 
 /**
- * Middleware to be used and registered with the InstructionExecutor on OP_GENERATE instructions
- * to generate ProtocolOperations. When combined with signatures from all parties
- * in the state channel, the ProtocolOperation transitions the state to that
- * yielded by STATE_TRANSITION_PROPOSE.
+ * Registered with OP_GENERATE
  */
-export class EthOpGenerator extends OpGenerator {
-  public generate(
+export class EthOpGenerator {
+  public static generate(
     message: InternalMessage,
     next: Function,
     context: Context,
     node: Node
   ): ProtocolOperation {
-    const proposedState = getFirstResult(
-      Opcode.STATE_TRANSITION_PROPOSE,
-      context.results
-    ).value;
+    const proposedState = context.intermediateResults.proposedStateTransition!;
     let op;
     if (message.actionName === cf.legacy.node.ActionName.UPDATE) {
       op = this.update(message, context, node, proposedState.state);
@@ -41,7 +33,7 @@ export class EthOpGenerator extends OpGenerator {
         context,
         node,
         proposedState.state,
-        proposedState.cfAddr
+        proposedState.cfAddr!
       );
     } else if (message.actionName === cf.legacy.node.ActionName.UNINSTALL) {
       op = this.uninstall(message, context, node, proposedState.state);
@@ -49,7 +41,7 @@ export class EthOpGenerator extends OpGenerator {
     return op;
   }
 
-  public update(
+  public static update(
     message: InternalMessage,
     context: Context,
     node: Node,
@@ -108,7 +100,7 @@ export class EthOpGenerator extends OpGenerator {
     );
   }
 
-  public setup(
+  public static setup(
     message: InternalMessage,
     context: Context,
     node: Node,
@@ -153,7 +145,7 @@ export class EthOpGenerator extends OpGenerator {
     );
   }
 
-  public install(
+  public static install(
     message: InternalMessage,
     context: Context,
     node: Node,
@@ -198,7 +190,7 @@ export class EthOpGenerator extends OpGenerator {
     return op;
   }
 
-  public uninstall(
+  public static uninstall(
     message: InternalMessage,
     context: Context,
     node: Node,

--- a/packages/machine/src/middleware/state-transition/install-proposer.ts
+++ b/packages/machine/src/middleware/state-transition/install-proposer.ts
@@ -2,10 +2,8 @@ import * as cf from "@counterfactual/cf.js";
 import { ethers } from "ethers";
 
 import { Context } from "../../instruction-executor";
-import { Opcode } from "../../instructions";
 import { Node, StateChannelInfoImpl } from "../../node";
 import { InternalMessage, StateProposal } from "../../types";
-import { getLastResult } from "../middleware";
 
 export class InstallProposer {
   public static propose(
@@ -77,11 +75,11 @@ export class InstallProposer {
     context: Context,
     data: cf.legacy.app.InstallData
   ): string[] {
-    const lastResult = getLastResult(Opcode.IO_WAIT, context.results);
+    const lastResult = context.intermediateResults.inbox!;
 
     let signingKeys;
-    if (lastResult && lastResult.value && lastResult.value.data) {
-      signingKeys = [lastResult.value.data.keyA, lastResult.value.data.keyB];
+    if (lastResult && lastResult.data) {
+      signingKeys = [lastResult.data.keyA, lastResult.data.keyB];
     } else {
       signingKeys = [data.keyA!, data.keyB!];
     }

--- a/packages/machine/src/middleware/state-transition/state-transition.ts
+++ b/packages/machine/src/middleware/state-transition/state-transition.ts
@@ -1,6 +1,4 @@
 import { Context } from "../../instruction-executor";
-import { Opcode } from "../../instructions";
-import { getFirstResult } from "../../middleware/middleware";
 import { Node } from "../../node";
 import { InternalMessage, StateProposal } from "../../types";
 
@@ -25,19 +23,5 @@ export class StateTransition {
     }
 
     return proposer.propose(message, context, node);
-  }
-
-  public static commit(
-    message: InternalMessage,
-    next: Function,
-    context: Context,
-    state: Node
-  ) {
-    const newState = getFirstResult(
-      Opcode.STATE_TRANSITION_PROPOSE,
-      context.results
-    );
-    context.instructionExecutor.mutateState(newState.value.state);
-    next();
   }
 }

--- a/packages/machine/src/write-ahead-log.ts
+++ b/packages/machine/src/write-ahead-log.ts
@@ -1,7 +1,7 @@
 import * as cf from "@counterfactual/cf.js";
 
-import { Context } from "./instruction-executor";
-import { InternalMessage, OpCodeResult } from "./types";
+import { Context, IntermediateResults } from "./instruction-executor";
+import { InternalMessage } from "./types";
 
 /**
  * Persistent write ahead log to be able to resume or abort protocols if the
@@ -59,7 +59,7 @@ export class WriteAheadLog {
       clientMessage: message.clientMessage,
       isAckSide: message.isAckSide,
       instructionPointer: context.instructionPointer,
-      results: context.results
+      intermediateResults: context.intermediateResults
     };
   }
 
@@ -96,7 +96,7 @@ interface LogRecord {
   clientMessage: cf.legacy.node.ClientActionMessage;
   isAckSide: boolean;
   instructionPointer: number;
-  results: OpCodeResult[];
+  intermediateResults: IntermediateResults;
 }
 
 /**

--- a/packages/machine/test/integration/resume-protocols.spec.ts
+++ b/packages/machine/test/integration/resume-protocols.spec.ts
@@ -131,12 +131,13 @@ class ResumeFirstInstructionTest extends SetupProtocolTestCase {
         if (shouldError) {
           throw new Error("Crashing the machine on purpose");
         }
-        return StateTransition.propose(
+        const proposal = StateTransition.propose(
           message,
           next,
           context,
           peer.instructionExecutor.node
         );
+        context.intermediateResults.proposedStateTransition = proposal;
       }
     );
   }
@@ -180,13 +181,13 @@ class ResumeSecondInstructionTest extends SetupProtocolTestCase {
         if (shouldError) {
           throw new Error("Crashing the machine on purpose");
         }
-        const opGenerator = new EthOpGenerator();
-        return opGenerator.generate(
+        const operation = EthOpGenerator.generate(
           message,
           next,
           context,
           peer.instructionExecutor.node
         );
+        context.intermediateResults.operation = operation;
       }
     );
   }
@@ -232,12 +233,8 @@ class ResumeLastInstructionTest extends SetupProtocolTestCase {
         if (shouldError) {
           throw new Error("Crashing the machine on purpose");
         }
-        return StateTransition.commit(
-          message,
-          next,
-          context,
-          peer.instructionExecutor.node
-        );
+        const newState = context.intermediateResults.proposedStateTransition!;
+        context.instructionExecutor.mutateState(newState.state);
       }
     );
   }

--- a/packages/machine/test/integration/test-io-provider.ts
+++ b/packages/machine/test/integration/test-io-provider.ts
@@ -2,13 +2,6 @@ import * as cf from "@counterfactual/cf.js";
 
 import { Context } from "../../src/instruction-executor";
 
-// FIXME: Don't import functions from source code.
-// https://github.com/counterfactual/monorepo/issues/98
-import { Opcode } from "../../src/instructions";
-
-// FIXME: Don't import functions from source code.
-// https://github.com/counterfactual/monorepo/issues/8
-import { getLastResult } from "../../src/middleware/middleware";
 import { InternalMessage } from "../../src/types";
 
 import { TestResponseSink } from "./test-response-sink";
@@ -112,19 +105,17 @@ export class TestIOProvider {
     next: Function,
     context: Context
   ) {
-    const msg = getLastResult(Opcode.IO_PREPARE_SEND, context.results);
-
-    // FIXME: (ts-strict) msg should never be null here
-    // https://github.com/counterfactual/monorepo/issues/94
-    const value = msg.value;
-
-    // Hack for testing and demo purposes, full IO handling by client goes here
+    const value = context.intermediateResults.outbox!
+    if (value === undefined) {
+      throw Error("ioSendMessage cannot send message with value undefined");
+    }
     this.peer.receiveMessageFromPeer(value);
   }
 
   public async waitForIo(
     message: InternalMessage,
-    next: Function
+    next: Function,
+    context: Context
   ): Promise<cf.legacy.node.ClientActionMessage> {
     // Has websocket received a message for this appId/multisig
     // If yes, return the message, if not wait until it does
@@ -133,6 +124,10 @@ export class TestIOProvider {
       r => (resolve = r)
     );
 
+    // checks the ActionName and based on that register different types of
+    // message-received callback.
+    // todo(IIIIllllIIIIllllIIIIllllIIIIllllIIIIll): It would be better to just
+    // wait for the "next message".
     let multisig: string = "";
     let appId: string = "";
 
@@ -152,6 +147,7 @@ export class TestIOProvider {
 
     this.listenOnce(
       msg => {
+        context.intermediateResults.inbox = msg;
         resolve(msg);
       },
       multisig,

--- a/packages/machine/test/integration/test-setup.ts
+++ b/packages/machine/test/integration/test-setup.ts
@@ -26,13 +26,8 @@ export class SetupProtocol {
     peerA: TestResponseSink,
     peerB: TestResponseSink
   ) {
-    console.log("printing everything");
-    console.log(peerA);
-    console.log(peerA.instructionExecutor);
-    console.log(peerA.instructionExecutor.node);
     expect(peerA.instructionExecutor.node.channelStates).toEqual({});
     expect(peerB.instructionExecutor.node.channelStates).toEqual({});
-    console.log("passed...");
   }
 
   public static setupStartMsg(


### PR DESCRIPTION
- delete `context.results` 
- delete `get{First, Last}result`
- creates a `context.intermediateResults` that holds what used to be stored in `context.results`
- middlewares now mutate `context.intermediateResults` directly
- merges `Action` and `ActionExecution`
- fixes #131, #115 