### PR TITLE
Add noImplicitAny to tsconfigs that already comply

### DIFF
--- a/packages/apps/tsconfig.json
+++ b/packages/apps/tsconfig.json
@@ -1,4 +1,7 @@
 {
   "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "noImplicitAny": true
+  },
   "include": ["test"]
 }

--- a/packages/node-provider/rollup.config.js
+++ b/packages/node-provider/rollup.config.js
@@ -18,6 +18,7 @@ export default [
     ],
     plugins: [
       typescript()
-    ]
+    ],
+    exclude: ["test"]
   }
 ];

--- a/packages/node-provider/test/unit/node-provider.spec.ts
+++ b/packages/node-provider/test/unit/node-provider.spec.ts
@@ -2,6 +2,7 @@ import { Node } from "@counterfactual/types";
 
 import NodeProvider from "../../src/node-provider";
 import {
+  Context,
   createMockMessageChannel,
   mockAddEventListenerFunction,
   MockMessagePort,
@@ -17,7 +18,7 @@ const context = {
   connected: false,
   dappPort: new MockMessagePort(),
   nodeProviderPort: new MockMessagePort()
-};
+} as Context;
 
 describe("NodeProvider", () => {
   beforeAll(() => {

--- a/packages/node-provider/test/utils/message-api-mocks.ts
+++ b/packages/node-provider/test/utils/message-api-mocks.ts
@@ -1,4 +1,15 @@
-export function createMockMessageEvent(message, transferables) {
+export interface Context {
+  originalAddEventListener: typeof addEventListener;
+  messageCallbacks: any[];
+  connected: boolean;
+  dappPort: MockMessagePort;
+  nodeProviderPort: MockMessagePort;
+}
+
+export function createMockMessageEvent(
+  message: string,
+  transferables: MockMessagePort[]
+) {
   return {
     data: message,
     ports: transferables,
@@ -40,7 +51,7 @@ export class MockMessagePort {
     }
   }
 
-  postMessage(message, transferables) {
+  postMessage(message: string, transferables: MockMessagePort[]) {
     this.onMessageCallback.forEach(callback =>
       createMockMessageEvent(message, transferables)
     );
@@ -54,8 +65,10 @@ export function createMockMessagePort() {
   return new MockMessagePort();
 }
 
-export function mockAddEventListenerFunction(context) {
-  return (eventName, callback) => {
+export function mockAddEventListenerFunction(
+  context: Context
+): typeof window.addEventListener {
+  return (eventName: string, callback: EventListenerOrEventListenerObject) => {
     if (eventName !== "message") {
       context.originalAddEventListener(eventName, callback);
       return;
@@ -65,8 +78,12 @@ export function mockAddEventListenerFunction(context) {
   };
 }
 
-export function mockPostMessageFunction(context) {
-  return (message, target, transferables) => {
+export function mockPostMessageFunction(context: Context) {
+  return (
+    message: string,
+    target: string,
+    transferables: MockMessagePort[]
+  ) => {
     context.messageCallbacks.forEach(callback => {
       callback(createMockMessageEvent(message, transferables));
     });

--- a/packages/node-provider/tsconfig.json
+++ b/packages/node-provider/tsconfig.json
@@ -4,6 +4,6 @@
     "outDir": "dist/",
     "noImplicitAny": true
   },
-  "include": ["src"],
+  "include": ["src", "test"],
   "exclude": ["dist"]
 }

--- a/packages/node-provider/tsconfig.json
+++ b/packages/node-provider/tsconfig.json
@@ -1,7 +1,8 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
-    "outDir": "dist/"
+    "outDir": "dist/",
+    "noImplicitAny": true
   },
   "include": ["src"],
   "exclude": ["dist"]

--- a/yarn.lock
+++ b/yarn.lock
@@ -12306,10 +12306,10 @@ tslint-eslint-rules@^5.4.0:
     tslib "1.9.0"
     tsutils "^3.0.0"
 
-tslint-microsoft-contrib@~5.2.1:
-  version "5.2.1"
-  resolved "https://registry.yarnpkg.com/tslint-microsoft-contrib/-/tslint-microsoft-contrib-5.2.1.tgz#a6286839f800e2591d041ea2800c77487844ad81"
-  integrity sha512-PDYjvpo0gN9IfMULwKk0KpVOPMhU6cNoT9VwCOLeDl/QS8v8W2yspRpFFuUS7/c5EIH/n8ApMi8TxJAz1tfFUA==
+tslint-microsoft-contrib@^6.0.0, tslint-microsoft-contrib@~5.2.1:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/tslint-microsoft-contrib/-/tslint-microsoft-contrib-6.0.0.tgz#7bff73c9ad7a0b7eb5cdb04906de58f42a2bf7a2"
+  integrity sha512-R//efwn+34IUjTJeYgNDAJdzG0jyLWIehygPt/PHuZAieTolFVS56FgeFW7DOLap9ghXzMiFPTmDgm54qaL7QA==
   dependencies:
     tsutils "^2.27.2 <2.29.0"
 


### PR DESCRIPTION
Adds the rule `"noImplicitAny": true` to `tsconfig.json` files for packages whose source code already has no implicit `any`s.