### PR TITLE
[playground] Added support for opening a dApp

### DIFF
--- a/packages/playground/package.json
+++ b/packages/playground/package.json
@@ -11,7 +11,7 @@
   },
   "dependencies": {
     "@stencil/core": "~0.15.1",
-    "@stencil/router": "~0.3.0",
+    "@stencil/router": "~0.2.6",
     "eventemitter3": "^3.1.0"
   },
   "repository": {

--- a/packages/playground/src/components/app-home/app-home.tsx
+++ b/packages/playground/src/components/app-home/app-home.tsx
@@ -1,18 +1,7 @@
 import { Component } from "@stencil/core";
 
-const apps = {
-  // TODO: How do we get a list of available apps?
-  "0x822c045f6F5e7E8090eA820E24A5f327C4E62c96": {
-    name: "High Roller",
-    url: "dapps/high-roller.html",
-    icon: "assets/icon/high-roller.svg"
-  },
-  "0xd545e82792b6EF2000908F224275ED0456Cf36FA": {
-    name: "Tic-Tac-Toe",
-    url: "dapps/tic-tac-toe.html",
-    icon: "assets/icon/icon.png"
-  }
-};
+import apps from "../../utils/app-list";
+
 @Component({
   tag: "app-home",
   styleUrl: "app-home.css",

--- a/packages/playground/src/components/app-home/app-home.tsx
+++ b/packages/playground/src/components/app-home/app-home.tsx
@@ -1,4 +1,5 @@
-import { Component } from "@stencil/core";
+import { Component, Prop } from "@stencil/core";
+import { RouterHistory } from "@stencil/router";
 
 import apps from "../../utils/app-list";
 
@@ -8,10 +9,16 @@ import apps from "../../utils/app-list";
   shadow: true
 })
 export class AppHome {
+  @Prop() history: RouterHistory = {} as RouterHistory;
+
+  appClickedHandler(e) {
+    this.history.push(e.detail.dappContainerUrl, e.detail);
+  }
+
   render() {
     return (
       <div class="app-home">
-        <apps-list apps={apps} />
+        <apps-list apps={apps} onAppClicked={e => this.appClickedHandler(e)} />
       </div>
     );
   }

--- a/packages/playground/src/components/app-root/app-root.tsx
+++ b/packages/playground/src/components/app-root/app-root.tsx
@@ -21,6 +21,7 @@ export class AppRoot {
           <stencil-router>
             <stencil-route-switch scrollTopOffset={0}>
               <stencil-route url="/" component="app-home" exact={true} />
+              <stencil-route url="/dapp/:dappName" component="dapp-container" />
             </stencil-route-switch>
           </stencil-router>
         </main>

--- a/packages/playground/src/components/apps-list-item/apps-list-item.tsx
+++ b/packages/playground/src/components/apps-list-item/apps-list-item.tsx
@@ -1,4 +1,4 @@
-import { Component, Prop } from "@stencil/core";
+import { Component, Event, EventEmitter, Prop } from "@stencil/core";
 
 @Component({
   tag: "apps-list-item",
@@ -6,14 +6,33 @@ import { Component, Prop } from "@stencil/core";
   shadow: true
 })
 export class AppsListItem {
+  @Event() appClicked: EventEmitter = {} as EventEmitter;
   @Prop() icon: string = "";
   @Prop() name: string = "";
   @Prop() url: string = "";
 
+  private getAppSlug() {
+    return this.name.toLowerCase().replace(/ /g, "-");
+  }
+
+  appClickedHandler(event) {
+    this.appClicked.emit(event);
+  }
+
+  private openApp(event: MouseEvent) {
+    event.preventDefault();
+
+    this.appClicked.emit({
+      name: this.name,
+      dappContainerUrl: `/dapp/${this.getAppSlug()}`,
+      dappUrl: this.url
+    });
+  }
+
   render() {
     return (
       <li class="item">
-        <a href={this.url}>
+        <a href={`/dapp/${this.getAppSlug()}`} onClick={e => this.openApp(e)}>
           <div class="icon">
             <img src={this.icon} alt={this.name} />
           </div>

--- a/packages/playground/src/components/apps-list/apps-list.tsx
+++ b/packages/playground/src/components/apps-list/apps-list.tsx
@@ -1,4 +1,4 @@
-import { Component, Prop } from "@stencil/core";
+import { Component, Event, EventEmitter, Prop } from "@stencil/core";
 
 import { AppDefinition } from "../../types";
 
@@ -8,17 +8,27 @@ import { AppDefinition } from "../../types";
   shadow: true
 })
 export class AppsList {
+  @Event() appClicked: EventEmitter = {} as EventEmitter;
   @Prop() apps: { [s: string]: AppDefinition } = {};
 
   public get appsList(): AppDefinition[] {
     return Object.keys(this.apps).map(key => this.apps[key]);
   }
 
+  appClickedHandler(event) {
+    this.appClicked.emit(event.detail);
+  }
+
   render() {
     return (
       <ul class="list">
         {this.appsList.map(app => (
-          <apps-list-item icon={app.icon} name={app.name} url={app.url} />
+          <apps-list-item
+            onAppClicked={e => this.appClickedHandler(e)}
+            icon={app.icon}
+            name={app.name}
+            url={app.url}
+          />
         ))}
       </ul>
     );

--- a/packages/playground/src/types.ts
+++ b/packages/playground/src/types.ts
@@ -1,5 +1,6 @@
 export interface AppDefinition {
   name: string;
+  slug: string;
   url: string;
   icon: string;
 }

--- a/packages/playground/src/utils/app-list.ts
+++ b/packages/playground/src/utils/app-list.ts
@@ -1,0 +1,17 @@
+import { AppDefinition } from "../types";
+
+export default {
+  // TODO: How do we get a list of available apps?
+  "0x822c045f6F5e7E8090eA820E24A5f327C4E62c96": {
+    name: "High Roller",
+    slug: "high-roller",
+    url: "/dapps/high-roller.html",
+    icon: "assets/icon/high-roller.svg"
+  },
+  "0xd545e82792b6EF2000908F224275ED0456Cf36FA": {
+    name: "Tic-Tac-Toe",
+    slug: "tic-tac-toe",
+    url: "/dapps/tic-tac-toe.html",
+    icon: "assets/icon/icon.png"
+  }
+} as { [index: string]: AppDefinition };


### PR DESCRIPTION
This PR expands on previous work done in #277 and #278. A dApp icon is now clickable, transitioning to a route `/dapp/<app-slug>`, where the `<dapp-container />` component is instantiated, opening the dApp's URL.