### PR TITLE
[monorepo] Adds arbitrary order build script

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -5,5 +5,5 @@ for package in $packages; do
   echo ">>> Building package: $package"
   cd packages/$package
   yarn build
-  cd ../..
+  cd -
 done

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,9 @@
+#!/usr/bin
+packages="contracts common-types machine cf.js node node-provider playground dapp-high-roller"
+
+for package in $packages; do
+  echo ">>> Building package: $package"
+  cd packages/$package
+  yarn build
+  cd ../..
+done

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "yarn": "^1.10"
   },
   "scripts": {
-    "build": "lerna run build --sort",
+    "build": "sh build.sh",
     "clean": "lerna run clean --parallel --no-bail",
     "test": "lerna run --stream --concurrency 1 test",
     "ganache": "ganache-cli --networkId ${npm_package_config_ganacheNetworkID} --verbose --gasLimit ${npm_package_config_ganacheGasLimit} --gasPrice ${npm_package_config_ganacheGasPrice} --port ${npm_package_config_ganachePort} --deterministic --account=\"${npm_package_config_unlockedAccount0},${npm_package_config_etherBalance}\" --account=\"${npm_package_config_unlockedAccount1},${npm_package_config_etherBalance}\" --account=\"${npm_package_config_unlockedAccount2},${npm_package_config_etherBalance}\" --account=\"${npm_package_config_unlockedAccount3},${npm_package_config_etherBalance}\" &> /dev/null &",


### PR DESCRIPTION
According to findings on #312, while we work on IIFE mode, we need to use symlinks to connect the dependencies. To keep `lerna` from breaking the build, we now use a bash script to arbitrarily build the packages in the order we need them to.

:warning: This should be reverted as soon as we fix Rollup.