### PR TITLE
add menu drawer for mobile

### DIFF
--- a/packages/playground/src/assets/icon/menu-btn.svg
+++ b/packages/playground/src/assets/icon/menu-btn.svg
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="20px" height="12px" viewBox="0 0 20 12" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    <title>Open Menu</title>
+    <defs>
+        <path d="M0,0 L20,0 L20,1.5 L0,1.5 L0,0 Z M0,10 L20,10 L20,11.5 L0,11.5 L0,10 Z M0,5 L20,5 L20,6.5 L0,6.5 L0,5 Z" id="path-1"></path>
+    </defs>
+    <g id="Symbols" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
+        <g id="#UI-/-Components-/-Icons-/-Hamburger">
+            <g>
+                <mask id="mask-2" fill="white">
+                    <use xlink:href="#path-1"></use>
+                </mask>
+                <use id="Mask" fill="#101010" xlink:href="#path-1"></use>
+            </g>
+        </g>
+    </g>
+</svg>

--- a/packages/playground/src/components/app-connection/app-connection.scss
+++ b/packages/playground/src/components/app-connection/app-connection.scss
@@ -27,3 +27,9 @@
     transform: scale(1);
   }
 }
+
+@media screen and (max-width: $screen-sm) {
+  .connection {
+    margin: 24px 0;
+  }
+}

--- a/packages/playground/src/components/app-drawer/app-drawer.e2e.ts
+++ b/packages/playground/src/components/app-drawer/app-drawer.e2e.ts
@@ -1,0 +1,27 @@
+import { newE2EPage } from "@stencil/core/testing";
+
+describe("app-drawer", () => {
+  it("renders", async () => {
+    const page = await newE2EPage();
+    await page.setContent("<app-drawer></app-drawer>");
+
+    const element = await page.find("app-drawer");
+    expect(element).toHaveClass("hydrated");
+  });
+
+  it("applies the .opened class when opened=true", async () => {
+    const page = await newE2EPage();
+    await page.setContent("<app-drawer opened=true></app-drawer>");
+
+    const element = await page.find("app-drawer >>> .drawer-container");
+    expect(element).toHaveClass("opened");
+  });
+
+  it("does not apply the .opened class when opened=false", async () => {
+    const page = await newE2EPage();
+    await page.setContent("<app-drawer></app-drawer>");
+
+    const element = await page.find("app-drawer >>> .drawer-container");
+    expect(element).not.toHaveClass("opened");
+  });
+});

--- a/packages/playground/src/components/app-drawer/app-drawer.scss
+++ b/packages/playground/src/components/app-drawer/app-drawer.scss
@@ -1,0 +1,52 @@
+.drawer-container {
+  position: fixed;
+  top: 0;
+  height: 100vh;
+  width: 100vw;
+  z-index: -1;
+
+  .drawer {
+    position: absolute;
+    top: 0;
+    width: 75%;
+    height: 100%;
+    margin: 0;
+    padding: 1rem;
+    background: $c-white;
+    transition: transform 150ms;
+    transform: translateX(-100%);
+    z-index: 101;
+  
+    .top-line {
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+    }
+  }
+
+  .drawer-screen {
+    display: none;
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    background-color: $c-black;
+    opacity: 0;
+    z-index: 100;
+    transition: opacity 150ms;
+  }
+
+  &.opened {
+    z-index: 100;
+
+    .drawer {
+      transform: translateX(0%);
+    }
+
+    .drawer-screen {
+      display: block;
+      opacity: 0.32;
+    }
+  }
+}

--- a/packages/playground/src/components/app-drawer/app-drawer.scss
+++ b/packages/playground/src/components/app-drawer/app-drawer.scss
@@ -4,6 +4,7 @@
   height: 100vh;
   width: 100vw;
   z-index: -1;
