### PR TITLE
[CFjs + Node] Rewrite/extend the CFjs.2 spec with Node Protocol

### DIFF
--- a/packages/cf.js/API_REFERENCE.md
+++ b/packages/cf.js/API_REFERENCE.md
@@ -8,37 +8,37 @@
             - Refer to `node-provider` package
     - Instance methods
         - `async getAppInstances(): AppInstance[]`
-            - [Node method](#getappinstances)
+            - [Node method](#method-getappinstances)
         - `async install(appInstanceId: AppInstanceID): Promise<AppInstance>`
-           - [Node method](#install)
+            - [Node method](#method-install)
         - `async rejectInstall(appInstanceId: AppInstanceID)`
-            - [Node method](#rejectinstall)
+            - [Node method](#method-rejectinstall)
     - Lifecycle
         - `on(eventType, callback: Function)`
             - `install`
-                - [Node event](#install-event)
+                - [Node event](#event-install)
                 - Params: `(appInstance: AppInstance)`
             - `rejectInstall`
-                - [Node event](#rejectinstall-event)
+                - [Node event](#event-rejectinstall)
                 - Params: `(appInstance: AppInstance)`
             - `updateState`
-                - [Node event](#rejectinstall-event)
+                - [Node event](#event-rejectinstall)
                 - Params: `(appInstance: AppInstance, oldState: AppState, newState: AppState)`
             - `proposeState`
-                - [Node event](#proposestate-event)
+                - [Node event](#event-proposestate)
                 - Params: `(appInstance: AppInstance, oldState: AppState, newState: AppState)`
             - `rejectState`
-                - [Node event](#rejectstate-event)¡
+                - [Node event](#event-rejectstate)
                 - Params: `(appInstance: AppInstance, state: AppState)`
             - `uninstall`
-                - [Node event](#uninstall-event)
+                - [Node event](#event-uninstall)
                 - Params: `(appInstance: AppInstance, finalState: AppState, myPayout: BigNumber, peerPayout: BigNumber)`
 - `AppFactory`
     - Properties
         - `provider: Provider`
         - `appId: string`
             - Address of the on-chain App Definition contract
-        - `encodings: `[`AppABIEncodings`](#appabiencodings)
+        - `encodings:`[`AppABIEncodings`](#appabiencodings)
     - Instance methods
         - `async proposeInstall({
                 peerAddress: Address,
@@ -47,22 +47,22 @@
                 peerDeposit: BigNumberish,
                 initialState: AppState
            }): Promise<AppInstanceID>`
-           - [Node method](#proposeinstall)
+           - [Node method](#method-proposeinstall)
 - `AppInstance`
-    - Extends [`AppInstance` data type](#appinstance)
+    - Extends [`AppInstanceInfo` data type](#appinstance)
     - Properties
         - `manifestUri: string`
             - TODO
     - Instance methods
         - `async takeAction(action: AppAction): Promise<AppState>`
-            - [Node method](#takeaction)
+            - [Node method](#method-takeaction)
             - Returns ABI decoded representation of the latest signed state of the app.
             - Throws error if app definition "appActionEncoding" is not defined
         - `async uninstall()`
-            - [Node method](#uninstall)
+            - [Node method](#method-uninstall)
             - Uninstall the app instance
         - `async getState(): AppState`
-            - [Node method](#getstate)
+            - [Node method](#method-getstate)
             - Get the latest signed state
         - `async getManifest(): AppManifest`
             - TODO
@@ -79,13 +79,13 @@
         - `on(eventType, callback: Function)`
             - eventTypes
                 - `updateState`
-                    - [Node event](#updatestate-event)
+                    - [Node event](#event-updatestate)
                 - `uninstall`
-                    - [Node event](#uninstall)
+                    - [Node event](#event-uninstall)
                 - `proposeState`
-                    - [Node event](#proposestate-event)
+                    - [Node event](#event-proposestate)
                 - `rejectState`
-                    - [Node event](#rejectstate-event)
+                    - [Node event](#event-rejectstate)
 - `types`
     - Everything under [Data Types](#data-types) except `AppInstance` 
     - `AppManifest`
@@ -100,7 +100,7 @@ Node Protocol
 Public Methods
 --------------
 
-#### getAppInstances
+### Method: `getAppInstances`
 
 Returns **all** app instances currently installed on the Node. 
 
@@ -110,7 +110,7 @@ Params: `[]`
 
 Result: list of [AppInstance](#appinstance)
 
-#### proposeInstall
+### Method: `proposeInstall`
 
 Generate an app instance ID given details about an app installation.  
 
@@ -119,9 +119,9 @@ Params:
     - Address of the peer to install the app with
 - `appId: string` 
     - On-chain address of App Definition contract
-- `abiEncodings: `[`AppABIEncodings`](#appabiencodings)
+- `abiEncodings:`[`AppABIEncodings`](#appabiencodings)
     - ABI encodings used for states and actions of this app
-- `asset: `[`BlockchainAsset`](#blockchainasset)
+- `asset:`[`BlockchainAsset`](#blockchainasset)
     - The asset used for deposits into this app
 - `myDeposit: BigNumber`
     - Amount of the asset deposited by this user
@@ -129,7 +129,7 @@ Params:
     - Amount of the asset deposited by the counterparty
 - `timeout: BigNumber`
     - Number of blocks until a submitted state for this app is considered finalized
-- `initialState: `[`AppState`](#appstate)
+- `initialState:`[`AppState`](#appstate)
     - Initial state of app instance
     
 Result: 
@@ -139,7 +139,7 @@ Result:
 Errors: (TODO)
 - Not enough funds
 
-#### rejectInstall
+### Method: `rejectInstall`
 
 Reject an app instance installation. 
 
@@ -152,7 +152,7 @@ Result: "OK"
 Errors: (TODO)
 - Proposed app instance doesn't exist
 
-#### install
+### Method: `install`
 
 Install an app instance. 
 
@@ -162,13 +162,13 @@ Params:
     
 
 Result:
-- `appInstance: `[`AppInstance`](#appinstance)
+- `appInstance:`[`AppInstanceInfo`](#appinstanceinfo)
     - Successfully installed app instance
 
 Errors: (TODO)
 - Counterparty rejected installation
 
-#### getState
+### Method: `getState`
 
 Get the latest state of an app instance.
 
@@ -177,14 +177,14 @@ Params:
     - Unique ID of the app instance 
 
 Result:
-- `state: `[`AppState`](#appstate)
+- `state:`[`AppState`](#appstate)
     - Latest state of the app instance
   
 Errors: (TODO)
 - App not installed
 
 
-#### getAppInstanceDetails
+### Method: `getAppInstanceDetails`
 
 Get details of an app instance.
 
@@ -193,11 +193,11 @@ Params:
     - Unique ID of the app instance 
 
 Result:
-- `appInstance: `[`AppInstance`](#appinstance)
+- `appInstance:`[`AppInstanceInfo`](#appinstanceinfo)
     - App instance details
 
 
-#### takeAction
+### Method: `takeAction`
 
 Take action on current app state to advance it to a new state.
 
@@ -205,15 +205,16 @@ Params:
 - `appInstanceId: string`
     - Unique ID of the app instance 
     - Action to take on the current state 
+- `action:`
 
 Result:
-- `newState: `[`AppState`](#appstate)
+- `newState:`[`AppState`](#appstate)
     - New app state
 
 Errors: (TODO)
 - Illegal action
 
-#### uninstall
+### Method: `uninstall`
 
 Uninstall an app instance, paying out users according to the latest signed state.
 
@@ -230,15 +231,15 @@ Result:
 Errors: (TODO)
 - App state not terminal  
 
-#### proposeState
+### Method: `proposeState`
 
 TODO
 
-#### acceptState
+### Method: `acceptState`
 
 TODO
 
-#### rejectState
+### Method: `rejectState`
 
 TODO
 
@@ -246,57 +247,57 @@ TODO
 Events
 ------
 
-#### install event
+### Event: `install`
 
 Fired if new app instance was successfully installed.
 
 Params:
-- `appInstance: `[`AppInstance`](#appinstance)
+- `appInstance:`[`AppInstanceInfo`](#appinstanceinfo)
     - Newly installed app instance
 
-#### rejectInstall event
+### Event: `rejectInstall`
 
 Fired if installation of a new app instance was rejected.
 
 Params:
-- `appInstance: `[`AppInstance`](#appinstance)
+- `appInstance:`[`AppInstanceInfo`](#appinstanceinfo)
     - Rejected app instance
 
-#### updateState event
+### Event: `updateState`
 
 Fired if app state is successfully updated.
 
 Params:
 - `appInstanceId: string`
     - Unique ID of app instance
-- `newState: `[`AppState`](#appstate)
-- `oldState: `[`AppState`](#appstate)
-- `action?: `[`AppAction`](#appaction)
+- `newState:`[`AppState`](#appstate)
+- `oldState:`[`AppState`](#appstate)
+- `action?:`[`AppAction`](#appaction)
     - Optional action that was taken to advance from the old state to the new state
 
-#### uninstall event
+### Event: `uninstall`
 
 Fired if app instance is successfully uninstalled
 
 Params:
-- `appInstance: `[`AppInstance`](#appinstance)
+- `appInstance:`[`AppInstanceInfo`](#appinstanceinfo)
     - Uninstalled app instance
 - `myPayout: BigNumber`
     - Amount of the asset paid out to this user 
 - `peerPayout: BigNumber`
     - Amount of the asset paid out to peer
 
-#### proposeState event
+### Event: `proposeState`
 
 TODO
 
-#### rejectState event
+### Event: `rejectState`
 
 TODO
 
 ### Data Types
 
-#### `AppInstance`
+### `AppInstanceInfo`
 
 An instance of an installed app.
 
@@ -305,9 +306,9 @@ An instance of an installed app.
 - `appId: string` 
     - Unique ID for this app
     - Currently corresponds to on-chain address of App Definition contract
-- `abiEncodings: `[`AppABIEncodings`](#appabiencodings)
+- `abiEncodings:`[`AppABIEncodings`](#appabiencodings)
     - ABI encodings used for states and actions of this app
-- `asset: `[`BlockchainAsset`](#blockchainasset)
+- `asset:`[`BlockchainAsset`](#blockchainasset)
     - The asset used for deposits into this app
 - `myDeposit: BigNumber`
     - Amount of the asset deposited by this user
@@ -316,14 +317,14 @@ An instance of an installed app.
 - `timeout: BigNumber`
     - Number of blocks until a submitted state for this app is considered finalized
    
-#### `BlockchainAsset`
+### `BlockchainAsset`
 - `assetType: number`
     - The type of the asset.
     - Set 0 for ETH, 1 for ERC20 token, 2 for Other.
 - `token?: string`
     - Optional address of token contract if assetType is set to 1.
 
-#### `AppABIEncodings`
+### `AppABIEncodings`
 - `stateEncoding: string` 
     - ABI encoding of the app state
 - `actionEncoding?: string`
@@ -331,12 +332,12 @@ An instance of an installed app.
     - If left blank, instances of the app will only be able to update state using [`proposeState`](#proposestate)
     - If supplied, instances of this app will also be able to update state using [`takeAction`](#takeaction) 
 
-#### AppState
+### AppState
 
 - Plain Old Javascript Object representation of the state of an app instance.
 - ABI encoded/decoded using the `stateEncoding` field on the instance's [`AppABIEncodings`](#appabiencodings).
 
-#### AppAction
+### AppAction
 
 - Plain Old Javascript Object representation of the action of an app instance.
 - ABI encoded/decoded using the `actionEncoding` field on the instance's [`AppABIEncodings`](#appabiencodings).

--- a/packages/cf.js/API_REFERENCE.md
+++ b/packages/cf.js/API_REFERENCE.md
@@ -38,7 +38,7 @@
         - `provider: Provider`
         - `appId: string`
             - Address of the on-chain App Definition contract
-        - `encodings:`[`AppABIEncodings`](#appabiencodings)
+        - `encodings:`[`AppABIEncodings`](#data-type-appabiencodings)
     - Instance methods
         - `async proposeInstall({
                 peerAddress: Address,
@@ -49,7 +49,7 @@
            }): Promise<AppInstanceID>`
            - [Node method](#method-proposeinstall)
 - `AppInstance`
-    - Extends [`AppInstanceInfo` data type](#appinstance)
+    - Extends [`AppInstanceInfo` data type](#data-type-appinstanceinfo)
     - Properties
         - `manifestUri: string`
             - TODO
@@ -67,12 +67,15 @@
         - `async getManifest(): AppManifest`
             - TODO
         - `async proposeState(state: AppState)`
+            - [Node method](#method-proposestate)
             - TODO
             - Proposes a state to countersign
         - `async acceptState(state: AppState)`
+            - [Node method](#method-acceptstate)
             - TODO
             - Accept a proposed state 
         - `async rejectState(state: AppState)`
+            - [Node method](#method-rejectstate)
             - TODO
             - Reject a proposed state 
     - App lifecycle
@@ -87,7 +90,7 @@
                 - `rejectState`
                     - [Node event](#event-rejectstate)
 - `types`
-    - Everything under [Data Types](#data-types) except `AppInstance` 
+    - Everything under [Data Types](#data-types) except `AppInstanceInfo` 
     - `AppManifest`
         - TODO
         - `name`: human-readable name of app e.g. "TicTacToe"
@@ -108,7 +111,7 @@ Returns **all** app instances currently installed on the Node.
 
 Params: `[]`
 
-Result: list of [AppInstance](#appinstance)
+Result: list of [`AppInstanceInfo`](#data-type-appinstanceinfo)
 
 ### Method: `proposeInstall`
 
@@ -119,9 +122,9 @@ Params:
     - Address of the peer to install the app with
 - `appId: string` 
     - On-chain address of App Definition contract
-- `abiEncodings:`[`AppABIEncodings`](#appabiencodings)
+- `abiEncodings:`[`AppABIEncodings`](#data-type-appabiencodings)
     - ABI encodings used for states and actions of this app
-- `asset:`[`BlockchainAsset`](#blockchainasset)
+- `asset:`[`BlockchainAsset`](#data-type-blockchainasset)
     - The asset used for deposits into this app
 - `myDeposit: BigNumber`
     - Amount of the asset deposited by this user
@@ -129,7 +132,7 @@ Params:
     - Amount of the asset deposited by the counterparty
 - `timeout: BigNumber`
     - Number of blocks until a submitted state for this app is considered finalized
-- `initialState:`[`AppState`](#appstate)
+- `initialState:`[`AppState`](#data-type-appstate)
     - Initial state of app instance
     
 Result: 
@@ -162,7 +165,7 @@ Params:
     
 
 Result:
-- `appInstance:`[`AppInstanceInfo`](#appinstanceinfo)
+- `appInstance:`[`AppInstanceInfo`](#data-type-appinstanceinfo)
     - Successfully installed app instance
 
 Errors: (TODO)
@@ -177,7 +180,7 @@ Params:
     - Unique ID of the app instance 
 
 Result:
-- `state:`[`AppState`](#appstate)
+- `state:`[`AppState`](#data-type-appstate)
     - Latest state of the app instance
   
 Errors: (TODO)
@@ -193,7 +196,7 @@ Params:
     - Unique ID of the app instance 
 
 Result:
-- `appInstance:`[`AppInstanceInfo`](#appinstanceinfo)
+- `appInstance:`[`AppInstanceInfo`](#data-type-appinstanceinfo)
     - App instance details
 
 
@@ -205,10 +208,10 @@ Params:
 - `appInstanceId: string`
     - Unique ID of the app instance 
     - Action to take on the current state 
-- `action:`
+- `action:`[`AppAction`](#data-type-appaction)
 
 Result:
-- `newState:`[`AppState`](#appstate)
+- `newState:`[`AppState`](#data-type-appstate)
     - New app state
 
 Errors: (TODO)
@@ -252,7 +255,7 @@ Events
 Fired if new app instance was successfully installed.
 
 Params:
-- `appInstance:`[`AppInstanceInfo`](#appinstanceinfo)
+- `appInstance:`[`AppInstanceInfo`](#data-type-appinstanceinfo)
     - Newly installed app instance
 
 ### Event: `rejectInstall`
@@ -260,7 +263,7 @@ Params:
 Fired if installation of a new app instance was rejected.
 
 Params:
-- `appInstance:`[`AppInstanceInfo`](#appinstanceinfo)
+- `appInstance:`[`AppInstanceInfo`](#data-type-appinstanceinfo)
     - Rejected app instance
 
 ### Event: `updateState`
@@ -270,9 +273,9 @@ Fired if app state is successfully updated.
 Params:
 - `appInstanceId: string`
     - Unique ID of app instance
-- `newState:`[`AppState`](#appstate)
-- `oldState:`[`AppState`](#appstate)
-- `action?:`[`AppAction`](#appaction)
+- `newState:`[`AppState`](#data-type-appstate)
+- `oldState:`[`AppState`](#data-type-appstate)
+- `action?:`[`AppAction`](#data-type-appaction)
     - Optional action that was taken to advance from the old state to the new state
 
 ### Event: `uninstall`
@@ -280,7 +283,7 @@ Params:
 Fired if app instance is successfully uninstalled
 
 Params:
-- `appInstance:`[`AppInstanceInfo`](#appinstanceinfo)
+- `appInstance:`[`AppInstanceInfo`](#data-type-appinstanceinfo)
     - Uninstalled app instance
 - `myPayout: BigNumber`
     - Amount of the asset paid out to this user 
@@ -295,9 +298,10 @@ TODO
 
 TODO
 
-### Data Types
+Data Types
+----------
 
-### `AppInstanceInfo`
+### Data Type: `AppInstanceInfo`
 
 An instance of an installed app.
 
@@ -306,9 +310,9 @@ An instance of an installed app.
 - `appId: string` 
     - Unique ID for this app
     - Currently corresponds to on-chain address of App Definition contract
-- `abiEncodings:`[`AppABIEncodings`](#appabiencodings)
+- `abiEncodings:`[`AppABIEncodings`](#data-type-appabiencodings)
     - ABI encodings used for states and actions of this app
-- `asset:`[`BlockchainAsset`](#blockchainasset)
+- `asset:`[`BlockchainAsset`](#data-type-blockchainasset)
     - The asset used for deposits into this app
 - `myDeposit: BigNumber`
     - Amount of the asset deposited by this user
@@ -317,28 +321,28 @@ An instance of an installed app.
 - `timeout: BigNumber`
     - Number of blocks until a submitted state for this app is considered finalized
    
-### `BlockchainAsset`
+### Data Type: `BlockchainAsset`
 - `assetType: number`
     - The type of the asset.
     - Set 0 for ETH, 1 for ERC20 token, 2 for Other.
 - `token?: string`
     - Optional address of token contract if assetType is set to 1.
 
-### `AppABIEncodings`
+### Data Type: `AppABIEncodings`
 - `stateEncoding: string` 
     - ABI encoding of the app state
 - `actionEncoding?: string`
     - Optional ABI encoding of the app action
-    - If left blank, instances of the app will only be able to update state using [`proposeState`](#proposestate)
-    - If supplied, instances of this app will also be able to update state using [`takeAction`](#takeaction) 
+    - If left blank, instances of the app will only be able to update state using [`proposeState`](#method-proposestate)
+    - If supplied, instances of this app will also be able to update state using [`takeAction`](#method-takeaction) 
 
-### AppState
+### Data Type: `AppState`
 
 - Plain Old Javascript Object representation of the state of an app instance.
-- ABI encoded/decoded using the `stateEncoding` field on the instance's [`AppABIEncodings`](#appabiencodings).
+- ABI encoded/decoded using the `stateEncoding` field on the instance's [`AppABIEncodings`](#data-type-appabiencodings).
 
-### AppAction
+### Data Type: `AppAction`
 
 - Plain Old Javascript Object representation of the action of an app instance.
-- ABI encoded/decoded using the `actionEncoding` field on the instance's [`AppABIEncodings`](#appabiencodings).
+- ABI encoded/decoded using the `actionEncoding` field on the instance's [`AppABIEncodings`](#data-type-appabiencodings).
 

--- a/packages/cf.js/API_REFERENCE.md
+++ b/packages/cf.js/API_REFERENCE.md
@@ -36,7 +36,9 @@
 - `AppFactory`
     - Properties
         - `provider: Provider`
-        - `appDefinition: AppDefinition`
+        - `appId: string`
+            - Address of the on-chain App Definition contract
+        - `encodings: `[`AppABIEncodings`](#appabiencodings)
     - Instance methods
         - `async proposeInstall({
                 peerAddress: Address,

--- a/packages/cf.js/API_REFERENCE.md
+++ b/packages/cf.js/API_REFERENCE.md
@@ -207,8 +207,8 @@ Take action on current app state to advance it to a new state.
 Params:
 - `appInstanceId: string`
     - Unique ID of the app instance 
-    - Action to take on the current state 
 - `action:`[`AppAction`](#data-type-appaction)
+    - Action to take on the current state 
 
 Result:
 - `newState:`[`AppState`](#data-type-appstate)

--- a/packages/cf.js/API_REFERENCE.md
+++ b/packages/cf.js/API_REFERENCE.md
@@ -1,82 +1,341 @@
-# API V0.0.2
-## `cf.js`
+# CF.js API Specification V0.0.2
+
+### `cfjs` Typescript Package
 
 - `Provider`
     - Properties
         - `nodeProvider: NodeProvider`
+            - Refer to `node-provider` package
     - Instance methods
         - `async getAppInstances(): AppInstance[]`
-        - `createAppFactory(appDefinition: AppDefinition): AppFactory`
+            - [Node method](#getappinstances)
+        - `async install(appInstanceId: AppInstanceID): Promise<AppInstance>`
+           - [Node method](#install)
+        - `async rejectInstall(appInstanceId: AppInstanceID)`
+            - [Node method](#rejectinstall)
     - Lifecycle
         - `on(eventType, callback: Function)`
-            - eventTypes
-                - `install(appInstance)`
-                - `rejectInstall(appInstance)`
-                - `updateState(appInstance, oldState, newState, action?)`
-                - `uninstall(appInstance)`
-                - `proposeState(appInstance, oldState, newState)`
+            - `install`
+                - [Node event](#install-event)
+                - Params: `(appInstance: AppInstance)`
+            - `rejectInstall`
+                - [Node event](#rejectinstall-event)
+                - Params: `(appInstance: AppInstance)`
+            - `updateState`
+                - [Node event](#rejectinstall-event)
+                - Params: `(appInstance: AppInstance, oldState: AppState, newState: AppState)`
+            - `proposeState`
+                - [Node event](#proposestate-event)
+                - Params: `(appInstance: AppInstance, oldState: AppState, newState: AppState)`
+            - `rejectState`
+                - [Node event](#rejectstate-event)¡
+                - Params: `(appInstance: AppInstance, state: AppState)`
+            - `uninstall`
+                - [Node event](#uninstall-event)
+                - Params: `(appInstance: AppInstance, finalState: AppState, myPayout: BigNumber, peerPayout: BigNumber)`
 - `AppFactory`
     - Properties
+        - `provider: Provider`
         - `appDefinition: AppDefinition`
     - Instance methods
-        // TODO: We're missing a "rejectInstall" method here.
         - `async proposeInstall({
                 peerAddress: Address,
                 asset: BlockchainAsset,
                 myDeposit: BigNumberish,
                 peerDeposit: BigNumberish,
-                initialState: any
+                initialState: AppState
            }): Promise<AppInstanceID>`
-        - `async install(appInstanceId: AppInstanceID): Promise<AppInstance>`
-        - `async getAppInstances(): Promise<AppInstance[]>`
+           - [Node method](#proposeinstall)
 - `AppInstance`
+    - Extends [`AppInstance` data type](#appinstance)
     - Properties
-        - `id: AppInstanceID` — Identifier for this specific app instance
-        - `definition: AppDefinition`
-        - `terms: AppTerms`
         - `manifestUri: string`
+            - TODO
     - Instance methods
-        - `async applyAction(action: AppAction): AppState`
+        - `async takeAction(action: AppAction): Promise<AppState>`
+            - [Node method](#takeaction)
             - Returns ABI decoded representation of the latest signed state of the app.
             - Throws error if app definition "appActionEncoding" is not defined
-        - `async proposeState(state: AppState)`
-            - Proposes a state to countersign
-            - Throws error if app definition "appActionEncoding" is defined
-        - `async acceptState(state: AppState)`
-            - Throws error if app definition "appActionEncoding" is defined
-        - `async rejectState(state: AppState)`
-            - Throws error if app definition "appActionEncoding" is defined
         - `async uninstall()`
-            - Uninstall the app
+            - [Node method](#uninstall)
+            - Uninstall the app instance
+        - `async getState(): AppState`
+            - [Node method](#getstate)
+            - Get the latest signed state
         - `async getManifest(): AppManifest`
-        - `async getState(): any`
+            - TODO
+        - `async proposeState(state: AppState)`
+            - TODO
+            - Proposes a state to countersign
+        - `async acceptState(state: AppState)`
+            - TODO
+            - Accept a proposed state 
+        - `async rejectState(state: AppState)`
+            - TODO
+            - Reject a proposed state 
     - App lifecycle
         - `on(eventType, callback: Function)`
             - eventTypes
-                - `updateState(newState)`
-                - `uninstall()`
-                - `proposeState(newState)`
+                - `updateState`
+                    - [Node event](#updatestate-event)
+                - `uninstall`
+                    - [Node event](#uninstall)
+                - `proposeState`
+                    - [Node event](#proposestate-event)
+                - `rejectState`
+                    - [Node event](#rejectstate-event)
 - `types`
-    - `NodeProvider` (external)
-        - (Injected into webpage)
-        - Instance methods
-            - `postMessage(message)`
-            - `onMessage(callback)`
-    - `AppInstanceID`: string
-    - `AppState`: object, a POJO describing app state, encoded using app state encoding
-    - `AppAction`: object, a POJO describing app action, encoded using app action encoding
-    - `BlockchainAsset`:
-        - `assetType`: ETH or ERC20 or OTHER
-        - `token`: Address of token contract if applicable
-    - `AppTerms`:
-        - `asset: BlockchainAsset`
-        - `limit`: Funds limit committed to app
-    - `AppDefinition`
-        - `address`: on-chain address for the app definition contract
-        - `appStateEncoding`: ABI encoding for App State.
-        - `appActionEncoding`: Optional ABI encoding for App Action.
-            - Leave empty to signify that app state updates using state proposals, not actions.
+    - Everything under [Data Types](#data-types) except `AppInstance` 
     - `AppManifest`
+        - TODO
         - `name`: human-readable name of app e.g. "TicTacToe"
         - `version`: semantic version of app definition contract
         - `definition: AppDefinition`
+
+Node Protocol
+=============
+
+Public Methods
+--------------
+
+#### getAppInstances
+
+Returns **all** app instances currently installed on the Node. 
+
+**NOTE**: This is terrible from a security perspective. In the future this method will be changed or deprecated to fix the security flaw. 
+
+Params: `[]`
+
+Result: list of [AppInstance](#appinstance)
+
+#### proposeInstall
+
+Generate an app instance ID given details about an app installation.  
+
+Params:
+- `peerAddress: string` 
+    - Address of the peer to install the app with
+- `appId: string` 
+    - On-chain address of App Definition contract
+- `abiEncodings: `[`AppABIEncodings`](#appabiencodings)
+    - ABI encodings used for states and actions of this app
+- `asset: `[`BlockchainAsset`](#blockchainasset)
+    - The asset used for deposits into this app
+- `myDeposit: BigNumber`
+    - Amount of the asset deposited by this user
+- `peerDeposit: BigNumber`
+    - Amount of the asset deposited by the counterparty
+- `timeout: BigNumber`
+    - Number of blocks until a submitted state for this app is considered finalized
+- `initialState: `[`AppState`](#appstate)
+    - Initial state of app instance
+    
+Result: 
+- `appInstanceId: string`
+    - Unique ID for this app instance 
+
+Errors: (TODO)
+- Not enough funds
+
+#### rejectInstall
+
+Reject an app instance installation. 
+
+Params:
+- `appInstanceId: string`
+    - Unique ID for the app instance to reject 
+    
+Result: "OK"
+
+Errors: (TODO)
+- Proposed app instance doesn't exist
+
+#### install
+
+Install an app instance. 
+
+Params:
+- `appInstanceId: string`
+    - Unique ID for the app instance to install 
+    
+
+Result:
+- `appInstance: `[`AppInstance`](#appinstance)
+    - Successfully installed app instance
+
+Errors: (TODO)
+- Counterparty rejected installation
+
+#### getState
+
+Get the latest state of an app instance.
+
+Params:
+- `appInstanceId: string`
+    - Unique ID of the app instance 
+
+Result:
+- `state: `[`AppState`](#appstate)
+    - Latest state of the app instance
+  
+Errors: (TODO)
+- App not installed
+
+
+#### getAppInstanceDetails
+
+Get details of an app instance.
+
+Params:
+- `appInstanceId: string`
+    - Unique ID of the app instance 
+
+Result:
+- `appInstance: `[`AppInstance`](#appinstance)
+    - App instance details
+
+
+#### takeAction
+
+Take action on current app state to advance it to a new state.
+
+Params:
+- `appInstanceId: string`
+    - Unique ID of the app instance 
+    - Action to take on the current state 
+
+Result:
+- `newState: `[`AppState`](#appstate)
+    - New app state
+
+Errors: (TODO)
+- Illegal action
+
+#### uninstall
+
+Uninstall an app instance, paying out users according to the latest signed state.
+
+Params:
+- `appInstanceId: string`
+    - Unique ID of the app instance to uninstall
+
+Result:
+- `myPayout: BigNumber`
+    - Amount of the asset paid out to this user 
+- `peerPayout: BigNumber`
+    - Amount of the asset paid out to peer
+    
+Errors: (TODO)
+- App state not terminal  
+
+#### proposeState
+
+TODO
+
+#### acceptState
+
+TODO
+
+#### rejectState
+
+TODO
+
+
+Events
+------
+
+#### install event
+
+Fired if new app instance was successfully installed.
+
+Params:
+- `appInstance: `[`AppInstance`](#appinstance)
+    - Newly installed app instance
+
+#### rejectInstall event
+
+Fired if installation of a new app instance was rejected.
+
+Params:
+- `appInstance: `[`AppInstance`](#appinstance)
+    - Rejected app instance
+
+#### updateState event
+
+Fired if app state is successfully updated.
+
+Params:
+- `appInstanceId: string`
+    - Unique ID of app instance
+- `newState: `[`AppState`](#appstate)
+- `oldState: `[`AppState`](#appstate)
+- `action?: `[`AppAction`](#appaction)
+    - Optional action that was taken to advance from the old state to the new state
+
+#### uninstall event
+
+Fired if app instance is successfully uninstalled
+
+Params:
+- `appInstance: `[`AppInstance`](#appinstance)
+    - Uninstalled app instance
+- `myPayout: BigNumber`
+    - Amount of the asset paid out to this user 
+- `peerPayout: BigNumber`
+    - Amount of the asset paid out to peer
+
+#### proposeState event
+
+TODO
+
+#### rejectState event
+
+TODO
+
+### Data Types
+
+#### `AppInstance`
+
+An instance of an installed app.
+
+- `id: string` 
+    - Unique ID for this app instance
+- `appId: string` 
+    - Unique ID for this app
+    - Currently corresponds to on-chain address of App Definition contract
+- `abiEncodings: `[`AppABIEncodings`](#appabiencodings)
+    - ABI encodings used for states and actions of this app
+- `asset: `[`BlockchainAsset`](#blockchainasset)
+    - The asset used for deposits into this app
+- `myDeposit: BigNumber`
+    - Amount of the asset deposited by this user
+- `peerDeposit: BigNumber`
+    - Amount of the asset deposited by the counterparty
+- `timeout: BigNumber`
+    - Number of blocks until a submitted state for this app is considered finalized
+   
+#### `BlockchainAsset`
+- `assetType: number`
+    - The type of the asset.
+    - Set 0 for ETH, 1 for ERC20 token, 2 for Other.
+- `token?: string`
+    - Optional address of token contract if assetType is set to 1.
+
+#### `AppABIEncodings`
+- `stateEncoding: string` 
+    - ABI encoding of the app state
+- `actionEncoding?: string`
+    - Optional ABI encoding of the app action
+    - If left blank, instances of the app will only be able to update state using [`proposeState`](#proposestate)
+    - If supplied, instances of this app will also be able to update state using [`takeAction`](#takeaction) 
+
+#### AppState
+
+- Plain Old Javascript Object representation of the state of an app instance.
+- ABI encoded/decoded using the `stateEncoding` field on the instance's [`AppABIEncodings`](#appabiencodings).
+
+#### AppAction
+
+- Plain Old Javascript Object representation of the action of an app instance.
+- ABI encoded/decoded using the `actionEncoding` field on the instance's [`AppABIEncodings`](#appabiencodings).
+


### PR DESCRIPTION
- Add Node Protocol heading with methods and events
- Split AppDefinition into appId (on-chain address) and encodings
- Move install() to Provider
- Refer to Node Protocol methods and events for CFjs instance methods and events
- Leave anything with app manifest or proposing states TODO
