### PR TITLE
[dapp-high-roller] Clean up tsconfig.json

### DIFF
--- a/packages/dapp-high-roller/tsconfig.json
+++ b/packages/dapp-high-roller/tsconfig.json
@@ -5,7 +5,7 @@
     "declaration": false,
     "experimentalDecorators": true,
     "lib": [
-      "es2015"
+      "dom", "es2015"
     ],
     "module": "esnext",
     "jsx": "react",

--- a/packages/dapp-high-roller/tsconfig.json
+++ b/packages/dapp-high-roller/tsconfig.json
@@ -3,7 +3,6 @@
   "compilerOptions": {
     "allowUnreachableCode": false,
     "declaration": false,
-    "experimentalDecorators": true,
     "lib": [
       "dom",
       "es2015"

--- a/packages/dapp-high-roller/tsconfig.json
+++ b/packages/dapp-high-roller/tsconfig.json
@@ -6,7 +6,6 @@
     "declaration": false,
     "experimentalDecorators": true,
     "lib": [
-      "dom",
       "es2015"
     ],
     "moduleResolution": "node",

--- a/packages/dapp-high-roller/tsconfig.json
+++ b/packages/dapp-high-roller/tsconfig.json
@@ -5,7 +5,8 @@
     "declaration": false,
     "experimentalDecorators": true,
     "lib": [
-      "dom", "es2015"
+      "dom",
+      "es2015"
     ],
     "module": "esnext",
     "jsx": "react",

--- a/packages/dapp-high-roller/tsconfig.json
+++ b/packages/dapp-high-roller/tsconfig.json
@@ -1,16 +1,13 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
-    "allowSyntheticDefaultImports": true,
     "allowUnreachableCode": false,
     "declaration": false,
     "experimentalDecorators": true,
     "lib": [
       "es2015"
     ],
-    "moduleResolution": "node",
     "module": "esnext",
-    "target": "es2017",
     "jsx": "react",
     "jsxFactory": "h"
   },

--- a/packages/playground/tsconfig.json
+++ b/packages/playground/tsconfig.json
@@ -1,17 +1,13 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
-    "allowSyntheticDefaultImports": true,
     "allowUnreachableCode": false,
     "declaration": false,
-    "experimentalDecorators": true,
     "lib": [
       "dom",
       "es2015"
     ],
-    "moduleResolution": "node",
     "module": "esnext",
-    "target": "es2017",
     "jsx": "react",
     "jsxFactory": "h"
   },


### PR DESCRIPTION
~Removes `dom` from the `lib` key on the `tsconfig.json` inside `dapp-high-roller` because it is already declared in the root level `tsconfig.json`:~

Removes some duplicated fields from the root `tsconfig.json`