### PR TITLE
[contracts] use buildArtifacts

### DIFF
--- a/packages/contracts/test/integration/countingGame.spec.ts
+++ b/packages/contracts/test/integration/countingGame.spec.ts
@@ -1,6 +1,6 @@
 import { ethers } from "ethers";
 
-import { AbstractContract, expect } from "../../utils";
+import { AbstractContract, buildArtifacts, expect } from "../../utils";
 import * as Utils from "../../utils/misc";
 
 const web3 = (global as any).web3;
@@ -94,13 +94,7 @@ contract("CountingApp", (accounts: string[]) => {
   beforeEach(async () => {
     const networkID = await AbstractContract.getNetworkID(unlockedAccount);
     const staticCall = AbstractContract.fromArtifactName("StaticCall");
-    const signatures = AbstractContract.fromArtifactName("Signatures");
-    const transfer = AbstractContract.fromArtifactName("Transfer");
-    const appInstance = await AbstractContract.fromArtifactName("AppInstance", {
-      Signatures: signatures,
-      StaticCall: staticCall,
-      Transfer: transfer
-    });
+    const appInstance = await buildArtifacts.AppInstance;
     const countingApp = await AbstractContract.fromArtifactName("CountingApp", {
       StaticCall: staticCall
     });

--- a/packages/contracts/test/integration/ticTacToe.spec.ts
+++ b/packages/contracts/test/integration/ticTacToe.spec.ts
@@ -1,6 +1,6 @@
 import { ethers } from "ethers";
 
-import { AbstractContract, expect } from "../../utils";
+import { AbstractContract, buildArtifacts, expect } from "../../utils";
 import * as Utils from "../../utils/misc";
 
 const web3 = (global as any).web3;
@@ -14,7 +14,7 @@ contract("TicTacToe", (accounts: string[]) => {
 
   // @ts-ignore
   before(async () => {
-    const staticCall = AbstractContract.fromArtifactName("StaticCall");
+    const staticCall = buildArtifacts.StaticCall;
     const ticTacToe = await AbstractContract.fromArtifactName("TicTacToe", {
       StaticCall: staticCall
     });

--- a/packages/contracts/test/unit/appInstance.spec.ts
+++ b/packages/contracts/test/unit/appInstance.spec.ts
@@ -1,6 +1,6 @@
 import { ethers } from "ethers";
 
-import { AbstractContract, expect } from "../../utils";
+import { AbstractContract, expect, buildArtifacts } from "../../utils";
 import * as Utils from "../../utils/misc";
 
 const web3 = (global as any).web3;
@@ -56,12 +56,7 @@ contract("AppInstance", (accounts: string[]) => {
   // @ts-ignore
   before(async () => {
     networkID = await AbstractContract.getNetworkID(unlockedAccount);
-    const staticCall = AbstractContract.fromArtifactName("StaticCall");
-    const signatures = AbstractContract.fromArtifactName("Signatures");
-    appInstance = await AbstractContract.fromArtifactName("AppInstance", {
-      StaticCall: staticCall,
-      Signatures: signatures
-    });
+    appInstance = await buildArtifacts.AppInstance;
 
     sendUpdateToChainWithNonce = (nonce: number, appState?: string) =>
       stateChannel.functions.setState(

--- a/packages/contracts/test/unit/appInstance.spec.ts
+++ b/packages/contracts/test/unit/appInstance.spec.ts
@@ -1,6 +1,6 @@
 import { ethers } from "ethers";
 
-import { AbstractContract, expect, buildArtifacts } from "../../utils";
+import { AbstractContract, buildArtifacts, expect } from "../../utils";
 import * as Utils from "../../utils/misc";
 
 const web3 = (global as any).web3;


### PR DESCRIPTION
use `buildArtifacts` instead of `AbstractContract.fromArtifactName` where possible