### PR TITLE
[playground-server] Adds extra Webpack configuration to build process

### DIFF
--- a/packages/playground-server/package.json
+++ b/packages/playground-server/package.json
@@ -22,7 +22,7 @@
   },
   "scripts": {
     "start": "netlify-lambda -c webpack.config.js serve src",
-    "build": "netlify-lambda build src",
+    "build": "netlify-lambda -c webpack.config.js build src",
     "test": "jest"
   },
   "bugs": {


### PR DESCRIPTION
Apparently the deployed Netlify function isn't working due to lacking configuration. This PR should fix it.