### PR TITLE
Rename AppId -> AppInstanceId

### DIFF
--- a/packages/cf.js/API_REFERENCE.md
+++ b/packages/cf.js/API_REFERENCE.md
@@ -10,9 +10,9 @@
     - Lifecycle
         - `on(eventType, callback: Function)`
             - eventTypes
-                - `proposeInstall(proposal: {appId, appDefinition, terms}, function reject())`
+                - `proposeInstall(proposal: {appInstanceId, appDefinition, terms}, function reject())`
                 - `install(appInstance)`
-                - `rejectInstall(proposal: {appId, appDefinition, terms})`
+                - `rejectInstall(proposal: {appInstanceId, appDefinition, terms})`
 - `AppFactory`
     - Properties
         - `appDefinition: AppDefinition`
@@ -23,12 +23,12 @@
                 myDeposit: BigNumber,
                 peerDeposit: BigNumber,
                 initialState: object
-           }): Promise<AppID>`
-        - `async install(appId: AppID): Promise<AppInstance>`
+           }): Promise<AppInstanceID>`
+        - `async install(appInstanceId: AppInstanceID): Promise<AppInstance>`
         - `getApps(): AppInstance[]`
 - `AppInstance`
     - Properties
-        - `id: AppID` — Identifier for this specific app instance
+        - `id: AppInstanceID` — Identifier for this specific app instance
         - `definition: AppDefinition`
         - `terms: AppTerms`
         - `manifestUri: string`
@@ -59,7 +59,7 @@
         - Instance methods
             - `postMessage(message)`
             - `onMessage(callback)`
-    - `AppID`: string
+    - `AppInstanceID`: string
     - `AppState`: object, a POJO describing app state, encoded using app state encoding
     - `AppAction`: object, a POJO describing app action, encoded using app action encoding
     - `Asset`:

--- a/packages/cf.js/src/app-instance.ts
+++ b/packages/cf.js/src/app-instance.ts
@@ -1,5 +1,5 @@
-import { AppID } from "./simple-types";
+import { AppInstanceID } from "./simple-types";
 
 export class AppInstance {
-  constructor(readonly id: AppID) {}
+  constructor(readonly id: AppInstanceID) {}
 }

--- a/packages/cf.js/src/simple-types.ts
+++ b/packages/cf.js/src/simple-types.ts
@@ -1,3 +1,3 @@
 export type ABIEncoding = string;
-export type AppID = string;
+export type AppInstanceID = string;
 export type Address = string;


### PR DESCRIPTION
### Description

@ebryn and co. pointed out that it makes more sense that the identifier of an app instance is called "AppInstanceID" as opposed to "AppID". "AppID" better describes the identifier on an app *definition*. 
