### PR TITLE
[playground] Integrates Metamask account

### DIFF
--- a/packages/playground/src/components/account/account-register/account-register.tsx
+++ b/packages/playground/src/components/account/account-register/account-register.tsx
@@ -2,6 +2,7 @@ import { Component, Element, Prop } from "@stencil/core";
 import { RouterHistory } from "@stencil/router";
 
 import AccountTunnel from "../../../data/account";
+import NetworkTunnel from "../../../data/network";
 import { UserChangeset } from "../../../types";
 
 @Component({
@@ -11,6 +12,7 @@ import { UserChangeset } from "../../../types";
 })
 export class AccountRegister {
   @Element() el!: HTMLStencilElement;
+  @Prop() connected: boolean = false;
   @Prop() address: string = "";
   @Prop() email: string = "";
   @Prop() username: string = "";
@@ -20,7 +22,7 @@ export class AccountRegister {
   changeset: UserChangeset = {
     username: "",
     email: "",
-    address: ""
+    address: this.address
   };
 
   login() {
@@ -38,6 +40,10 @@ export class AccountRegister {
   }
 
   render() {
+    if (this.address) {
+      this.changeset.address = this.address;
+    }
+
     return (
       <widget-screen>
         <div slot="header">Create a Playground account</div>
@@ -56,7 +62,10 @@ export class AccountRegister {
           <form-input
             label="Ethereum address"
             value={this.changeset.address}
-            onChange={e => this.change("address", e)}
+            disabled={this.connected}
+            onChange={
+              !this.connected ? e => this.change("address", e) : () => {}
+            }
           />
           <form-button onButtonPressed={e => this.formSubmitionHandler()}>
             Create account
@@ -77,3 +86,5 @@ AccountTunnel.injectProps(AccountRegister, [
   "updateAccount",
   "username"
 ]);
+
+NetworkTunnel.injectProps(AccountRegister, ["connected"]);

--- a/packages/playground/src/components/app-root/app-root.tsx
+++ b/packages/playground/src/components/app-root/app-root.tsx
@@ -3,8 +3,8 @@ import { Component, State } from "@stencil/core";
 // Needed due to https://github.com/ionic-team/stencil-router/issues/62
 import { MatchResults } from "@stencil/router";
 
-import AccountTunnel, { State as AccountState } from "../../data/account";
-import NetworkTunnel, { State as NetworkState } from "../../data/network";
+import AccountTunnel, { AccountState } from "../../data/account";
+import NetworkTunnel, { NetworkState } from "../../data/network";
 
 @Component({
   tag: "app-root",
@@ -17,18 +17,21 @@ export class AppRoot {
     network: "Lorem"
   };
 
-  updateAccount(newProps) {
-    this.accountState = Object.assign({}, this.accountState, newProps);
+  async updateAccount(newProps: AccountState) {
+    this.accountState = { ...this.accountState, ...newProps };
+  }
+
+  async updateNetwork(newProps: NetworkState) {
+    this.networkState = { ...this.networkState, ...newProps };
   }
 
   render() {
-    const accountState = this.accountState;
-
-    accountState.updateAccount = this.updateAccount.bind(this);
+    this.accountState.updateAccount = this.updateAccount.bind(this);
+    this.networkState.updateNetwork = this.updateNetwork.bind(this);
 
     return (
       <NetworkTunnel.Provider state={this.networkState}>
-        <AccountTunnel.Provider state={accountState}>
+        <AccountTunnel.Provider state={this.accountState}>
           <div class="app-root wrapper">
             <main class="wrapper__content">
               <stencil-router>
@@ -47,6 +50,10 @@ export class AppRoot {
             </main>
             <layout-footer />
             <node-listener />
+            <web3-connector
+              accountState={this.accountState}
+              networkState={this.networkState}
+            />
           </div>
         </AccountTunnel.Provider>
       </NetworkTunnel.Provider>

--- a/packages/playground/src/components/web3-connector/web3-connector.tsx
+++ b/packages/playground/src/components/web3-connector/web3-connector.tsx
@@ -1,0 +1,43 @@
+import { Component, Prop } from "@stencil/core";
+
+import { AccountState } from "../../data/account";
+import { NetworkState } from "../../data/network";
+
+declare var web3: {
+  currentProvider: {
+    enable: () => Promise<void>;
+    selectedAddress: string;
+  };
+  version: {
+    network: string;
+  };
+};
+
+@Component({
+  tag: "web3-connector",
+  shadow: true
+})
+export class Web3Connector {
+  @Prop() accountState: AccountState = {};
+  @Prop() networkState: NetworkState = {};
+
+  async componentDidLoad() {
+    try {
+      await web3.currentProvider.enable();
+    } catch {}
+
+    if (web3.currentProvider) {
+      this.accountState.updateAccount!({
+        address: web3.currentProvider.selectedAddress
+      });
+      this.networkState.updateNetwork!({
+        network: web3.version.network,
+        connected: true
+      });
+    } else {
+      this.networkState.updateNetwork!({
+        connected: false
+      });
+    }
+  }
+}

--- a/packages/playground/src/components/widgets/widget-connection/widget-connection.tsx
+++ b/packages/playground/src/components/widgets/widget-connection/widget-connection.tsx
@@ -4,9 +4,9 @@ import NetworkTunnel from "../../../data/network";
 
 const NETWORK_NAMES = {
   "1": "Ethereum (Mainnet)",
-  "3": "Ropsten (Private)",
+  "3": "Ropsten (Testnet)",
   "42": "Kovan (Testnet)",
-  "4": "Rinkeby (Private)"
+  "4": "Rinkeby (Testnet)"
 };
 @Component({
   tag: "widget-connection",

--- a/packages/playground/src/components/widgets/widget-connection/widget-connection.tsx
+++ b/packages/playground/src/components/widgets/widget-connection/widget-connection.tsx
@@ -2,6 +2,12 @@ import { Component, Element, Prop } from "@stencil/core";
 
 import NetworkTunnel from "../../../data/network";
 
+const NETWORK_NAMES = {
+  "1": "Ethereum (Mainnet)",
+  "3": "Ropsten (Private)",
+  "42": "Kovan (Testnet)",
+  "4": "Rinkeby (Private)"
+};
 @Component({
   tag: "widget-connection",
   styleUrl: "widget-connection.scss",
@@ -16,7 +22,9 @@ export class WidgetConnection {
       <div class="connection">
         <span class={this.network ? "dot connected" : "dot"} />
         <span class="status">
-          {this.network ? `Connected to ${this.network}` : "No Connection"}
+          {this.network
+            ? `Connected to ${NETWORK_NAMES[this.network]}`
+            : "No Connection"}
         </span>
       </div>
     );

--- a/packages/playground/src/data/account.tsx
+++ b/packages/playground/src/data/account.tsx
@@ -1,13 +1,13 @@
 import { createProviderConsumer } from "@stencil/state-tunnel";
 
-export interface State {
+export interface AccountState {
   balance?: number;
   username?: string;
   email?: string;
   address?: string;
-  updateAccount?: (e) => void;
+  updateAccount?(data: AccountState): Promise<void>;
 }
 
-export default createProviderConsumer<State>({}, (subscribe, child) => (
+export default createProviderConsumer<AccountState>({}, (subscribe, child) => (
   <context-consumer subscribe={subscribe} renderer={child} />
 ));

--- a/packages/playground/src/data/network.tsx
+++ b/packages/playground/src/data/network.tsx
@@ -1,9 +1,14 @@
 import { createProviderConsumer } from "@stencil/state-tunnel";
 
-export interface State {
+export interface NetworkState {
   network?: string;
+  connected?: boolean;
+  updateNetwork?(data: NetworkState): Promise<void>;
 }
 
-export default createProviderConsumer<State>({}, (subscribe, child) => (
-  <context-consumer subscribe={subscribe} renderer={child} />
-));
+export default createProviderConsumer<NetworkState>(
+  { network: "Unknown network" },
+  (subscribe, child) => (
+    <context-consumer subscribe={subscribe} renderer={child} />
+  )
+);

--- a/packages/playground/src/index.html
+++ b/packages/playground/src/index.html
@@ -31,6 +31,8 @@
 
     <script>
       EventEmitter = EventEmitter3.EventEmitter;
+      utils = ethers.utils;
+      constants = ethers.constants;
     </script>
 
     <script src="/assets/cf.js"></script>

--- a/yarn.lock
+++ b/yarn.lock
@@ -12306,10 +12306,10 @@ tslint-eslint-rules@^5.4.0:
     tslib "1.9.0"
     tsutils "^3.0.0"
 
-tslint-microsoft-contrib@~5.2.1:
-  version "5.2.1"
-  resolved "https://registry.yarnpkg.com/tslint-microsoft-contrib/-/tslint-microsoft-contrib-5.2.1.tgz#a6286839f800e2591d041ea2800c77487844ad81"
-  integrity sha512-PDYjvpo0gN9IfMULwKk0KpVOPMhU6cNoT9VwCOLeDl/QS8v8W2yspRpFFuUS7/c5EIH/n8ApMi8TxJAz1tfFUA==
+tslint-microsoft-contrib@^6.0.0, tslint-microsoft-contrib@~5.2.1:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/tslint-microsoft-contrib/-/tslint-microsoft-contrib-6.0.0.tgz#7bff73c9ad7a0b7eb5cdb04906de58f42a2bf7a2"
+  integrity sha512-R//efwn+34IUjTJeYgNDAJdzG0jyLWIehygPt/PHuZAieTolFVS56FgeFW7DOLap9ghXzMiFPTmDgm54qaL7QA==
   dependencies:
     tsutils "^2.27.2 <2.29.0"
 


### PR DESCRIPTION
This PR will expose the following functionality to the Playground:

- [x] Request Metamask permission to connect from the Playground (`web3.currentProvider.enable()`).
- [x] Detect the current Ethereum network being used
- [x] Store the current Ethereum address
- [x] Show the address in the Account Register form 

![image](https://user-images.githubusercontent.com/118913/50567399-3a060400-0d23-11e9-8385-c76dcb33b34e.png)
