### PR TITLE
Serialize stencil tests

### DIFF
--- a/packages/playground/package.json
+++ b/packages/playground/package.json
@@ -6,7 +6,9 @@
     "start": "stencil build --dev --watch --serve",
     "lint": "tslint -c tslint.json -p tsconfig.json",
     "lint:fix": "tslint -c tslint.json -p tsconfig.json --fix",
-    "test": "stencil test --spec --e2e",
+    "test": "yarn test:spec && yarn test:e2e",
+    "test:spec": "stencil test --spec",
+    "test:e2e": "stencil test --e2e",
     "test:watch": "stencil test --spec --e2e --watchAll"
   },
   "dependencies": {


### PR DESCRIPTION
### Description

Serializes stencil tests to prevent OOM errors.

The stencil documentation does not show any options to serialize directly through CLI, hence the separate commands.
