### PR TITLE
[monorepo] Rename AppInstanceId to AppInstanceIdentityHash

### DIFF
--- a/packages/contracts/contracts/ETHVirtualAppAgreement.sol
+++ b/packages/contracts/contracts/ETHVirtualAppAgreement.sol
@@ -26,7 +26,7 @@ contract ETHVirtualAppAgreement {
     AppRegistry registry;
     Transfer.Terms terms;
     uint256 expiry;
-    bytes32 appInstanceId;
+    bytes32 appIdentityHash;
     uint256 capitalProvided;
     address[2] beneficiaries;
   }
@@ -38,7 +38,7 @@ contract ETHVirtualAppAgreement {
     );
 
     Transfer.Transaction memory resolution = agreement.registry
-      .getResolution(agreement.appInstanceId);
+      .getResolution(agreement.appIdentityHash);
 
     require(
       agreement.terms.assetType == resolution.assetType,

--- a/packages/contracts/contracts/StateChannelTransaction.sol
+++ b/packages/contracts/contracts/StateChannelTransaction.sol
@@ -25,8 +25,8 @@ contract StateChannelTransaction is LibCondition {
     AppRegistry appRegistry,
     NonceRegistry nonceRegistry,
     bytes32 uninstallKey,
-    bytes32 appIdentityHash,
     uint256 rootNonceExpectedValue,
+    bytes32 appIdentityHash,
     Transfer.Terms memory terms
   )
     public

--- a/packages/contracts/contracts/StateChannelTransaction.sol
+++ b/packages/contracts/contracts/StateChannelTransaction.sol
@@ -19,13 +19,13 @@ contract StateChannelTransaction is LibCondition {
 
   /// @notice Execute a fund transfer for a state channel app in a finalized state
   /// @param uninstallKey The key in the nonce registry
-  /// @param appInstanceId AppInstanceId to be resolved
+  /// @param appIdentityHash AppIdentityHash to be resolved
   /// @param terms The pre-agreed upon terms of the funds transfer
   function executeAppConditionalTransaction(
     AppRegistry appRegistry,
     NonceRegistry nonceRegistry,
     bytes32 uninstallKey,
-    bytes32 appInstanceId,
+    bytes32 appIdentityHash,
     uint256 rootNonceExpectedValue,
     Transfer.Terms memory terms
   )
@@ -46,11 +46,13 @@ contract StateChannelTransaction is LibCondition {
     );
 
     require(
-      appRegistry.isStateFinalized(appInstanceId),
+      appRegistry.isStateFinalized(appIdentityHash),
       "App is not finalized yet"
     );
 
-    Transfer.Transaction memory txn = appRegistry.getResolution(appInstanceId);
+    Transfer.Transaction memory txn = appRegistry.getResolution(
+      appIdentityHash
+    );
 
     require(
       Transfer.meetsTerms(txn, terms),

--- a/packages/contracts/contracts/libs/LibStateChannelApp.sol
+++ b/packages/contracts/contracts/libs/LibStateChannelApp.sol
@@ -44,11 +44,10 @@ contract LibStateChannelApp {
 
   // A minimal structure representing a state update that can be signed
   struct AppStateProof {
-    bytes32 id;
+    bytes32 identityHash;
     bytes32 appStateHash;
     uint256 nonce;
     uint256 timeout;
   }
-
 
 }

--- a/packages/contracts/contracts/mixins/MAppRegistryCore.sol
+++ b/packages/contracts/contracts/mixins/MAppRegistryCore.sol
@@ -23,7 +23,7 @@ contract MAppRegistryCore {
     bytes32 appInterfaceHash
   ) {
     // TODO: This is inefficient from a gas point of view since we could just include
-    // the hash of appInterface in the call to computeAppIdentityHash. Cleanup in the fututre.
+    // the hash of appInterface in the call to appIdentityToHash. Cleanup in the fututre.
     require(
       keccak256(abi.encode(appInterface)) == appInterfaceHash,
       "Call to AppRegistry included mismatched appInterface and appInterfaceHash"
@@ -45,7 +45,7 @@ contract MAppRegistryCore {
   /// @notice Compute a unique hash for a single instance of an App
   /// @param appIdentity An `AppIdentity` struct that encodes all unqiue info for an App
   /// @return A bytes32 hash of the AppIdentity
-  function computeAppIdentityHash(
+  function appIdentityToHash(
     LibStateChannelApp.AppIdentity memory appIdentity
   )
     internal
@@ -56,13 +56,13 @@ contract MAppRegistryCore {
   }
 
   /// @notice Compute a unique hash for a state of this state channel and application
-  /// @param id The unique hash of an `AppIdentity`
+  /// @param identityHash The unique hash of an `AppIdentity`
   /// @param appStateHash The hash of a state to be signed
   /// @param nonce The nonce corresponding to the version of the state
   /// @param timeout A dynamic timeout value representing the timeout for this state
   /// @return A bytes32 hash of the arguments encoded with the signing keys for the channel
   function computeStateHash(
-    bytes32 id,
+    bytes32 identityHash,
     bytes32 appStateHash,
     uint256 nonce,
     uint256 timeout
@@ -74,7 +74,7 @@ contract MAppRegistryCore {
     return keccak256(
       abi.encodePacked(
         byte(0x19),
-        id,
+        identityHash,
         nonce,
         timeout,
         appStateHash

--- a/packages/contracts/contracts/mixins/MAppRegistryCore.sol
+++ b/packages/contracts/contracts/mixins/MAppRegistryCore.sol
@@ -9,11 +9,11 @@ contract MAppRegistryCore {
 
   using Transfer for Transfer.Transaction;
 
-  // A mapping of AppInstanceIds to AppChallenge structs which represents
+  // A mapping of appIdentityHash to AppChallenge structs which represents
   // the current on-chain status of some particular applications state.
   mapping (bytes32 => LibStateChannelApp.AppChallenge) public appStates;
 
-  // A mapping of AppInstanceIds to Transaction structs which represents
+  // A mapping of appIdentityHash to Transaction structs which represents
   // the *final* resolution of a particular application
   mapping (bytes32 => Transfer.Transaction) public appResolutions;
 

--- a/packages/contracts/contracts/mixins/MixinAppRegistryCore.sol
+++ b/packages/contracts/contracts/mixins/MixinAppRegistryCore.sol
@@ -13,42 +13,42 @@ import "./MAppRegistryCore.sol";
 contract MixinAppRegistryCore is MAppRegistryCore {
 
   /// @notice A getter function for the current AppChallenge state
-  /// @param id The unique hash of an `AppIdentity`
+  /// @param identityHash The unique hash of an `AppIdentity`
   /// @return A `AppChallenge` object representing the state of the on-chain challenge
-  function getAppChallenge(bytes32 id)
+  function getAppChallenge(bytes32 identityHash)
     external
     view
     returns (LibStateChannelApp.AppChallenge memory)
   {
-    return appStates[id];
+    return appStates[identityHash];
   }
 
   /// @notice Checks whether or not some application's state is OFF or timed out
-  /// @param id The unique hash of an `AppIdentity`
+  /// @param identityHash The unique hash of an `AppIdentity`
   /// @return A boolean indicator
-  function isStateFinalized(bytes32 id)
+  function isStateFinalized(bytes32 identityHash)
     external
     view
     returns (bool)
   {
     return (
-      appStates[id].status == LibStateChannelApp.AppStatus.OFF ||
+      appStates[identityHash].status == LibStateChannelApp.AppStatus.OFF ||
       (
-        appStates[id].status == LibStateChannelApp.AppStatus.DISPUTE &&
-        appStates[id].finalizesAt <= block.number
+        appStates[identityHash].status == LibStateChannelApp.AppStatus.DISPUTE &&
+        appStates[identityHash].finalizesAt <= block.number
       )
     );
   }
 
   /// @notice A getter function for the resolution if one is set
-  /// @param id The unique hash of an `AppIdentity`
+  /// @param identityHash The unique hash of an `AppIdentity`
   /// @return A `Transfer.Transaction` object representing the resolution of the channel
-  function getResolution(bytes32 id)
+  function getResolution(bytes32 identityHash)
     external
     view
     returns (Transfer.Transaction memory)
   {
-    return appResolutions[id];
+    return appResolutions[identityHash];
   }
 
 }

--- a/packages/contracts/contracts/mixins/MixinCancelChallenge.sol
+++ b/packages/contracts/contracts/mixins/MixinCancelChallenge.sol
@@ -28,9 +28,9 @@ contract MixinCancelChallenge is
     // external
     public
   {
-    bytes32 id = computeAppIdentityHash(appIdentity);
+    bytes32 identityHash = appIdentityToHash(appIdentity);
 
-    AppChallenge storage challenge = appStates[id];
+    AppChallenge storage challenge = appStates[identityHash];
 
     require(
       challenge.status == AppStatus.DISPUTE && challenge.finalizesAt >= block.number,
@@ -38,7 +38,7 @@ contract MixinCancelChallenge is
     );
 
     bytes32 stateHash = computeStateHash(
-      id,
+      identityHash,
       challenge.appStateHash,
       challenge.nonce,
       appIdentity.defaultTimeout

--- a/packages/contracts/contracts/mixins/MixinSetResolution.sol
+++ b/packages/contracts/contracts/mixins/MixinSetResolution.sol
@@ -28,9 +28,9 @@ contract MixinSetResolution is
     doAppInterfaceCheck(appInterface, appIdentity.appInterfaceHash)
     doTermsCheck(terms, appIdentity.termsHash)
   {
-    bytes32 id = computeAppIdentityHash(appIdentity);
+    bytes32 identityHash = appIdentityToHash(appIdentity);
 
-    AppChallenge storage app = appStates[id];
+    AppChallenge storage app = appStates[identityHash];
 
     require(
       app.status == AppStatus.OFF ||
@@ -43,7 +43,11 @@ contract MixinSetResolution is
       "setResolution called with incorrect witness data of finalState"
     );
 
-    appResolutions[id] = MAppCaller.resolve(appInterface, finalState, terms);
+    appResolutions[identityHash] = MAppCaller.resolve(
+      appInterface,
+      finalState,
+      terms
+    );
   }
 
 }

--- a/packages/contracts/contracts/mixins/MixinSetState.sol
+++ b/packages/contracts/contracts/mixins/MixinSetState.sol
@@ -38,9 +38,9 @@ contract MixinSetState is
   )
     public
   {
-    bytes32 id = computeAppIdentityHash(appIdentity);
+    bytes32 identityHash = appIdentityToHash(appIdentity);
 
-    AppChallenge storage challenge = appStates[id];
+    AppChallenge storage challenge = appStates[identityHash];
 
     require(
       challenge.status == AppStatus.ON,
@@ -50,7 +50,7 @@ contract MixinSetState is
     if (msg.sender != appIdentity.owner) {
       require(
         correctKeysSignedTheStateUpdate(
-          id,
+          identityHash,
           appIdentity.signingKeys,
           req
         ),
@@ -73,7 +73,7 @@ contract MixinSetState is
   }
 
   function correctKeysSignedTheStateUpdate(
-    bytes32 id,
+    bytes32 identityHash,
     address[] memory signingKeys,
     SignedStateHashUpdate memory req
   )
@@ -82,7 +82,7 @@ contract MixinSetState is
     returns (bool)
   {
     bytes32 digest = computeStateHash(
-      id,
+      identityHash,
       req.stateHash,
       req.nonce,
       req.timeout

--- a/packages/contracts/contracts/mixins/MixinSetStateWithAction.sol
+++ b/packages/contracts/contracts/mixins/MixinSetStateWithAction.sol
@@ -45,12 +45,12 @@ contract MixinSetStateWithAction is
     public
     doAppInterfaceCheck(appInterface, appIdentity.appInterfaceHash)
   {
-    bytes32 id = computeAppIdentityHash(appIdentity);
+    bytes32 identityHash = appIdentityToHash(appIdentity);
 
-    AppChallenge storage challenge = appStates[id];
+    AppChallenge storage challenge = appStates[identityHash];
 
     require(
-      correctKeysSignedTheStateUpdate(id, appIdentity.signingKeys, req),
+      correctKeysSignedTheStateUpdate(identityHash, appIdentity.signingKeys, req),
       "Call to setStateWithAction included incorrectly signed state update"
     );
 
@@ -101,7 +101,7 @@ contract MixinSetStateWithAction is
   }
 
   function correctKeysSignedTheStateUpdate(
-    bytes32 id,
+    bytes32 identityHash,
     address[] memory signingKeys,
     SignedStateUpdate memory req
   )
@@ -110,7 +110,7 @@ contract MixinSetStateWithAction is
     returns (bool)
   {
     bytes32 digest = computeStateHash(
-      id,
+      identityHash,
       keccak256(req.encodedState),
       req.nonce,
       req.timeout

--- a/packages/contracts/test/app-registry-new.spec.ts
+++ b/packages/contracts/test/app-registry-new.spec.ts
@@ -69,7 +69,7 @@ contract("AppRegistry - Counterparty is Unresponsive", (accounts: string[]) => {
       disputeNonce,
       finalizesAt,
       nonce
-    } = await appRegistry.functions.appStates(appInstance.id);
+    } = await appRegistry.functions.appStates(appInstance.identityHash);
 
     expect(status).to.be.eq(1);
     expect(latestSubmitter).to.be.eq(await unlockedAccount.getAddress());

--- a/packages/contracts/test/app-registry.spec.ts
+++ b/packages/contracts/test/app-registry.spec.ts
@@ -66,14 +66,14 @@ contract("AppRegistry", (accounts: string[]) => {
     );
 
     latestState = async () =>
-      (await appRegistry.functions.getAppChallenge(appInstance.id))
+      (await appRegistry.functions.getAppChallenge(appInstance.identityHash))
         .appStateHash;
 
     latestNonce = async () =>
-      (await appRegistry.functions.getAppChallenge(appInstance.id)).nonce;
+      (await appRegistry.functions.getAppChallenge(appInstance.identityHash)).nonce;
 
     isStateFinalized = async () =>
-      await appRegistry.functions.isStateFinalized(appInstance.id);
+      await appRegistry.functions.isStateFinalized(appInstance.identityHash);
 
     setStateAsOwner = (nonce: number, appState?: string) =>
       appRegistry.functions.setState(appInstance.appIdentity, {
@@ -93,7 +93,7 @@ contract("AppRegistry", (accounts: string[]) => {
         timeout: ONCHAIN_CHALLENGE_TIMEOUT,
         signatures: await wallet.signMessage(
           computeStateHash(
-            appInstance.id,
+            appInstance.identityHash,
             appState || HashZero,
             nonce,
             ONCHAIN_CHALLENGE_TIMEOUT
@@ -108,7 +108,7 @@ contract("AppRegistry", (accounts: string[]) => {
         timeout: 0,
         signatures: await wallet.signMessage(
           computeStateHash(
-            appInstance.id,
+            appInstance.identityHash,
             await latestState(),
             await latestNonce(),
             0

--- a/packages/contracts/test/eth-virtual-app-agreement.spec.ts
+++ b/packages/contracts/test/eth-virtual-app-agreement.spec.ts
@@ -18,7 +18,7 @@ contract("ETHVirtualAppAgreement", (accounts: string[]) => {
   let appRegistry: Contract;
   let virtualAppAgreement: Contract;
   let fixedResolutionApp: Contract;
-  let appInstanceId: string;
+  let appIdentityHash: string;
 
   /// Deploys a new DelegateProxy instance, funds it, and delegatecalls to
   /// FixedResolutionApp with random beneficiaries
@@ -59,7 +59,7 @@ contract("ETHVirtualAppAgreement", (accounts: string[]) => {
           limit: 0,
           token: AddressZero
         },
-        appInstanceId: resolutionAddr
+        appIdentityHash: resolutionAddr
       }
     ]);
 
@@ -153,7 +153,7 @@ contract("ETHVirtualAppAgreement", (accounts: string[]) => {
       defaultTimeout: 10
     };
 
-    appInstanceId = keccak256(
+    appIdentityHash = keccak256(
       defaultAbiCoder.encode(
         [
           `tuple(
@@ -192,7 +192,7 @@ contract("ETHVirtualAppAgreement", (accounts: string[]) => {
       const beneficiaries = await delegatecallVirtualAppAgreement(
         virtualAppAgreement,
         appRegistry,
-        appInstanceId,
+        appIdentityHash,
         0,
         bigNumberify(10),
         0
@@ -223,7 +223,7 @@ contract("ETHVirtualAppAgreement", (accounts: string[]) => {
         delegatecallVirtualAppAgreement(
           virtualAppAgreement,
           appRegistry,
-          appInstanceId,
+          appIdentityHash,
           (await provider.getBlockNumber()) + 10,
           bigNumberify(10),
           0
@@ -237,7 +237,7 @@ contract("ETHVirtualAppAgreement", (accounts: string[]) => {
         delegatecallVirtualAppAgreement(
           virtualAppAgreement,
           appRegistry,
-          appInstanceId,
+          appIdentityHash,
           0,
           bigNumberify(2),
           0
@@ -251,7 +251,7 @@ contract("ETHVirtualAppAgreement", (accounts: string[]) => {
         delegatecallVirtualAppAgreement(
           virtualAppAgreement,
           appRegistry,
-          appInstanceId,
+          appIdentityHash,
           0,
           bigNumberify(10),
           1

--- a/packages/contracts/test/utils/index.ts
+++ b/packages/contracts/test/utils/index.ts
@@ -104,7 +104,7 @@ export const computeActionHash = (
   );
 
 export class AppInstance {
-  get id(): string {
+  get identityHash(): string {
     return this.hashOfEncoding();
   }
 

--- a/packages/machine/src/ethereum/install-commitment.ts
+++ b/packages/machine/src/ethereum/install-commitment.ts
@@ -51,7 +51,7 @@ export class InstallCommitment extends MultiSendCommitment {
       )
     );
 
-    const appInstanceId = appIdentityToHash(this.appIdentity);
+    const appIdentityHash = appIdentityToHash(this.appIdentity);
 
     return {
       to: this.networkContext.StateChannelTransaction,
@@ -60,8 +60,8 @@ export class InstallCommitment extends MultiSendCommitment {
         this.networkContext.AppRegistry,
         this.networkContext.NonceRegistry,
         uninstallKey,
-        appInstanceId,
         this.rootNonceValue,
+        appIdentityHash,
         this.terms
       ]),
       operation: MultisigOperation.DelegateCall

--- a/packages/machine/src/ethereum/setup-commitment.ts
+++ b/packages/machine/src/ethereum/setup-commitment.ts
@@ -34,10 +34,10 @@ export class SetupCommitment extends MultisigTransactionCommitment {
         this.networkContext.AppRegistry,
         this.networkContext.NonceRegistry,
         this.getUninstallKeyForNonceRegistry(),
-        appIdentityToHash(this.freeBalanceAppIdentity),
         // NOTE: We *assume* here that the root nonce value will be 0
         //       when creating the setup commitment
         0,
+        appIdentityToHash(this.freeBalanceAppIdentity),
         this.freeBalanceTerms
       ]),
       operation: MultisigOperation.DelegateCall

--- a/packages/machine/src/models/app-instance.ts
+++ b/packages/machine/src/models/app-instance.ts
@@ -106,7 +106,7 @@ export class AppInstance {
   }
 
   @Memoize()
-  public get id() {
+  public get identityHash() {
     return appIdentityToHash(this.identity);
   }
 

--- a/packages/machine/src/protocol-types-tbd.ts
+++ b/packages/machine/src/protocol-types-tbd.ts
@@ -34,7 +34,7 @@ export type ProtocolMessage = {
 export type SetupParams = {};
 
 export type UpdateData = {
-  appInstanceId: string;
+  appIdentityHash: string;
   newState: AppState;
 };
 
@@ -49,7 +49,7 @@ export type InstallParams = {
 };
 
 export type UninstallParams = {
-  appInstanceId: string;
+  appIdentityHash: string;
   aliceBalanceIncrement: BigNumber;
   bobBalanceIncrement: BigNumber;
 };

--- a/packages/machine/src/protocol/install.ts
+++ b/packages/machine/src/protocol/install.ts
@@ -110,9 +110,9 @@ function proposeStateTransition(
 export function constructInstallOp(
   network: NetworkContext,
   stateChannel: StateChannel,
-  appInstanceId: string
+  appIdentityHash: string
 ) {
-  const app = stateChannel.getAppInstance(appInstanceId);
+  const app = stateChannel.getAppInstance(appIdentityHash);
 
   const freeBalance = stateChannel.getFreeBalanceFor(AssetType.ETH);
 

--- a/packages/machine/src/protocol/install.ts
+++ b/packages/machine/src/protocol/install.ts
@@ -103,7 +103,7 @@ function proposeStateTransition(
   context.operation = constructInstallOp(
     context.network,
     context.stateChannel,
-    appInstance.id
+    appInstance.identityHash
   );
 }
 

--- a/packages/machine/src/protocol/uninstall.ts
+++ b/packages/machine/src/protocol/uninstall.ts
@@ -69,13 +69,13 @@ function proposeStateTransition(
   state: StateChannel
 ) {
   const {
-    appInstanceId,
+    appIdentityHash,
     aliceBalanceIncrement,
     bobBalanceIncrement
   } = message.params as UninstallParams;
 
   context.stateChannel = state.uninstallApp(
-    appInstanceId,
+    appIdentityHash,
     aliceBalanceIncrement,
     bobBalanceIncrement
   );
@@ -83,7 +83,7 @@ function proposeStateTransition(
   context.operation = constructUninstallOp(
     context.network,
     context.stateChannel,
-    appInstanceId
+    appIdentityHash
   );
 }
 

--- a/packages/machine/src/protocol/update.ts
+++ b/packages/machine/src/protocol/update.ts
@@ -64,21 +64,21 @@ function proposeStateTransition(
   context: Context,
   state: StateChannel
 ) {
-  const { appInstanceId, newState } = message.params as UpdateData;
-  context.stateChannel = state.setState(appInstanceId, newState);
+  const { appIdentityHash, newState } = message.params as UpdateData;
+  context.stateChannel = state.setState(appIdentityHash, newState);
   context.operation = constructUpdateOp(
     context.network,
     context.stateChannel,
-    appInstanceId
+    appIdentityHash
   );
 }
 
 export function constructUpdateOp(
   network: NetworkContext,
   stateChannel: StateChannel,
-  appInstanceId: string
+  appIdentityHash: string
 ) {
-  const app = stateChannel.getAppInstance(appInstanceId);
+  const app = stateChannel.getAppInstance(appIdentityHash);
 
   return new SetStateCommitment(
     network,

--- a/packages/machine/test/integration/install-then-set-state.spec.ts
+++ b/packages/machine/test/integration/install-then-set-state.spec.ts
@@ -107,7 +107,7 @@ describe("Scenario: install AppInstance, set state, put on-chain", () => {
         bobBalance: WeiPerEther
       };
 
-      stateChannel = stateChannel.setState(freeBalanceETH.id, state);
+      stateChannel = stateChannel.setState(freeBalanceETH.identityHash, state);
       freeBalanceETH = stateChannel.getFreeBalanceFor(AssetType.ETH);
 
       const appInstance = new AppInstance(

--- a/packages/machine/test/integration/setup-then-set-state.spec.ts
+++ b/packages/machine/test/integration/setup-then-set-state.spec.ts
@@ -101,7 +101,7 @@ describe("Scenario: Setup, set state on free balance, go on chain", () => {
         bobBalance: WeiPerEther
       };
 
-      stateChannel = stateChannel.setState(freeBalanceETH.id, state);
+      stateChannel = stateChannel.setState(freeBalanceETH.identityHash, state);
       freeBalanceETH = stateChannel.getFreeBalanceFor(AssetType.ETH);
 
       const setStateCommitment = new SetStateCommitment(

--- a/packages/machine/test/unit/ethereum/install-commitment.spec.ts
+++ b/packages/machine/test/unit/ethereum/install-commitment.spec.ts
@@ -52,7 +52,7 @@ describe("InstallCommitment", () => {
 
   // Set the state to some test values
   stateChannel = stateChannel.setState(
-    stateChannel.getFreeBalanceFor(AssetType.ETH).id,
+    stateChannel.getFreeBalanceFor(AssetType.ETH).identityHash,
     {
       alice: stateChannel.multisigOwners[0],
       bob: stateChannel.multisigOwners[1],
@@ -229,8 +229,8 @@ describe("InstallCommitment", () => {
             appRegistryAddress,
             nonceRegistryAddress,
             uninstallKey,
-            appIdentityHash,
             rootNonceValue,
+            appIdentityHash,
             terms
           ] = calldata.args;
           expect(appRegistryAddress).toBe(networkContext.AppRegistry);

--- a/packages/machine/test/unit/ethereum/install-commitment.spec.ts
+++ b/packages/machine/test/unit/ethereum/install-commitment.spec.ts
@@ -229,14 +229,14 @@ describe("InstallCommitment", () => {
             appRegistryAddress,
             nonceRegistryAddress,
             uninstallKey,
-            appInstanceId,
+            appIdentityHash,
             rootNonceValue,
             terms
           ] = calldata.args;
           expect(appRegistryAddress).toBe(networkContext.AppRegistry);
           expect(nonceRegistryAddress).toBe(networkContext.NonceRegistry);
           expect(uninstallKey).toBe(appInstance.uninstallKey);
-          expect(appInstanceId).toBe(appIdentityToHash(appInstance.identity));
+          expect(appIdentityHash).toBe(appIdentityToHash(appInstance.identity));
           expect(rootNonceValue).toEqual(
             bigNumberify(appInstance.rootNonceValue)
           );

--- a/packages/machine/test/unit/ethereum/setup-commitment.spec.ts
+++ b/packages/machine/test/unit/ethereum/setup-commitment.spec.ts
@@ -90,17 +90,17 @@ describe("SetupCommitment", () => {
         appRegistry,
         nonceRegistry,
         uninstallKey,
-        appInstanceId,
         rootNonceValue,
+        appIdentityHash,
         [assetType, limit, token]
       ] = desc.args;
       expect(appRegistry).toBe(networkContext.AppRegistry);
       expect(nonceRegistry).toEqual(networkContext.NonceRegistry);
       expect(uninstallKey).toBe(freeBalanceETH.uninstallKey);
-      expect(appInstanceId).toBe(appIdentityToHash(freeBalanceETH.identity));
       expect(rootNonceValue).toEqual(
         bigNumberify(freeBalanceETH.rootNonceValue)
       );
+      expect(appIdentityHash).toBe(appIdentityToHash(freeBalanceETH.identity));
       expect(assetType).toBe(freeBalanceETH.terms.assetType);
       expect(limit).toEqual(freeBalanceETH.terms.limit);
       expect(token).toBe(freeBalanceETH.terms.token);

--- a/packages/machine/test/unit/ethereum/uninstall-commitment.spec.ts
+++ b/packages/machine/test/unit/ethereum/uninstall-commitment.spec.ts
@@ -57,7 +57,7 @@ describe("Uninstall Commitment", () => {
 
   // Set the state to some test values
   stateChannel = stateChannel.setState(
-    stateChannel.getFreeBalanceFor(AssetType.ETH).id,
+    stateChannel.getFreeBalanceFor(AssetType.ETH).identityHash,
     {
       alice: stateChannel.multisigOwners[0],
       bob: stateChannel.multisigOwners[1],

--- a/packages/machine/test/unit/models/state-channel/install.spec.ts
+++ b/packages/machine/test/unit/models/state-channel/install.spec.ts
@@ -17,7 +17,7 @@ describe("StateChannel::uninstallApp", () => {
   let sc1: StateChannel;
   let sc2: StateChannel;
 
-  let appInstanceId: string;
+  let appIdentityHash: string;
 
   beforeAll(() => {
     const multisigAddress = getAddress(hexlify(randomBytes(20)));
@@ -59,7 +59,7 @@ describe("StateChannel::uninstallApp", () => {
       Math.ceil(1000 * Math.random())
     );
 
-    appInstanceId = appInstance.id;
+    appIdentityHash = appInstance.id;
 
     // Give 1 ETH to Alice and to Bob so they can spend it on the new app
     const fb = sc1.getFreeBalanceFor(AssetType.ETH);
@@ -83,7 +83,7 @@ describe("StateChannel::uninstallApp", () => {
   });
 
   it("should have added something at the id of thew new app", () => {
-    expect(sc2.getAppInstance(appInstanceId)).not.toBe(undefined);
+    expect(sc2.getAppInstance(appIdentityHash)).not.toBe(undefined);
   });
 
   describe("the updated ETH Free Balance", () => {
@@ -104,7 +104,7 @@ describe("StateChannel::uninstallApp", () => {
     let app: AppInstance;
 
     beforeAll(() => {
-      app = sc2.getAppInstance(appInstanceId)!;
+      app = sc2.getAppInstance(appIdentityHash)!;
     });
 
     it("should not be a virtual app", () => {

--- a/packages/machine/test/unit/models/state-channel/install.spec.ts
+++ b/packages/machine/test/unit/models/state-channel/install.spec.ts
@@ -59,12 +59,12 @@ describe("StateChannel::uninstallApp", () => {
       Math.ceil(1000 * Math.random())
     );
 
-    appIdentityHash = appInstance.id;
+    appIdentityHash = appInstance.identityHash;
 
     // Give 1 ETH to Alice and to Bob so they can spend it on the new app
     const fb = sc1.getFreeBalanceFor(AssetType.ETH);
 
-    sc1 = sc1.setState(fb.id, {
+    sc1 = sc1.setState(fb.identityHash, {
       ...fb.state,
       aliceBalance: WeiPerEther,
       bobBalance: WeiPerEther

--- a/packages/machine/test/unit/models/state-channel/set-state.spec.ts
+++ b/packages/machine/test/unit/models/state-channel/set-state.spec.ts
@@ -58,7 +58,7 @@ describe("StateChannel::setState", () => {
       .setupChannel(networkContext)
       .installApp(testApp, Zero, Zero);
 
-    sc2 = sc1.setState(testApp.id, { foo: AddressZero, bar: 1337 });
+    sc2 = sc1.setState(testApp.identityHash, { foo: AddressZero, bar: 1337 });
   });
 
   it("should not alter any of the base properties", () => {
@@ -74,7 +74,7 @@ describe("StateChannel::setState", () => {
     let app: AppInstance;
 
     beforeAll(() => {
-      app = sc2.getAppInstance(testApp.id)!;
+      app = sc2.getAppInstance(testApp.identityHash)!;
     });
 
     it("should have the new state", () => {

--- a/packages/machine/test/unit/models/state-channel/uninstall-app.spec.ts
+++ b/packages/machine/test/unit/models/state-channel/uninstall-app.spec.ts
@@ -58,7 +58,7 @@ describe("StateChannel::uninstallApp", () => {
       .setupChannel(networkContext)
       .installApp(testApp, Zero, Zero);
 
-    sc2 = sc1.uninstallApp(testApp.id, Zero, Zero);
+    sc2 = sc1.uninstallApp(testApp.identityHash, Zero, Zero);
   });
 
   it("should not alter any of the base properties", () => {
@@ -71,7 +71,7 @@ describe("StateChannel::uninstallApp", () => {
   });
 
   it("should have deleted the app being uninstalled", () => {
-    expect(sc2.isAppInstanceInstalled(testApp.id)).toBe(false);
+    expect(sc2.isAppInstanceInstalled(testApp.identityHash)).toBe(false);
   });
 
   describe("the updated ETH Free Balance", () => {

--- a/packages/node/src/models.ts
+++ b/packages/node/src/models.ts
@@ -48,7 +48,7 @@ class FreeBalance {
  *  multisigAddress: Address,
  *  multisigOwners: Address[],
  *  rootNonce: Nonce,
- *  appInstances: Map<AppInstanceID,
+ *  appInstances: Map<AppInstanceIdentityHash>,
  *    appInstance: {
  *      id: string,
  *      appId: Address,


### PR DESCRIPTION
Due to historical reasons, the word `AppInstanceId` in the monorepo refers to two separate things:

- something generated by cf.js via a call to `uuid.v4()` which looks like `9956b015-46b2-4e05-8528-54071bbcfa38`
- the `keccak256` hash of an `AppIdentity` struct, which looks like `c5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470`

(notice that they do not even encode the same number of bits)

This PR changes  occurrences of `AppInstanceId` referring to the latter to `AppIdentityHash`