### PR TITLE
Implement root nonce functonality in codebase

### DIFF
--- a/packages/contracts/contracts/StateChannelTransaction.sol
+++ b/packages/contracts/contracts/StateChannelTransaction.sol
@@ -26,10 +26,19 @@ contract StateChannelTransaction is LibCondition {
     NonceRegistry nonceRegistry,
     bytes32 uninstallKey,
     bytes32 appInstanceId,
+    uint256 rootNonceExpectedValue,
     Transfer.Terms terms
   )
     public
   {
+    require(
+      nonceRegistry.isFinalized(
+        keccak256(address(this)),
+        rootNonceExpectedValue
+      ),
+      "Root nonce not finalized or finalized at an incorrect value"
+    );
+
     require(
       !nonceRegistry.isFinalized(uninstallKey, 1),
       "App has been uninstalled"

--- a/packages/machine/src/ethereum/install-commitment.ts
+++ b/packages/machine/src/ethereum/install-commitment.ts
@@ -22,7 +22,8 @@ export class InstallCommitment extends MultiSendCommitment {
     public readonly freeBalanceStateHash: string,
     public readonly freeBalanceNonce: number,
     public readonly freeBalanceTimeout: number,
-    public readonly dependencyNonce: number
+    public readonly dependencyNonce: number,
+    public readonly rootNonceValue: number
   ) {
     super(
       networkContext,
@@ -60,6 +61,7 @@ export class InstallCommitment extends MultiSendCommitment {
         this.networkContext.NonceRegistry,
         uninstallKey,
         appInstanceId,
+        this.rootNonceValue,
         this.terms
       ]),
       operation: MultisigOperation.DelegateCall

--- a/packages/machine/src/ethereum/setup-commitment.ts
+++ b/packages/machine/src/ethereum/setup-commitment.ts
@@ -35,6 +35,9 @@ export class SetupCommitment extends MultisigTransactionCommitment {
         this.networkContext.NonceRegistry,
         this.getUninstallKeyForNonceRegistry(),
         appIdentityToHash(this.freeBalanceAppIdentity),
+        // NOTE: We *assume* here that the root nonce value will be 0
+        //       when creating the setup commitment
+        0,
         this.freeBalanceTerms
       ]),
       operation: MultisigOperation.DelegateCall

--- a/packages/machine/src/models/app-instance.ts
+++ b/packages/machine/src/models/app-instance.ts
@@ -21,6 +21,7 @@ export type AppInstanceJson = {
   terms: Terms;
   isVirtualApp: boolean;
   appSeqNo: number;
+  rootNonceValue: number;
   latestState: object;
   latestNonce: number;
   latestTimeout: number;
@@ -65,6 +66,7 @@ export class AppInstance {
     terms: Terms,
     isVirtualApp: boolean,
     appSeqNo: number,
+    rootNonceValue: number,
     latestState: object,
     latestNonce: number,
     latestTimeout: number
@@ -77,6 +79,7 @@ export class AppInstance {
       terms,
       isVirtualApp,
       appSeqNo,
+      rootNonceValue,
       latestState,
       latestNonce,
       latestTimeout,
@@ -93,6 +96,7 @@ export class AppInstance {
       json.terms,
       json.isVirtualApp,
       json.appSeqNo,
+      json.rootNonceValue,
       json.latestState,
       json.latestNonce,
       json.latestTimeout
@@ -207,6 +211,10 @@ export class AppInstance {
 
   public get isVirtualApp() {
     return this.json.isVirtualApp;
+  }
+
+  public get rootNonceValue() {
+    return this.json.rootNonceValue;
   }
 
   public setState(

--- a/packages/machine/src/models/state-channel.ts
+++ b/packages/machine/src/models/state-channel.ts
@@ -18,7 +18,9 @@ import { AppInstance } from "./app-instance";
 const HARD_CODED_ASSUMPTIONS = {
   freeBalanceDefaultTimeout: 10,
   freeBalanceInitialStateTimeout: 10,
-  appSequenceNumberForFreeBalance: 0
+  appSequenceNumberForFreeBalance: 0,
+  // We assume the Free Balance is installed when the Root Nonce value is 0
+  rootNonceValueAtFreeBalanceInstall: 0
 };
 
 const ERRORS = {
@@ -51,6 +53,7 @@ function createETHFreeBalance(
     freeBalanceTerms,
     false,
     HARD_CODED_ASSUMPTIONS.appSequenceNumberForFreeBalance,
+    HARD_CODED_ASSUMPTIONS.rootNonceValueAtFreeBalanceInstall,
     {
       alice: signingKeyForFreeBalanceForPerson1,
       bob: signingKeyForFreeBalanceForPerson2,
@@ -74,7 +77,8 @@ export class StateChannel {
       AssetType,
       string
     > = new Map<AssetType, string>([]),
-    private readonly monotonicNumInstalledApps: number = 0
+    private readonly monotonicNumInstalledApps: number = 0,
+    public readonly rootNonceValue: number = 0
   ) {}
 
   public get numInstalledApps() {

--- a/packages/machine/src/protocol/install.ts
+++ b/packages/machine/src/protocol/install.ts
@@ -87,6 +87,7 @@ function proposeStateTransition(
     //       the computed value here and is ALSO still the number compute
     //       inside the installApp function below
     state.numInstalledApps + 1,
+    state.rootNonceValue,
     initialState,
     // KEY: Set the nonce to be 0
     0,
@@ -126,6 +127,7 @@ export function constructInstallOp(
     freeBalance.hashOfLatestState,
     freeBalance.nonce,
     freeBalance.timeout,
-    freeBalance.appSeqNo
+    freeBalance.appSeqNo,
+    freeBalance.rootNonceValue
   );
 }

--- a/packages/machine/test/integration/install-then-set-state.spec.ts
+++ b/packages/machine/test/integration/install-then-set-state.spec.ts
@@ -122,6 +122,7 @@ describe("Scenario: install AppInstance, set state, put on-chain", () => {
         },
         false,
         stateChannel.numInstalledApps + 1,
+        stateChannel.rootNonceValue,
         state,
         0,
         freeBalanceETH.timeout // Re-use ETH FreeBalance timeout
@@ -172,7 +173,8 @@ describe("Scenario: install AppInstance, set state, put on-chain", () => {
         freeBalanceETH.hashOfLatestState,
         freeBalanceETH.nonce,
         freeBalanceETH.timeout,
-        appInstance.appSeqNo
+        appInstance.appSeqNo,
+        stateChannel.rootNonceValue
       );
 
       const installTx = installCommitment.transaction([

--- a/packages/machine/test/unit/ethereum/install-commitment.spec.ts
+++ b/packages/machine/test/unit/ethereum/install-commitment.spec.ts
@@ -86,6 +86,7 @@ describe("InstallCommitment", () => {
     },
     false,
     stateChannel.numInstalledApps + 1,
+    0,
     { foo: AddressZero, bar: 0 },
     0,
     Math.ceil(1000 * Math.random())
@@ -103,7 +104,8 @@ describe("InstallCommitment", () => {
       freeBalanceETH.hashOfLatestState,
       freeBalanceETH.nonce,
       freeBalanceETH.timeout,
-      stateChannel.numInstalledApps + 1
+      stateChannel.numInstalledApps + 1,
+      stateChannel.rootNonceValue
     ).getTransactionDetails();
   });
 
@@ -228,12 +230,16 @@ describe("InstallCommitment", () => {
             nonceRegistryAddress,
             uninstallKey,
             appInstanceId,
+            rootNonceValue,
             terms
           ] = calldata.args;
           expect(appRegistryAddress).toBe(networkContext.AppRegistry);
           expect(nonceRegistryAddress).toBe(networkContext.NonceRegistry);
           expect(uninstallKey).toBe(appInstance.uninstallKey);
           expect(appInstanceId).toBe(appIdentityToHash(appInstance.identity));
+          expect(rootNonceValue).toEqual(
+            bigNumberify(appInstance.rootNonceValue)
+          );
           expect(terms[0]).toBe(appInstance.terms.assetType);
           expect(terms[1]).toEqual(appInstance.terms.limit);
           expect(terms[2]).toBe(appInstance.terms.token);

--- a/packages/machine/test/unit/ethereum/set-state-commitment.spec.ts
+++ b/packages/machine/test/unit/ethereum/set-state-commitment.spec.ts
@@ -59,6 +59,7 @@ describe("Set State Commitment", () => {
     },
     false,
     Math.ceil(1000 * Math.random()),
+    0,
     { foo: AddressZero, bar: 0 },
     0,
     Math.ceil(1000 * Math.random())

--- a/packages/machine/test/unit/ethereum/setup-commitment.spec.ts
+++ b/packages/machine/test/unit/ethereum/setup-commitment.spec.ts
@@ -1,6 +1,7 @@
 import StateChannelTransaction from "@counterfactual/contracts/build/contracts/StateChannelTransaction.json";
 import { AssetType, NetworkContext } from "@counterfactual/types";
 import {
+  bigNumberify,
   getAddress,
   hexlify,
   Interface,
@@ -90,12 +91,16 @@ describe("SetupCommitment", () => {
         nonceRegistry,
         uninstallKey,
         appInstanceId,
+        rootNonceValue,
         [assetType, limit, token]
       ] = desc.args;
       expect(appRegistry).toBe(networkContext.AppRegistry);
       expect(nonceRegistry).toEqual(networkContext.NonceRegistry);
       expect(uninstallKey).toBe(freeBalanceETH.uninstallKey);
       expect(appInstanceId).toBe(appIdentityToHash(freeBalanceETH.identity));
+      expect(rootNonceValue).toEqual(
+        bigNumberify(freeBalanceETH.rootNonceValue)
+      );
       expect(assetType).toBe(freeBalanceETH.terms.assetType);
       expect(limit).toEqual(freeBalanceETH.terms.limit);
       expect(token).toBe(freeBalanceETH.terms.token);

--- a/packages/machine/test/unit/models/app-instance/app-instance.spec.ts
+++ b/packages/machine/test/unit/models/app-instance/app-instance.spec.ts
@@ -32,6 +32,7 @@ describe("AppInstance", () => {
       },
       false,
       Math.ceil(Math.random() * 2e10),
+      0,
       { foo: getAddress(hexlify(randomBytes(20))), bar: 0 },
       999, // <------ nonce
       Math.ceil(1000 * Math.random())

--- a/packages/machine/test/unit/models/state-channel/install.spec.ts
+++ b/packages/machine/test/unit/models/state-channel/install.spec.ts
@@ -53,6 +53,7 @@ describe("StateChannel::uninstallApp", () => {
       },
       false,
       Math.ceil(Math.random() * 2e10),
+      0,
       { foo: getAddress(hexlify(randomBytes(20))), bar: 0 },
       999, // <------ nonce
       Math.ceil(1000 * Math.random())

--- a/packages/machine/test/unit/models/state-channel/set-state.spec.ts
+++ b/packages/machine/test/unit/models/state-channel/set-state.spec.ts
@@ -48,6 +48,7 @@ describe("StateChannel::setState", () => {
       },
       false,
       Math.ceil(Math.random() * 2e10),
+      0,
       { foo: getAddress(hexlify(randomBytes(20))), bar: 0 },
       999, // <------ nonce
       Math.ceil(1000 * Math.random())

--- a/packages/machine/test/unit/models/state-channel/uninstall-app.spec.ts
+++ b/packages/machine/test/unit/models/state-channel/uninstall-app.spec.ts
@@ -48,6 +48,7 @@ describe("StateChannel::uninstallApp", () => {
       },
       false,
       Math.ceil(Math.random() * 2e10),
+      0,
       { foo: getAddress(hexlify(randomBytes(20))), bar: 0 },
       999, // <------ nonce
       Math.ceil(1000 * Math.random())


### PR DESCRIPTION
## This PR
1. Adds `rootNonceExpectedValue` to the `StateChannelTransaction` `executeAppConditionalTransaction` function. It assumed the hash of the multisignature address as the root nonce key.
2. Added `rootNonceValue` to `AppInstance` model
3. Added `rootNonceValue` to `StateChannel` model
4. Tests
