### PR TITLE
delete unused exports in cf.legacy

### DIFF
--- a/packages/cf.js/src/legacy/index.ts
+++ b/packages/cf.js/src/legacy/index.ts
@@ -5,11 +5,4 @@ import * as network from "./network";
 import * as node from "./node";
 import * as utils from "./utils";
 
-export {
-  app,
-  channel,
-  network,
-  node,
-  NotificationType,
-  utils
-};
+export { app, channel, network, node, NotificationType, utils };

--- a/packages/cf.js/src/legacy/index.ts
+++ b/packages/cf.js/src/legacy/index.ts
@@ -1,23 +1,15 @@
 import * as app from "./app";
-import { AppInstance } from "./app-instance";
-import { AppInstanceClient } from "./app-instance-client";
 import * as channel from "./channel";
-import { Client } from "./client";
 import { NotificationType } from "./mixins/observable";
 import * as network from "./network";
 import * as node from "./node";
-import * as types from "./types";
 import * as utils from "./utils";
 
 export {
   app,
-  AppInstance,
-  AppInstanceClient,
   channel,
-  Client,
   network,
   node,
   NotificationType,
-  types,
   utils
 };


### PR DESCRIPTION
these exported values in the namespace `cf.legacy` are not unused. deleting will prevent accidental uses of them from being added.