### PR TITLE
pass --fix flag in lint:fix

### DIFF
--- a/packages/iframe-wallet-poc/package.json
+++ b/packages/iframe-wallet-poc/package.json
@@ -14,7 +14,7 @@
   "scripts": {
     "clean": "rm -rf .rpt2_cache dist",
     "build": "tsc -p tsconfig.test.json && rollup -c",
-    "lint:fix": "tslint -c tslint.json -p .",
+    "lint:fix": "tslint -c tslint.json -p . --fix",
     "lint": "tslint -c tslint.json -p .",
     "test": "jest --runInBand --detectOpenHandles --bail"
   },


### PR DESCRIPTION
Previously, `yarn lint:fix` behaved like `yarn lint` in the wallet package