### PR TITLE
[CFjs] Update spec: move events to Provider, remove proposeInstall event

### DIFF
--- a/packages/cf.js/API_REFERENCE.md
+++ b/packages/cf.js/API_REFERENCE.md
@@ -10,22 +10,24 @@
     - Lifecycle
         - `on(eventType, callback: Function)`
             - eventTypes
-                - `proposeInstall(proposal: {appInstanceId, appDefinition, terms}, function reject())`
                 - `install(appInstance)`
-                - `rejectInstall(proposal: {appInstanceId, appDefinition, terms})`
+                - `rejectInstall(appInstance)`
+                - `updateState(appInstance, oldState, newState, action?)`
+                - `uninstall(appInstance)`
+                - `proposeState(appInstance, oldState, newState)`
 - `AppFactory`
     - Properties
         - `appDefinition: AppDefinition`
     - Instance methods
         - `async proposeInstall({
                 peerAddress: Address,
-                asset: Asset,
-                myDeposit: BigNumber,
-                peerDeposit: BigNumber,
-                initialState: object
+                asset: BlockchainAsset,
+                myDeposit: BigNumberish,
+                peerDeposit: BigNumberish,
+                initialState: any
            }): Promise<AppInstanceID>`
         - `async install(appInstanceId: AppInstanceID): Promise<AppInstance>`
-        - `getApps(): AppInstance[]`
+        - `async getAppInstances(): Promise<AppInstance[]>`
 - `AppInstance`
     - Properties
         - `id: AppInstanceID` — Identifier for this specific app instance
@@ -46,11 +48,11 @@
         - `async uninstall()`
             - Uninstall the app
         - `async getManifest(): AppManifest`
-        - `async getState(): object`
+        - `async getState(): any`
     - App lifecycle
         - `on(eventType, callback: Function)`
             - eventTypes
-                - `stateUpdate(newState)`
+                - `updateState(newState)`
                 - `uninstall()`
                 - `proposeState(newState)`
 - `types`
@@ -62,11 +64,11 @@
     - `AppInstanceID`: string
     - `AppState`: object, a POJO describing app state, encoded using app state encoding
     - `AppAction`: object, a POJO describing app action, encoded using app action encoding
-    - `Asset`:
+    - `BlockchainAsset`:
         - `assetType`: ETH or ERC20 or OTHER
         - `token`: Address of token contract if applicable
     - `AppTerms`:
-        - `asset: Asset`
+        - `asset: BlockchainAsset`
         - `limit`: Funds limit committed to app
     - `AppDefinition`
         - `address`: on-chain address for the app definition contract


### PR DESCRIPTION
### Description

Update the CFjs spec after a productive call with @ebryn, @joelalejandro, @patience-tema-baron.

1) Add all event listeners to top-level Provider. Keep "updateState", "uninstall" and "proposeState" event listeners on AppInstance. dApps will likely be most interested in events for ALL app instances, and only in specific cases be interested in events relating to specific app instances.

2) dApps don't need to know when an installation is proposed. Install proposals go through the Playground (later the Wallet). dApps only need to know whether an app instance was succesfully installed, or rejected. 

+ some renames
