### PR TITLE
[playground] Implements stencil-route-link for app-logo

### DIFF
--- a/packages/playground/src/components/layout/app-header/app-logo/app-logo.tsx
+++ b/packages/playground/src/components/layout/app-header/app-logo/app-logo.tsx
@@ -9,10 +9,10 @@ export class AppLogo {
   render() {
     return (
       <h1 class="logo">
-        <a href="/">
+        <stencil-route-link url="/">
           <img src="/assets/icon/logo.svg" alt="Counterfactual" />
           <span>Playground</span>
-        </a>
+        </stencil-route-link>
       </h1>
     );
   }


### PR DESCRIPTION
This PR fixes the event handler for the logo click to use the Stencil router instead of a regular link. This prevents a hard-refresh of the page.