### PR TITLE
pass --trace-warnings flag to node on test

### DIFF
--- a/packages/machine/package.json
+++ b/packages/machine/package.json
@@ -12,7 +12,7 @@
   "scripts": {
     "clean": "rm -rf .rpt2_cache jest-cache build dist",
     "build": "tsc -p tsconfig.test.json && rollup -c",
-    "test": "tsc -b && jest --runInBand --detectOpenHandles --bail",
+    "test": "tsc -b && node --trace-warnings node_modules/.bin/jest --runInBand --detectOpenHandles --bail",
     "test-debug": "node --inspect-brk jest --runInBand",
     "test-debug-ide": "node $NODE_DEBUG_OPTION ./node_modules/.bin/jest --runInBand",
     "lint:fix": "tslint -c tslint.json -p . --fix",


### PR DESCRIPTION
Without this, errors thrown outside a catch block mostly don't print stack traces.

how to pass arguments to node: https://github.com/facebook/create-react-app/issues/549