### PR TITLE
[contracts] kill ganache before starting tests

### DIFF
--- a/packages/contracts/scripts/test.sh
+++ b/packages/contracts/scripts/test.sh
@@ -8,7 +8,7 @@ function clean {
 
 trap clean INT TERM EXIT
 
-pkill -9 ganache-cli
+bash -c 'pkill -9 ganache-cli; exit 0'
 
 ganache-cli \
   --defaultBalanceEther 10000 \

--- a/packages/contracts/scripts/test.sh
+++ b/packages/contracts/scripts/test.sh
@@ -8,7 +8,11 @@ function clean {
 
 trap clean INT TERM EXIT
 
-bash -c 'lsof -ti :8545 | xargs kill -9; exit 0'
+if lsof -ti :8545
+then
+  echo "Detected a process (probably an existing ganache instance) listening on 8545. Exiting."
+  exit 1
+fi
 
 ganache-cli \
   --defaultBalanceEther 10000 \

--- a/packages/contracts/scripts/test.sh
+++ b/packages/contracts/scripts/test.sh
@@ -8,12 +8,13 @@ function clean {
 
 trap clean INT TERM EXIT
 
+ps aux | grep ganache-cli | grep -v grep | awk '{print $2}' | xargs kill -9
+
 ganache-cli \
   --defaultBalanceEther 10000 \
   --gasLimit 0xfffffffffff \
   --gasPrice 0x01 \
   --networkId 7777777 \
-  --quiet \
   &> /dev/null \
   &
 

--- a/packages/contracts/scripts/test.sh
+++ b/packages/contracts/scripts/test.sh
@@ -8,7 +8,7 @@ function clean {
 
 trap clean INT TERM EXIT
 
-ps aux | grep ganache-cli | grep -v grep | awk '{print $2}' | xargs kill -9
+pkill -9 ganache-cli
 
 ganache-cli \
   --defaultBalanceEther 10000 \

--- a/packages/contracts/scripts/test.sh
+++ b/packages/contracts/scripts/test.sh
@@ -8,7 +8,7 @@ function clean {
 
 trap clean INT TERM EXIT
 
-bash -c 'pkill -9 ganache-cli; exit 0'
+bash -c 'lsof -ti :8545 | xargs kill -9; exit 0'
 
 ganache-cli \
   --defaultBalanceEther 10000 \

--- a/packages/machine/scripts/test.sh
+++ b/packages/machine/scripts/test.sh
@@ -32,7 +32,11 @@ export DEV_GANACHE_MNEMONIC=$(
   "brain surround have swap horror body response double fire dumb bring hazard"
 )
 
-bash -c "lsof -ti :${DEV_GANACHE_PORT} | xargs kill -9; exit 0"
+if lsof -ti :${DEV_GANACHE_PORT}
+then
+  echo "Detected a process (probably an existing ganache instance) listening on ${DEV_GANACHE_PORT}. Exiting."
+  exit 1
+fi
 
 {
   long_console_info="⛓ Starting ganache-cli at "

--- a/packages/machine/scripts/test.sh
+++ b/packages/machine/scripts/test.sh
@@ -32,6 +32,8 @@ export DEV_GANACHE_MNEMONIC=$(
   "brain surround have swap horror body response double fire dumb bring hazard"
 )
 
+bash -c "lsof -ti :${DEV_GANACHE_PORT} | xargs kill -9; exit 0"
+
 {
   long_console_info="⛓ Starting ganache-cli at "
   long_console_info+="http://${DEV_GANACHE_HOST}:${DEV_GANACHE_PORT} "


### PR DESCRIPTION
Previously, if an existing ganache instance is running, `test.sh`'s invocation of ganache-cli would fail silently and the `kill` call would fail.

Why an existing instance might be running: user ran it in another tab, or (in my case) `ganache-cli` gets reparented to PID 1 for some reason.