### PR TITLE
[playground] Moves usage of apps-list to app-home route

### DIFF
--- a/packages/playground/src/components/app-home/app-home.tsx
+++ b/packages/playground/src/components/app-home/app-home.tsx
@@ -1,5 +1,18 @@
 import { Component } from "@stencil/core";
 
+const apps = {
+  // TODO: How do we get a list of available apps?
+  "0x822c045f6F5e7E8090eA820E24A5f327C4E62c96": {
+    name: "High Roller",
+    url: "dapps/high-roller.html",
+    icon: "assets/icon/high-roller.svg"
+  },
+  "0xd545e82792b6EF2000908F224275ED0456Cf36FA": {
+    name: "Tic-Tac-Toe",
+    url: "dapps/tic-tac-toe.html",
+    icon: "assets/icon/icon.png"
+  }
+};
 @Component({
   tag: "app-home",
   styleUrl: "app-home.css",
@@ -9,7 +22,7 @@ export class AppHome {
   render() {
     return (
       <div class="app-home">
-        <span>Soon, we'll have some dApps for you!</span>
+        <apps-list apps={apps} />
       </div>
     );
   }

--- a/packages/playground/src/components/app-root/app-root.tsx
+++ b/packages/playground/src/components/app-root/app-root.tsx
@@ -1,18 +1,8 @@
 import { Component } from "@stencil/core";
 
-const apps = {
-  // TODO: How do we get a list of available apps?
-  "0x822c045f6F5e7E8090eA820E24A5f327C4E62c96": {
-    name: "High Roller",
-    url: "dapps/high-roller.html",
-    icon: "assets/icon/high-roller.svg"
-  },
-  "0xd545e82792b6EF2000908F224275ED0456Cf36FA": {
-    name: "Tic-Tac-Toe",
-    url: "dapps/tic-tac-toe.html",
-    icon: "assets/icon/icon.png"
-  }
-};
+// @ts-ignore
+// Needed due to https://github.com/ionic-team/stencil-router/issues/62
+import { MatchResults } from "@stencil/router";
 
 @Component({
   tag: "app-root",
@@ -33,8 +23,6 @@ export class AppRoot {
               <stencil-route url="/" component="app-home" exact={true} />
             </stencil-route-switch>
           </stencil-router>
-
-          <apps-list apps={apps} />
         </main>
       </div>
     );

--- a/packages/playground/src/components/apps-list-item/apps-list-item.tsx
+++ b/packages/playground/src/components/apps-list-item/apps-list-item.tsx
@@ -6,9 +6,9 @@ import { Component, Prop } from "@stencil/core";
   shadow: true
 })
 export class AppsListItem {
-  @Prop() icon: string;
-  @Prop() name: string;
-  @Prop() url: string;
+  @Prop() icon: string = "";
+  @Prop() name: string = "";
+  @Prop() url: string = "";
 
   render() {
     return (

--- a/packages/playground/src/components/apps-list/apps-list.tsx
+++ b/packages/playground/src/components/apps-list/apps-list.tsx
@@ -8,7 +8,7 @@ import { AppDefinition } from "../../types";
   shadow: true
 })
 export class AppsList {
-  @Prop() apps: { [s: string]: AppDefinition };
+  @Prop() apps: { [s: string]: AppDefinition } = {};
 
   public get appsList(): AppDefinition[] {
     return Object.keys(this.apps).map(key => this.apps[key]);


### PR DESCRIPTION
Components inserted via #277 were being instantiated directly on `<app-root />`, and I didn't notice that during the review. This PR moves the usage of `<apps-list />` to the `render()` function of  `<app-home />` and adds some initialization values for properties.