### PR TITLE
[playground] Implements fakeConnect for <header-account>

### DIFF
--- a/packages/playground/src/components/layout/layout-header/header-account/header-account.spec.ts
+++ b/packages/playground/src/components/layout/layout-header/header-account/header-account.spec.ts
@@ -4,4 +4,11 @@ describe("app", () => {
   it("builds", () => {
     expect(new HeaderAccount()).toBeTruthy();
   });
+
+  it("authenticates automatically when using fakeConnect", () => {
+    const component = new HeaderAccount();
+    component.fakeConnect = true;
+    component.login();
+    expect(component.authenticated).toEqual(true);
+  });
 });

--- a/packages/playground/src/components/layout/layout-header/header-account/header-account.tsx
+++ b/packages/playground/src/components/layout/layout-header/header-account/header-account.tsx
@@ -1,4 +1,4 @@
-import { Component, Prop } from "@stencil/core";
+import { Component, Event, EventEmitter, Prop, Watch } from "@stencil/core";
 
 @Component({
   tag: "header-account",
@@ -6,9 +6,24 @@ import { Component, Prop } from "@stencil/core";
   shadow: true
 })
 export class HeaderAccount {
-  @Prop() authenticated: boolean = false;
+  @Prop({ mutable: true }) authenticated: boolean = false;
+  @Prop() fakeConnect: boolean = false;
+  @Event() authenticationChanged: EventEmitter = {} as EventEmitter;
+
+  @Watch("authenticated")
+  authenticationChangedHandler() {
+    this.authenticationChanged.emit({ authenticated: this.authenticated });
+  }
 
   login() {
+    if (this.fakeConnect) {
+      console.warn(
+        "Faked connection, app thinks it's authenticated but it's not"
+      );
+      this.authenticated = true;
+      return;
+    }
+
     console.log("login");
   }
 

--- a/packages/playground/src/components/layout/layout-header/header-account/header-account.tsx
+++ b/packages/playground/src/components/layout/layout-header/header-account/header-account.tsx
@@ -16,6 +16,7 @@ export class HeaderAccount {
   }
 
   login() {
+    // This will make the UI behave as if the user is really logged in.
     if (this.fakeConnect) {
       console.warn(
         "Faked connection, app thinks it's authenticated but it's not"

--- a/packages/playground/src/components/layout/layout-header/header-content/header-content.tsx
+++ b/packages/playground/src/components/layout/layout-header/header-content/header-content.tsx
@@ -1,4 +1,11 @@
-import { Component, Event, EventEmitter, Prop } from "@stencil/core";
+import {
+  Component,
+  Event,
+  EventEmitter,
+  Prop,
+  State,
+  Watch
+} from "@stencil/core";
 
 @Component({
   tag: "header-content",
@@ -8,11 +15,18 @@ import { Component, Event, EventEmitter, Prop } from "@stencil/core";
 export class HeaderContent {
   @Event() closeDrawer: EventEmitter = {} as EventEmitter;
   @Prop() opened: boolean = false;
+  @State() connected: boolean = false;
 
   private menuClicked(event: MouseEvent) {
     event.preventDefault();
 
     this.closeDrawer.emit();
+  }
+
+  private updateConnectionWidget(
+    event: CustomEvent<{ authenticated: boolean }>
+  ) {
+    this.connected = event.detail.authenticated;
   }
 
   render() {
@@ -27,11 +41,14 @@ export class HeaderContent {
             </a>
           </div>
           <div class="connection">
-            <widget-connection />
+            <widget-connection connected={this.connected} />
           </div>
         </div>
         <div class="right" />
-        <header-account />
+        <header-account
+          fakeConnect={true}
+          onAuthenticationChanged={e => this.updateConnectionWidget(e)}
+        />
       </nav>
     );
   }


### PR DESCRIPTION
To facilitate mocking interactions while we get ready to have real connections in the Playground, this PR adds a `fakeConnect` property to the account component, which will change the state of the header app to `{ authenticated: true }`.