### PR TITLE
[node] Add InstructionExecutor to requests to methods

### DIFF
--- a/packages/node/src/methods/app-instance-operations.ts
+++ b/packages/node/src/methods/app-instance-operations.ts
@@ -1,3 +1,4 @@
+import { InstructionExecutor } from "@counterfactual/machine";
 import { Node } from "@counterfactual/types";
 
 import { Channels } from "../channels";
@@ -17,6 +18,7 @@ export async function getInstalledAppInstances(
 export async function getProposedAppInstances(
   channels: Channels,
   messagingService: IMessagingService,
+  instructionExecutor: InstructionExecutor,
   params: Node.GetAppInstancesParams
 ): Promise<Node.GetAppInstancesResult> {
   return {

--- a/packages/node/src/methods/install-operations.ts
+++ b/packages/node/src/methods/install-operations.ts
@@ -1,3 +1,4 @@
+import { InstructionExecutor } from "@counterfactual/machine";
 import { Node } from "@counterfactual/types";
 
 import { Channels } from "../channels";
@@ -17,6 +18,7 @@ import { IMessagingService } from "../services";
 export async function proposeInstall(
   channels: Channels,
   messagingService: IMessagingService,
+  instructionExecutor: InstructionExecutor,
   params: Node.ProposeInstallParams
 ): Promise<Node.ProposeInstallResult> {
   const uuid = await channels.proposeInstall(params);
@@ -48,6 +50,7 @@ export async function proposeInstall(
 export async function install(
   channels: Channels,
   messagingService: IMessagingService,
+  instructionExecutor: InstructionExecutor,
   params: Node.InstallParams
 ): Promise<Node.InstallResult> {
   const appInstance = await channels.install(params);
@@ -84,6 +87,7 @@ export async function install(
 export async function addAppInstance(
   channels: Channels,
   messagingService: IMessagingService,
+  instructionExecutor: InstructionExecutor,
   nodeMsg: NodeMessage
 ) {
   const params = { ...nodeMsg.data };

--- a/packages/node/src/methods/multisig-operations.ts
+++ b/packages/node/src/methods/multisig-operations.ts
@@ -1,3 +1,4 @@
+import { InstructionExecutor } from "@counterfactual/machine";
 import { Node } from "@counterfactual/types";
 
 import { Channels } from "../channels";
@@ -14,6 +15,7 @@ import { IMessagingService } from "../services";
 export async function createMultisig(
   channels: Channels,
   messagingService: IMessagingService,
+  instructionExecutor: InstructionExecutor,
   params: Node.CreateMultisigParams
 ): Promise<Node.CreateMultisigResult> {
   const result = {
@@ -44,6 +46,7 @@ export async function createMultisig(
 export async function addMultisig(
   channels: Channels,
   messagingService: IMessagingService,
+  instructionExecutor: InstructionExecutor,
   nodeMsg: NodeMessage
 ) {
   const params = nodeMsg.data;
@@ -53,6 +56,7 @@ export async function addMultisig(
 export async function getChannelAddresses(
   channels: Channels,
   messagingService: IMessagingService,
+  instructionExecutor: InstructionExecutor,
   nodeMsg: NodeMessage
 ): Promise<Node.GetChannelAddressesResult> {
   return {

--- a/packages/node/src/methods/request-handler.ts
+++ b/packages/node/src/methods/request-handler.ts
@@ -1,3 +1,4 @@
+import { InstructionExecutor } from "@counterfactual/machine";
 import { Node } from "@counterfactual/types";
 import EventEmitter from "eventemitter3";
 
@@ -27,7 +28,8 @@ export class RequestHandler {
     private readonly incoming: EventEmitter,
     private readonly outgoing: EventEmitter,
     private readonly channels: Channels,
-    private readonly messagingService: IMessagingService
+    private readonly messagingService: IMessagingService,
+    private readonly instructionExecutor: InstructionExecutor
   ) {
     this.registerMethods();
     this.mapEventHandlers();
@@ -49,6 +51,7 @@ export class RequestHandler {
       result: await this.methods.get(method)(
         this.channels,
         this.messagingService,
+        this.instructionExecutor,
         req.params
       )
     };
@@ -87,7 +90,12 @@ export class RequestHandler {
         const res: Node.MethodResponse = {
           type: req.type,
           requestId: req.requestId,
-          result: await method(this.channels, this.messagingService, req.params)
+          result: await method(
+            this.channels,
+            this.messagingService,
+            this.instructionExecutor,
+            req.params
+          )
         };
         this.outgoing.emit(req.type, res);
       });
@@ -112,6 +120,11 @@ export class RequestHandler {
    * @param msg
    */
   public async callEvent(event: Node.EventName, msg: NodeMessage) {
-    await this.events.get(event)(this.channels, this.messagingService, msg);
+    await this.events.get(event)(
+      this.channels,
+      this.messagingService,
+      this.instructionExecutor,
+      msg
+    );
   }
 }

--- a/packages/node/src/node.ts
+++ b/packages/node/src/node.ts
@@ -55,15 +55,7 @@ export class Node {
       // account-address-based indexing
       `${nodeConfig.STORE_KEY_PREFIX}/${this.signer.address}`
     );
-    this.instructionExecutor = new InstructionExecutor({
-      // TODO: Pass in NetworkContext into Node constructor
-      AppRegistry: AddressZero,
-      ETHBalanceRefund: AddressZero,
-      ETHBucket: AddressZero,
-      MultiSend: AddressZero,
-      NonceRegistry: AddressZero,
-      StateChannelTransaction: AddressZero
-    });
+    this.instructionExecutor = new InstructionExecutor(networkContext);
     this.registerMessagingConnection();
     this.requestHandler = new RequestHandler(
       this.incoming,

--- a/packages/node/src/node.ts
+++ b/packages/node/src/node.ts
@@ -4,7 +4,6 @@ import {
   NetworkContext,
   Node as NodeTypes
 } from "@counterfactual/types";
-import { AddressZero } from "ethers/constants";
 import { SigningKey } from "ethers/utils";
 import EventEmitter from "eventemitter3";
 

--- a/packages/node/src/node.ts
+++ b/packages/node/src/node.ts
@@ -1,8 +1,10 @@
+import { InstructionExecutor } from "@counterfactual/machine";
 import {
   Address,
   NetworkContext,
   Node as NodeTypes
 } from "@counterfactual/types";
+import { AddressZero } from "ethers/constants";
 import { SigningKey } from "ethers/utils";
 import EventEmitter from "eventemitter3";
 
@@ -27,6 +29,9 @@ export class Node {
 
   private readonly channels: Channels;
   private readonly signer: SigningKey;
+
+  private readonly instructionExecutor: InstructionExecutor;
+
   protected readonly requestHandler: RequestHandler;
 
   /**
@@ -50,12 +55,22 @@ export class Node {
       // account-address-based indexing
       `${nodeConfig.STORE_KEY_PREFIX}/${this.signer.address}`
     );
+    this.instructionExecutor = new InstructionExecutor({
+      // TODO: Pass in NetworkContext into Node constructor
+      AppRegistry: AddressZero,
+      ETHBalanceRefund: AddressZero,
+      ETHBucket: AddressZero,
+      MultiSend: AddressZero,
+      NonceRegistry: AddressZero,
+      StateChannelTransaction: AddressZero
+    });
     this.registerMessagingConnection();
     this.requestHandler = new RequestHandler(
       this.incoming,
       this.outgoing,
       this.channels,
-      this.messagingService
+      this.messagingService,
+      this.instructionExecutor
     );
   }
 


### PR DESCRIPTION
Adds an instance of an `InstructionExecutor` to the `Node` and threads it through into all `methods` by adding an `InstructionExecutor` as the 3rd param in all `RequestHandler`-compliant methods.