### PR TITLE
add connected state

### DIFF
--- a/packages/playground/src/components/app-connection/app-connection.e2e.ts
+++ b/packages/playground/src/components/app-connection/app-connection.e2e.ts
@@ -8,4 +8,36 @@ describe("app-connection", () => {
     const element = await page.find("app-connection");
     expect(element).toHaveClass("hydrated");
   });
+
+  it("applies to .connected class to the dot when connected=true", async () => {
+    const page = await newE2EPage();
+    await page.setContent("<app-connection connected=true></app-connection>");
+
+    const element = await page.find("app-connection >>> .dot");
+    expect(element).toHaveClass("connected");
+  });
+
+  it("sets the status to 'Connected' when connected=true", async () => {
+    const page = await newE2EPage();
+    await page.setContent("<app-connection connected=true></app-connection>");
+
+    const element = await page.find("app-connection >>> .status");
+    expect(element.innerText).toEqual("Connected");
+  });
+
+  it("does not apply the .connected class to the dot when connected=false", async () => {
+    const page = await newE2EPage();
+    await page.setContent("<app-connection></app-connection>");
+
+    const element = await page.find("app-connection >>> .dot");
+    expect(element).not.toHaveClass("connected");
+  });
+
+  it("sets the status to 'No Connection' when connected=false", async () => {
+    const page = await newE2EPage();
+    await page.setContent("<app-connection></app-connection>");
+
+    const element = await page.find("app-connection >>> .status");
+    expect(element.innerText).toEqual("No Connection");
+  });
 });

--- a/packages/playground/src/components/app-connection/app-connection.scss
+++ b/packages/playground/src/components/app-connection/app-connection.scss
@@ -10,6 +10,10 @@
   display: inline-block;
   border-radius: 6px;
   animation: pulse 1.2s ease 0s infinite normal none running;
+
+  &.connected {
+    background-color: rgb(11, 192, 118);
+  }
 }
 
 @keyframes pulse {

--- a/packages/playground/src/components/app-connection/app-connection.tsx
+++ b/packages/playground/src/components/app-connection/app-connection.tsx
@@ -1,4 +1,4 @@
-import { Component } from "@stencil/core";
+import { Component, Prop } from "@stencil/core";
 
 @Component({
   tag: "app-connection",
@@ -6,11 +6,15 @@ import { Component } from "@stencil/core";
   shadow: true
 })
 export class AppConnection {
+  @Prop() connected: boolean = false;
+
   render() {
     return (
       <div class="connection">
-        <span class="dot" />
-        <span class="status">No Connection</span>
+        <span class={this.connected ? "dot connected" : "dot"} />
+        <span class="status">
+          {this.connected ? "Connected" : "No Connection"}
+        </span>
       </div>
     );
   }


### PR DESCRIPTION
Adds a simple `connected` boolean, currently purely for UI purposes:

![screenshot from 2018-11-30 13-36-17](https://user-images.githubusercontent.com/2700872/49308024-01b1a280-f4a5-11e8-96c3-461b2e4f2e60.png)
![screenshot from 2018-11-30 13-36-30](https://user-images.githubusercontent.com/2700872/49308025-01b1a280-f4a5-11e8-8339-ed51cb4341da.png)
