### PR TITLE
Rename appCfAddress to appInstanceId

### DIFF
--- a/packages/contracts/contracts/StateChannelTransaction.sol
+++ b/packages/contracts/contracts/StateChannelTransaction.sol
@@ -19,13 +19,13 @@ contract StateChannelTransaction is LibCondition {
 
   /// @notice Execute a fund transfer for a state channel app in a finalized state
   /// @param uninstallKey The key in the nonce registry
-  /// @param appCfAddress Counterfactual address of the app contract
+  /// @param appInstanceId AppInstanceId to be resolved
   /// @param terms The pre-agreed upon terms of the funds transfer
   function executeAppConditionalTransaction(
     AppRegistry appRegistry,
     NonceRegistry nonceRegistry,
     bytes32 uninstallKey,
-    bytes32 appCfAddress,
+    bytes32 appInstanceId,
     Transfer.Terms terms
   )
     public
@@ -36,11 +36,11 @@ contract StateChannelTransaction is LibCondition {
     );
 
     require(
-      appRegistry.isStateFinalized(appCfAddress),
+      appRegistry.isStateFinalized(appInstanceId),
       "App is not finalized yet"
     );
 
-    Transfer.Transaction memory txn = appRegistry.getResolution(appCfAddress);
+    Transfer.Transaction memory txn = appRegistry.getResolution(appInstanceId);
 
     require(
       Transfer.meetsTerms(txn, terms),

--- a/packages/machine/test/unit/ethereum/install.spec.ts
+++ b/packages/machine/test/unit/ethereum/install.spec.ts
@@ -227,13 +227,13 @@ describe("InstallCommitment", () => {
             appRegistryAddress,
             nonceRegistryAddress,
             uninstallKey,
-            appCfAddress,
+            appInstanceId,
             terms
           ] = calldata.args;
           expect(appRegistryAddress).toBe(networkContext.AppRegistry);
           expect(nonceRegistryAddress).toBe(networkContext.NonceRegistry);
           expect(uninstallKey).toBe(app.uninstallKey);
-          expect(appCfAddress).toBe(appIdentityToHash(app.identity));
+          expect(appInstanceId).toBe(appIdentityToHash(app.identity));
           expect(terms[0]).toBe(app.terms.assetType);
           expect(terms[1]).toEqual(app.terms.limit);
           expect(terms[2]).toBe(app.terms.token);

--- a/packages/machine/test/unit/ethereum/setup.spec.ts
+++ b/packages/machine/test/unit/ethereum/setup.spec.ts
@@ -89,13 +89,13 @@ describe("SetupCommitment", () => {
         appRegistry,
         nonceRegistry,
         uninstallKey,
-        appCfAddress, // FIXME: Rename this field on the contract
+        appInstanceId,
         [assetType, limit, token]
       ] = desc.args;
       expect(appRegistry).toBe(networkContext.AppRegistry);
       expect(nonceRegistry).toEqual(networkContext.NonceRegistry);
       expect(uninstallKey).toBe(freeBalanceETH.uninstallKey);
-      expect(appCfAddress).toBe(appIdentityToHash(freeBalanceETH.identity));
+      expect(appInstanceId).toBe(appIdentityToHash(freeBalanceETH.identity));
       expect(assetType).toBe(freeBalanceETH.terms.assetType);
       expect(limit).toEqual(freeBalanceETH.terms.limit);
       expect(token).toBe(freeBalanceETH.terms.token);


### PR DESCRIPTION
For clarity, this PR renames `appCfAddress` to `appInstanceId` in the `executeAppConditionalTransaction` method of the `StateChannelTransaction` contract:

https://github.com/counterfactual/monorepo/blob/4234063325dabe8738bd7db1e2860fdf502d8e8c/packages/contracts/contracts/StateChannelTransaction.sol#L24-L30