### PR TITLE
[node] Fix rollup globals

### DIFF
--- a/packages/node/rollup.config.js
+++ b/packages/node/rollup.config.js
@@ -4,7 +4,11 @@ import pkg from "./package.json";
 
 const globals = {
   "@counterfactual/cf.js": "cfjs",
-  "eventemitter3": "EventEmitter"
+  "@counterfactual/types": "types",
+  "eventemitter3": "EventEmitter",
+  "ethers/constants": "ethers.constants",
+  "ethers/utils": "ethers.utils",
+  "ethers/wallet": "ethers.wallet",
 }
 
 export default [

--- a/packages/node/src/channels.ts
+++ b/packages/node/src/channels.ts
@@ -1,5 +1,5 @@
 import { Address, AppInstanceInfo, Node } from "@counterfactual/types";
-import { Wallet } from "ethers";
+import { Wallet } from "ethers/wallet";
 import { v4 as generateUUID } from "uuid";
 
 import { APP_INSTANCE_STATUS, Channel } from "./models";


### PR DESCRIPTION
### Description

Specific module references are causing breakages, such as 
```
node.js:492 Uncaught ReferenceError: utils is not defined
    at node.js:492
```

### Related issues

This fixes: https://github.com/counterfactual/monorepo/issues/401