### PR TITLE
[monorepo] Use tslint-microsoft-contrib@^6.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,5 +50,8 @@
     "tslint-config-prettier": "^1.15.0",
     "tslint-plugin-prettier": "^2.0.0",
     "typescript": "^3.1.3"
+  },
+  "resolutions": {
+    "**/tslint-microsoft-contrib": "^6.0.0"
   }
 }

--- a/tslint.json
+++ b/tslint.json
@@ -6,15 +6,6 @@
   ],
   "rules": {
     "prettier": true,
-    // TODO: Remove this override once tslint-microsoft-contrib releases 5.2.2.
-    // https://github.com/counterfactual/monorepo/issues/216
-    "function-name": [true, {
-      "method-regex": "^\\*?\\[?[a-zA-Z][\\w\\d\\.]+\\]?$",
-      "private-method-regex": "^\\*?\\[?[a-zA-Z][\\w\\d\\.]+\\]?$",
-      "protected-method-regex": "^\\*?\\[?[a-zA-Z][\\w\\d\\.]+\\]?$",
-      "static-method-regex": "^\\*?\\[?[a-zA-Z][\\w\\d\\.]+\\]?$",
-      "function-regex": "^\\*?\\[?[a-zA-Z][\\w\\d\\.]+\\]?$"
-    }],
     // NOTE: Added by Liam. I just prefer this rule to be on. Looks clean.
     "ordered-imports": [
       true,

--- a/yarn.lock
+++ b/yarn.lock
@@ -1204,7 +1204,7 @@ async-eventemitter@^0.2.2:
   dependencies:
     async "^2.4.0"
 
-"async-eventemitter@github:ahultgren/async-eventemitter#fa06e39e56786ba541c180061dbf2c0a5bbf951c":
+async-eventemitter@ahultgren/async-eventemitter#fa06e39e56786ba541c180061dbf2c0a5bbf951c:
   version "0.2.3"
   resolved "https://codeload.github.com/ahultgren/async-eventemitter/tar.gz/fa06e39e56786ba541c180061dbf2c0a5bbf951c"
   dependencies:
@@ -10105,10 +10105,10 @@ tslint-eslint-rules@^5.4.0:
     tslib "1.9.0"
     tsutils "^3.0.0"
 
-tslint-microsoft-contrib@~5.2.1:
-  version "5.2.1"
-  resolved "https://registry.yarnpkg.com/tslint-microsoft-contrib/-/tslint-microsoft-contrib-5.2.1.tgz#a6286839f800e2591d041ea2800c77487844ad81"
-  integrity sha512-PDYjvpo0gN9IfMULwKk0KpVOPMhU6cNoT9VwCOLeDl/QS8v8W2yspRpFFuUS7/c5EIH/n8ApMi8TxJAz1tfFUA==
+tslint-microsoft-contrib@^6.0.0, tslint-microsoft-contrib@~5.2.1:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/tslint-microsoft-contrib/-/tslint-microsoft-contrib-6.0.0.tgz#7bff73c9ad7a0b7eb5cdb04906de58f42a2bf7a2"
+  integrity sha512-R//efwn+34IUjTJeYgNDAJdzG0jyLWIehygPt/PHuZAieTolFVS56FgeFW7DOLap9ghXzMiFPTmDgm54qaL7QA==
   dependencies:
     tsutils "^2.27.2 <2.29.0"
 


### PR DESCRIPTION
### Description

Since `tslint-microsoft-config` has finally left beta status for the v6.x branch, we can now use it to remove linting issues related to function names for iterators (i.e. `[Symbol.asyncIterator()]`).

:warning: In order to apply this change, it's possible that you need to reboot Visual Studio Code.

You can verify the linting rule works by putting an iterator function somewhere and running `yarn run tslint --project .` to confirm, in case Visual Studio Code gives false positives.

The maintainers at `tslint-config-airbnb` haven't released a new version with this library yet, hence the need for a local resolution.

### Related issues

This PR resolves #91.