### PR TITLE
[machine] Add an integration test for InstallCommitment

### DIFF
--- a/packages/machine/scripts/test.sh
+++ b/packages/machine/scripts/test.sh
@@ -58,4 +58,7 @@ echo "⚙️ Running migrations with build artifacts from @counterfactual/contra
 yarn run truffle migrate --network machine --reset > /dev/null
 
 echo "🧪 Starting jest test suites"
-jest --detectOpenHandles $1
+jest \
+  --runInBand `#integration tests fail parallelized (tx nonce out of sync)` \
+  --detectOpenHandles \
+  $1

--- a/packages/machine/test/integration/bignumber-jest-matcher.ts
+++ b/packages/machine/test/integration/bignumber-jest-matcher.ts
@@ -1,0 +1,16 @@
+import { BigNumber } from "ethers/utils";
+
+declare global {
+  namespace jest {
+    interface Matchers<R> {
+      toBeEq(expected: BigNumber): BigNumber;
+    }
+  }
+}
+
+export function toBeEq(received: BigNumber, argument: BigNumber) {
+  return {
+    pass: received.eq(argument),
+    message: () => `expected ${received} not to be equal to ${argument}`
+  };
+}

--- a/packages/machine/test/integration/connect-ganache.ts
+++ b/packages/machine/test/integration/connect-ganache.ts
@@ -1,0 +1,19 @@
+import dotenv from "dotenv-safe";
+import { Wallet } from "ethers";
+import { JsonRpcProvider } from "ethers/providers";
+
+dotenv.config();
+
+// Can use ! because dotenv-safe ensures value is set
+const host = process.env.DEV_GANACHE_HOST!;
+const port = process.env.DEV_GANACHE_PORT!;
+const mnemonic = process.env.DEV_GANACHE_MNEMONIC!;
+
+export async function connectToGanache(): Promise<
+  [JsonRpcProvider, Wallet, number]
+> {
+  const provider = new JsonRpcProvider(`http://${host}:${port}`);
+  const wallet = Wallet.fromMnemonic(mnemonic).connect(provider);
+  const networkId = (await provider.getNetwork()).chainId;
+  return [provider, wallet, networkId];
+}