+  transition: z-index 150ms;
 
   .drawer {
     position: absolute;

--- a/packages/playground/src/components/app-drawer/app-drawer.spec.ts
+++ b/packages/playground/src/components/app-drawer/app-drawer.spec.ts
@@ -1,0 +1,7 @@
+import { AppDrawer } from "./app-drawer";
+
+describe("app", () => {
+  it("builds", () => {
+    expect(new AppDrawer()).toBeTruthy();
+  });
+});

--- a/packages/playground/src/components/app-drawer/app-drawer.tsx
+++ b/packages/playground/src/components/app-drawer/app-drawer.tsx
@@ -1,0 +1,35 @@
+import { Component, Event, EventEmitter, Prop } from "@stencil/core";
+
+@Component({
+  tag: "app-drawer",
+  styleUrl: "app-drawer.scss",
+  shadow: true
+})
+export class AppDrawer {
+  @Event() closeDrawer: EventEmitter = {} as EventEmitter;
+  @Prop() opened: boolean = false;
+
+  private menuClicked(event: MouseEvent) {
+    event.preventDefault();
+
+    this.closeDrawer.emit();
+  }
+
+  render() {
+    return (
+      <div class={this.opened ? "drawer-container opened" : "drawer-container"}>
+        <a onClick={e => this.menuClicked(e)} class="drawer-screen" />
+        <menu class="drawer">
+          <div class="top-line">
+            <app-logo />
+
+            <a onClick={e => this.menuClicked(e)}>
+              <img src="/assets/icon/menu-btn.svg" alt="Menu" />
+            </a>
+          </div>
+          <app-connection />
+        </menu>
+      </div>
+    );
+  }
+}

--- a/packages/playground/src/components/app-header/app-header.scss
+++ b/packages/playground/src/components/app-header/app-header.scss
@@ -1,35 +1,20 @@
 .header {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
   padding: 1.06rem 1.333rem;
   border-bottom: 1px solid $c-blue;
+
+  .desktop {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+  }
+
+  .mobile {
+    display: none;
+  }
 
   .left {
     display: flex;
     align-items: center;
-  }
-
-  .logo {
-    margin: 0;
-    border: 1px solid $c-black;
-    font-size: $f-base;
-
-    a {
-      display: flex;
-      align-items: center;
-    }
-
-    img {
-      width: 3.2rem;
-      height: 3.2rem;
-    }
-
-    span {
-      @include f-logo;
-      display: block;
-      padding: 0 1.25rem;
-    }
   }
 
   .right {
@@ -41,17 +26,12 @@
 
 @media screen and (max-width: $screen-sm) {
   .header {
-    padding: 0.666rem;
+    .desktop {
+      display: none;
+    }
 
-    .left {
-      img {
-        width: 2.25rem;
-        height: 2.25rem;
-      }
-
-      span {
-        padding: 0 0.75rem;
-      }
+    .mobile {
+      display: block;
     }
   }
 }

--- a/packages/playground/src/components/app-header/app-header.tsx
+++ b/packages/playground/src/components/app-header/app-header.tsx
@@ -1,4 +1,4 @@
-import { Component } from "@stencil/core";
+import { Component, Event, EventEmitter } from "@stencil/core";
 
 @Component({
   tag: "app-header",
@@ -6,19 +6,29 @@ import { Component } from "@stencil/core";
   shadow: true
 })
 export class AppHeader {
+  @Event() openDrawer: EventEmitter = {} as EventEmitter;
+
+  private menuClicked(event: MouseEvent) {
+    event.preventDefault();
+
+    this.openDrawer.emit();
+  }
+
   render() {
     return (
       <header class="header">
-        <div class="left">
-          <h1 class="logo">
-            <a href="/">
-              <img src="/assets/icon/logo.svg" alt="Counterfactual" />
-              <span>Playground</span>
-            </a>
-          </h1>
-          <app-connection />
+        <div class="mobile">
+          <a onClick={e => this.menuClicked(e)}>
+            <img src="/assets/icon/menu-btn.svg" alt="Menu" />
+          </a>
         </div>
-        <nav class="right" />
+        <div class="desktop">
+          <div class="left">
+            <app-logo />
+            <app-connection />
+          </div>
+          <nav class="right" />
+        </div>
       </header>
     );
   }

--- a/packages/playground/src/components/app-logo/app-logo.e2e.ts
+++ b/packages/playground/src/components/app-logo/app-logo.e2e.ts
@@ -1,0 +1,11 @@
+import { newE2EPage } from "@stencil/core/testing";
+
+describe("app-logo", () => {
+  it("renders", async () => {
+    const page = await newE2EPage();
+    await page.setContent("<app-logo></app-logo>");
+
+    const element = await page.find("app-logo");
+    expect(element).toHaveClass("hydrated");
+  });
+});

--- a/packages/playground/src/components/app-logo/app-logo.scss
+++ b/packages/playground/src/components/app-logo/app-logo.scss
@@ -1,0 +1,21 @@
+.logo {
+  margin: 0;
+  border: 1px solid $c-black;
+  font-size: $f-base;
+
+  a {
+    display: flex;
+    align-items: center;
+  }
+
+  img {
+    width: 3.2rem;
+    height: 3.2rem;
+  }
+
+  span {
+    @include f-logo;
+    display: block;
+    padding: 0 1.25rem;
+  }
+}

--- a/packages/playground/src/components/app-logo/app-logo.spec.ts
+++ b/packages/playground/src/components/app-logo/app-logo.spec.ts
@@ -1,0 +1,7 @@
+import { AppLogo } from "./app-logo";
+
+describe("app", () => {
+  it("builds", () => {
+    expect(new AppLogo()).toBeTruthy();
+  });
+});

--- a/packages/playground/src/components/app-logo/app-logo.tsx
+++ b/packages/playground/src/components/app-logo/app-logo.tsx
@@ -1,0 +1,19 @@
+import { Component } from "@stencil/core";
+
+@Component({
+  tag: "app-logo",
+  styleUrl: "app-logo.scss",
+  shadow: true
+})
+export class AppLogo {
+  render() {
+    return (
+      <h1 class="logo">
+        <a href="/">
+          <img src="/assets/icon/logo.svg" alt="Counterfactual" />
+          <span>Playground</span>
+        </a>
+      </h1>
+    );
+  }
+}

--- a/packages/playground/src/components/app-root/app-root.tsx
+++ b/packages/playground/src/components/app-root/app-root.tsx
@@ -1,4 +1,4 @@
-import { Component } from "@stencil/core";
+import { Component, State } from "@stencil/core";
 
 // @ts-ignore
 // Needed due to https://github.com/ionic-team/stencil-router/issues/62
@@ -10,10 +10,24 @@ import { MatchResults } from "@stencil/router";
   shadow: true
 })
 export class AppRoot {
+  @State() drawerOpened: boolean = false;
+
+  closeDrawerHandler(e) {
+    this.drawerOpened = false;
+  }
+
+  openDrawerHandler(e) {
+    this.drawerOpened = true;
+  }
+
   render() {
     return (
       <div class="app-root wrapper">
-        <app-header />
+        <app-drawer
+          opened={this.drawerOpened}
+          onCloseDrawer={e => this.closeDrawerHandler(e)}
+        />
+        <app-header onOpenDrawer={e => this.openDrawerHandler(e)} />
 
         <main class="wrapper__content">
           <stencil-router>


### PR DESCRIPTION
On mobile, the topbar is now nested away in a drawer (the closing animation looks smoother in person):

![drawer](https://user-images.githubusercontent.com/2700872/49315297-2add2d80-f4bb-11e8-805e-0993c590169d.gif)

On pc, it continues to look like:

![screenshot from 2018-11-30 16-10-13](https://user-images.githubusercontent.com/2700872/49315198-c621d300-f4ba-11e8-844d-c7d7b94ea496.png)