--- a/packages/machine/test/integration/install-then-set-state.spec.ts
+++ b/packages/machine/test/integration/install-then-set-state.spec.ts
@@ -22,6 +22,8 @@ import {
 import { InstallCommitment, SetStateCommitment } from "../../src/ethereum";
 import { AppInstance, StateChannel } from "../../src/models";
 
+import { toBeEq } from "./bignumber-jest-matcher";
+
 // To be honest, 30000 is an arbitrary large number that has never failed
 // to reach the done() call in the test case, not intelligency chosen
 const JEST_TEST_WAIT_TIME = 30000;
@@ -43,23 +45,7 @@ let provider: JsonRpcProvider;
 let wallet: Wallet;
 let network: NetworkContext;
 
-// TODO: When we add a second use case of this custom mathcer,
-//       move it and its typigns into somewhere re-usable
-declare global {
-  namespace jest {
-    interface Matchers<R> {
-      toBeEq(expected: BigNumber): BigNumber;
-    }
-  }
-}
-expect.extend({
-  toBeEq(received: BigNumber, argument: BigNumber) {
-    return {
-      pass: received.eq(argument),
-      message: () => `expected ${received} not to be equal to ${argument}`
-    };
-  }
-});
+expect.extend({ toBeEq });
 
 // TODO: This will be re-used for all integration tests, so
 //       move it somewhere re-usable when we add a new test

--- a/packages/machine/test/integration/install-then-set-state.spec.ts
+++ b/packages/machine/test/integration/install-then-set-state.spec.ts
@@ -19,7 +19,7 @@ import { connectToGanache } from "./connect-ganache";
 import { getSortedRandomSigningKeys } from "./random-signing-keys";
 
 // To be honest, 30000 is an arbitrary large number that has never failed
-// to reach the done() call in the test case, not intelligency chosen
+// to reach the done() call in the test case, not intelligently chosen
 const JEST_TEST_WAIT_TIME = 30000;
 
 // ProxyFactory.createProxy uses assembly `call` so we can't estimate

--- a/packages/machine/test/integration/install-then-set-state.spec.ts
+++ b/packages/machine/test/integration/install-then-set-state.spec.ts
@@ -102,7 +102,7 @@ describe("Scenario: install AppInstance, set state, put on-chain", () => {
       stateChannel = stateChannel.setState(freeBalanceETH.id, state);
       freeBalanceETH = stateChannel.getFreeBalanceFor(AssetType.ETH);
 
-      const app = new AppInstance(
+      const appInstance = new AppInstance(
         stateChannel.multisigAddress,
         stateChannel.multisigOwners,
         freeBalanceETH.defaultTimeout, // Re-use ETH FreeBalance timeout
@@ -119,15 +119,19 @@ describe("Scenario: install AppInstance, set state, put on-chain", () => {
         freeBalanceETH.timeout // Re-use ETH FreeBalance timeout
       );
 
-      stateChannel = stateChannel.installApp(app, WeiPerEther, WeiPerEther);
+      stateChannel = stateChannel.installApp(
+        appInstance,
+        WeiPerEther,
+        WeiPerEther
+      );
       freeBalanceETH = stateChannel.getFreeBalanceFor(AssetType.ETH);
 
       const setStateCommitment = new SetStateCommitment(
         network,
-        app.identity,
-        app.encodedLatestState,
-        app.nonce + 1,
-        app.timeout
+        appInstance.identity,
+        appInstance.encodedLatestState,
+        appInstance.nonce + 1,
+        appInstance.timeout
       );
 
       await wallet.sendTransaction({
@@ -138,7 +142,7 @@ describe("Scenario: install AppInstance, set state, put on-chain", () => {
         gasLimit: SETSTATE_COMMITMENT_GAS
       });
 
-      for (const _ of Array(app.timeout)) {
+      for (const _ of Array(appInstance.timeout)) {
         await provider.send("evm_mine", []);
       }
 
@@ -149,24 +153,24 @@ describe("Scenario: install AppInstance, set state, put on-chain", () => {
       );
 
       await appRegistry.functions.setResolution(
-        app.identity,
-        app.appInterface,
-        app.encodedLatestState,
-        app.encodedTerms
+        appInstance.identity,
+        appInstance.appInterface,
+        appInstance.encodedLatestState,
+        appInstance.encodedTerms
       );
 
       const installCommitment = new InstallCommitment(
         network,
         stateChannel.multisigAddress,
         stateChannel.multisigOwners,
-        app.identity,
-        app.terms,
+        appInstance.identity,
+        appInstance.terms,
         freeBalanceETH.identity,
         freeBalanceETH.terms,
         freeBalanceETH.hashOfLatestState,
         freeBalanceETH.nonce,
         freeBalanceETH.timeout,
-        app.appSeqNo
+        appInstance.appSeqNo
       );
 
       const installTx = installCommitment.transaction([

--- a/packages/machine/test/integration/install-then-set-state.spec.ts
+++ b/packages/machine/test/integration/install-then-set-state.spec.ts
@@ -72,13 +72,14 @@ beforeAll(async () => {
 });
 
 /**
- * This test suite tests setting up a channel and then installing a new app into it.
- * We re-use the ETHBucket App (which is the app ETH Free Balance uses) as the
- * test app being installed. We then set the values to [1, 1] in that app
+ * @summary Set up a StateChannel and then install a new AppInstance into it.
+ *
+ * @description We re-use the ETHBucket App (which is the app ETH Free Balance uses)
+ * as the test app being installed. We then set the values to [1, 1] in that app
  * and trigger the InstallCommitment on-chain to resolve that app and verify
  * the balances have been updated on-chain.
  */
-describe("Scenario: install app, set state, put on-chain", () => {
+describe("Scenario: install AppInstance, set state, put on-chain", () => {
   jest.setTimeout(JEST_TEST_WAIT_TIME);
 
   it("returns the funds the app had locked up", async done => {

--- a/packages/machine/test/integration/install-then-set-state.spec.ts
+++ b/packages/machine/test/integration/install-then-set-state.spec.ts
@@ -6,12 +6,10 @@ import NonceRegistry from "@counterfactual/contracts/build/contracts/NonceRegist
 import ProxyFactory from "@counterfactual/contracts/build/contracts/ProxyFactory.json";
 import StateChannelTransaction from "@counterfactual/contracts/build/contracts/StateChannelTransaction.json";
 import { AssetType, NetworkContext } from "@counterfactual/types";
-import dotenv from "dotenv-safe";
 import { Contract, Wallet } from "ethers";
 import { AddressZero, WeiPerEther, Zero } from "ethers/constants";
 import { JsonRpcProvider } from "ethers/providers";
 import {
-  BigNumber,
   hexlify,
   Interface,
   parseEther,
@@ -23,6 +21,7 @@ import { InstallCommitment, SetStateCommitment } from "../../src/ethereum";
 import { AppInstance, StateChannel } from "../../src/models";
 
 import { toBeEq } from "./bignumber-jest-matcher";
+import { connectToGanache } from "./connect-ganache";
 
 // To be honest, 30000 is an arbitrary large number that has never failed
 // to reach the done() call in the test case, not intelligency chosen
@@ -47,19 +46,8 @@ let network: NetworkContext;
 
 expect.extend({ toBeEq });
 
-// TODO: This will be re-used for all integration tests, so
-//       move it somewhere re-usable when we add a new test
 beforeAll(async () => {
-  dotenv.config();
-
-  // Can use ! because dotenv-safe ensures value is set
-  const host = process.env.DEV_GANACHE_HOST!;
-  const port = process.env.DEV_GANACHE_PORT!;
-  const mnemonic = process.env.DEV_GANACHE_MNEMONIC!;
-
-  provider = new JsonRpcProvider(`http://${host}:${port}`);
-  wallet = Wallet.fromMnemonic(mnemonic).connect(provider);
-  networkId = (await provider.getNetwork()).chainId;
+  [provider, wallet, networkId] = await connectToGanache();
 
   const relevantArtifacts = [
     AppRegistry,

--- a/packages/machine/test/integration/install-then-set-state.spec.ts
+++ b/packages/machine/test/integration/install-then-set-state.spec.ts
@@ -9,19 +9,14 @@ import { AssetType, NetworkContext } from "@counterfactual/types";
 import { Contract, Wallet } from "ethers";
 import { AddressZero, WeiPerEther, Zero } from "ethers/constants";
 import { JsonRpcProvider } from "ethers/providers";
-import {
-  hexlify,
-  Interface,
-  parseEther,
-  randomBytes,
-  SigningKey
-} from "ethers/utils";
+import { Interface, parseEther } from "ethers/utils";
 
 import { InstallCommitment, SetStateCommitment } from "../../src/ethereum";
 import { AppInstance, StateChannel } from "../../src/models";
 
 import { toBeEq } from "./bignumber-jest-matcher";
 import { connectToGanache } from "./connect-ganache";
+import { getSortedRandomSigningKeys } from "./random-signing-keys";
 
 // To be honest, 30000 is an arbitrary large number that has never failed
 // to reach the done() call in the test case, not intelligency chosen
@@ -83,12 +78,7 @@ describe("Scenario: install AppInstance, set state, put on-chain", () => {
   jest.setTimeout(JEST_TEST_WAIT_TIME);
 
   it("returns the funds the app had locked up", async done => {
-    const signingKeys = [
-      new SigningKey(hexlify(randomBytes(32))),
-      new SigningKey(hexlify(randomBytes(32)))
-    ].sort((a, b) =>
-      parseInt(a.address, 16) < parseInt(b.address, 16) ? -1 : 1
-    );
+    const signingKeys = getSortedRandomSigningKeys(2);
 
     const users = signingKeys.map(x => x.address);
 

--- a/packages/machine/test/integration/install-then-set-state.spec.ts
+++ b/packages/machine/test/integration/install-then-set-state.spec.ts
@@ -38,6 +38,7 @@ let networkId: number;
 let provider: JsonRpcProvider;
 let wallet: Wallet;
 let network: NetworkContext;
+let appRegistry: Contract;
 
 expect.extend({ toBeEq });
 
@@ -64,6 +65,12 @@ beforeAll(async () => {
       {}
     )
   } as NetworkContext;
+
+  appRegistry = new Contract(
+    AppRegistry.networks[networkId].address,
+    AppRegistry.abi,
+    wallet
+  );
 });
 
 /**
@@ -145,12 +152,6 @@ describe("Scenario: install AppInstance, set state, put on-chain", () => {
       for (const _ of Array(appInstance.timeout)) {
         await provider.send("evm_mine", []);
       }
-
-      const appRegistry = new Contract(
-        AppRegistry.networks[networkId].address,
-        AppRegistry.abi,
-        wallet
-      );
 
       await appRegistry.functions.setResolution(
         appInstance.identity,

--- a/packages/machine/test/integration/install-then-set-state.spec.ts
+++ b/packages/machine/test/integration/install-then-set-state.spec.ts
@@ -71,12 +71,8 @@ beforeAll(async () => {
   const port = process.env.DEV_GANACHE_PORT!;
   const mnemonic = process.env.DEV_GANACHE_MNEMONIC!;
 
-  function pathForAccount(idx: number) {
-    return `m/44'/60'/0'/0/${idx}`;
-  }
-
   provider = new JsonRpcProvider(`http://${host}:${port}`);
-  wallet = Wallet.fromMnemonic(mnemonic, pathForAccount(1)).connect(provider);
+  wallet = Wallet.fromMnemonic(mnemonic).connect(provider);
   networkId = (await provider.getNetwork()).chainId;
 
   const relevantArtifacts = [

--- a/packages/machine/test/integration/random-signing-keys.ts
+++ b/packages/machine/test/integration/random-signing-keys.ts
@@ -1,0 +1,10 @@
+import { hexlify, randomBytes, SigningKey } from "ethers/utils";
+
+export function getSortedRandomSigningKeys(length: number) {
+  return Array(length)
+    .fill(0)
+    .map(_ => new SigningKey(hexlify(randomBytes(32))))
+    .sort((a, b) =>
+      parseInt(a.address, 16) < parseInt(b.address, 16) ? -1 : 1
+    );
+}

--- a/packages/machine/test/integration/setup-then-set-state.spec.ts
+++ b/packages/machine/test/integration/setup-then-set-state.spec.ts
@@ -9,16 +9,12 @@ import dotenv from "dotenv-safe";
 import { Contract, Wallet } from "ethers";
 import { AddressZero, WeiPerEther, Zero } from "ethers/constants";
 import { JsonRpcProvider } from "ethers/providers";
-import {
-  BigNumber,
-  hexlify,
-  Interface,
-  randomBytes,
-  SigningKey
-} from "ethers/utils";
+import { hexlify, Interface, randomBytes, SigningKey } from "ethers/utils";
 
 import { SetStateCommitment, SetupCommitment } from "../../src/ethereum";
 import { StateChannel } from "../../src/models";
+
+import { toBeEq } from "./bignumber-jest-matcher";
 
 // To be honest, 30000 is an arbitrary large number that has never failed
 // to reach the done() call in the test case, not intelligency chosen
@@ -40,23 +36,7 @@ let provider: JsonRpcProvider;
 let wallet: Wallet;
 let network: NetworkContext;
 
-// TODO: When we add a second use case of this custom mathcer,
-//       move it and its typigns into somewhere re-usable
-declare global {
-  namespace jest {
-    interface Matchers<R> {
-      toBeEq(expected: BigNumber): BigNumber;
-    }
-  }
-}
-expect.extend({
-  toBeEq(received: BigNumber, argument: BigNumber) {
-    return {
-      pass: received.eq(argument),
-      message: () => `expected ${received} not to be equal to ${argument}`
-    };
-  }
-});
+expect.extend({ toBeEq });
 
 // TODO: This will be re-used for all integration tests, so
 //       move it somewhere re-usable when we add a new test

--- a/packages/machine/test/integration/setup-then-set-state.spec.ts
+++ b/packages/machine/test/integration/setup-then-set-state.spec.ts
@@ -18,7 +18,7 @@ import { connectToGanache } from "./connect-ganache";
 import { getSortedRandomSigningKeys } from "./random-signing-keys";
 
 // To be honest, 30000 is an arbitrary large number that has never failed
-// to reach the done() call in the test case, not intelligency chosen
+// to reach the done() call in the test case, not intelligently chosen
 const JEST_TEST_WAIT_TIME = 30000;
 
 // ProxyFactory.createProxy uses assembly `call` so we can't estimate

--- a/packages/machine/test/integration/setup-then-set-state.spec.ts
+++ b/packages/machine/test/integration/setup-then-set-state.spec.ts
@@ -64,14 +64,13 @@ beforeAll(async () => {
   } as NetworkContext;
 });
 
-describe("Commitment tests on ganache-cli", () => {
+/**
+ * @summary Setup a StateChannel then set state on ETH Free Balance
+ */
+describe("Scenario: Setup, set state on free balance, go on chain", () => {
   jest.setTimeout(JEST_TEST_WAIT_TIME);
 
-  /**
-   * This test suite tests submitting a generated Set State Commitment
-   * to the blockchain and observing the result
-   */
-  it("Scenario - open channel, update free balance, on-chain resolution", async done => {
+  it("should distribute funds in ETH free balance when put on chain", async done => {
     const signingKeys = [
       new SigningKey(hexlify(randomBytes(32))),
       new SigningKey(hexlify(randomBytes(32)))

--- a/packages/machine/test/integration/setup-then-set-state.spec.ts
+++ b/packages/machine/test/integration/setup-then-set-state.spec.ts
@@ -36,6 +36,7 @@ let networkId: number;
 let provider: JsonRpcProvider;
 let wallet: Wallet;
 let network: NetworkContext;
+let appRegistry: Contract;
 
 expect.extend({ toBeEq });
 
@@ -63,6 +64,12 @@ beforeAll(async () => {
       {}
     )
   } as NetworkContext;
+
+  appRegistry = new Contract(
+    AppRegistry.networks[networkId].address,
+    AppRegistry.abi,
+    wallet
+  );
 });
 
 /**
@@ -117,12 +124,6 @@ describe("Scenario: Setup, set state on free balance, go on chain", () => {
       for (const _ of Array(freeBalanceETH.timeout)) {
         await provider.send("evm_mine", []);
       }
-
-      const appRegistry = new Contract(
-        AppRegistry.networks[networkId].address,
-        AppRegistry.abi,
-        wallet
-      );
 
       await appRegistry.functions.setResolution(
         freeBalanceETH.identity,

--- a/packages/machine/test/integration/setup-then-set-state.spec.ts
+++ b/packages/machine/test/integration/setup-then-set-state.spec.ts
@@ -5,7 +5,6 @@ import NonceRegistry from "@counterfactual/contracts/build/contracts/NonceRegist
 import ProxyFactory from "@counterfactual/contracts/build/contracts/ProxyFactory.json";
 import StateChannelTransaction from "@counterfactual/contracts/build/contracts/StateChannelTransaction.json";
 import { AssetType, NetworkContext } from "@counterfactual/types";
-import dotenv from "dotenv-safe";
 import { Contract, Wallet } from "ethers";
 import { AddressZero, WeiPerEther, Zero } from "ethers/constants";
 import { JsonRpcProvider } from "ethers/providers";
@@ -15,6 +14,7 @@ import { SetStateCommitment, SetupCommitment } from "../../src/ethereum";
 import { StateChannel } from "../../src/models";
 
 import { toBeEq } from "./bignumber-jest-matcher";
+import { connectToGanache } from "./connect-ganache";
 
 // To be honest, 30000 is an arbitrary large number that has never failed
 // to reach the done() call in the test case, not intelligency chosen
@@ -41,16 +41,7 @@ expect.extend({ toBeEq });
 // TODO: This will be re-used for all integration tests, so
 //       move it somewhere re-usable when we add a new test
 beforeAll(async () => {
-  dotenv.config();
-
-  // Can use ! because dotenv-safe ensures value is set
-  const host = process.env.DEV_GANACHE_HOST!;
-  const port = process.env.DEV_GANACHE_PORT!;
-  const mnemonic = process.env.DEV_GANACHE_MNEMONIC!;
-
-  provider = new JsonRpcProvider(`http://${host}:${port}`);
-  wallet = Wallet.fromMnemonic(mnemonic).connect(provider);
-  networkId = (await provider.getNetwork()).chainId;
+  [provider, wallet, networkId] = await connectToGanache();
 
   const relevantArtifacts = [
     AppRegistry,

--- a/packages/machine/test/integration/setup-then-set-state.spec.ts
+++ b/packages/machine/test/integration/setup-then-set-state.spec.ts
@@ -8,13 +8,14 @@ import { AssetType, NetworkContext } from "@counterfactual/types";
 import { Contract, Wallet } from "ethers";
 import { AddressZero, WeiPerEther, Zero } from "ethers/constants";
 import { JsonRpcProvider } from "ethers/providers";
-import { hexlify, Interface, randomBytes, SigningKey } from "ethers/utils";
+import { Interface } from "ethers/utils";
 
 import { SetStateCommitment, SetupCommitment } from "../../src/ethereum";
 import { StateChannel } from "../../src/models";
 
 import { toBeEq } from "./bignumber-jest-matcher";
 import { connectToGanache } from "./connect-ganache";
+import { getSortedRandomSigningKeys } from "./random-signing-keys";
 
 // To be honest, 30000 is an arbitrary large number that has never failed
 // to reach the done() call in the test case, not intelligency chosen
@@ -71,12 +72,7 @@ describe("Scenario: Setup, set state on free balance, go on chain", () => {
   jest.setTimeout(JEST_TEST_WAIT_TIME);
 
   it("should distribute funds in ETH free balance when put on chain", async done => {
-    const signingKeys = [
-      new SigningKey(hexlify(randomBytes(32))),
-      new SigningKey(hexlify(randomBytes(32)))
-    ].sort((a, b) =>
-      parseInt(a.address, 16) < parseInt(b.address, 16) ? -1 : 1
-    );
+    const signingKeys = getSortedRandomSigningKeys(2);
 
     const users = signingKeys.map(x => x.address);
 


### PR DESCRIPTION
Unfortunately it breaks parallelism so I had to add `--runInBand` back. I tried listening to events to uniquely identify transactions being submitted to ensure the callback in the integration tests runs for the correct multisig, but it seems like not all events are returned from `ethers.Contract.prototype.on`'s event emitter.

Also this PR includes two fixes that needed to be there:
- https://github.com/counterfactual/monorepo/pull/381
- https://github.com/counterfactual/monorepo/pull/382