### PR TITLE
virtual app commitments, messages, AppRegistry changes

### DIFF
--- a/packages/contracts/contracts/ETHVirtualAppAgreement.sol
+++ b/packages/contracts/contracts/ETHVirtualAppAgreement.sol
@@ -4,6 +4,8 @@ pragma experimental "ABIEncoderV2";
 import "./libs/Transfer.sol";
 import "./AppRegistry.sol";
 
+/// todo(ldct): make this agreement cancellable ("uninstallKey")
+
 
 /// @title ETHVirtualAppAgreement
 /// @notice Commitment target to support "virtual apps", i.e., apps which have

--- a/packages/contracts/contracts/ETHVirtualAppAgreement.sol
+++ b/packages/contracts/contracts/ETHVirtualAppAgreement.sol
@@ -4,8 +4,6 @@ pragma experimental "ABIEncoderV2";
 import "./libs/Transfer.sol";
 import "./AppRegistry.sol";
 
-/// todo(ldct): make this agreement cancellable ("uninstallKey")
-
 
 /// @title ETHVirtualAppAgreement
 /// @notice Commitment target to support "virtual apps", i.e., apps which have
@@ -17,6 +15,8 @@ import "./AppRegistry.sol";
 /// treated as the amount assigned to our first beneficiary (i.e.,
 /// `agreement.beneficiaries[0]`). Note that `terms.limit` is explicitly
 /// ignored since limits are enforced by `capitalProvided`.
+/// todo(xuanji): this agreement is not cancellable, so uninstallation of
+/// virtual apps do not work yet.
 contract ETHVirtualAppAgreement {
 
   using Transfer for Transfer.Transaction;

--- a/packages/contracts/contracts/mixins/MixinVirtualAppSetState.sol
+++ b/packages/contracts/contracts/mixins/MixinVirtualAppSetState.sol
@@ -1,0 +1,115 @@
+pragma solidity 0.5;
+pragma experimental "ABIEncoderV2";
+
+import "../libs/LibStateChannelApp.sol";
+import "../libs/LibSignature.sol";
+import "../libs/LibStaticCall.sol";
+
+import "./MAppRegistryCore.sol";
+import "./MAppCaller.sol";
+
+
+contract MixinVirtualAppSetState is
+  LibSignature,
+  LibStateChannelApp,
+  MAppRegistryCore,
+  MAppCaller
+{
+
+  /// signatures[0], instead of signing a message that authorizes
+  /// a state update with a given stateHash, signs a message that authorizes all
+  /// updates with nonce < nonceExpiry
+  struct VirtualAppSignedStateHashUpdate {
+    bytes32 stateHash;
+    uint256 nonce;
+    uint256 timeout;
+    bytes signatures;
+    uint256 nonceExpiry;
+  }
+
+  function virtualAppSetState(
+    AppIdentity memory appIdentity,
+    VirtualAppSignedStateHashUpdate memory req
+  )
+    public
+  {
+    bytes32 identityHash = appIdentityToHash(appIdentity);
+
+    AppChallenge storage challenge = appStates[identityHash];
+
+    require(
+      challenge.status == AppStatus.ON,
+      "setState was called on a virtual app that is either in DISPUTE or OFF"
+    );
+
+    require(
+      correctKeysSignedTheStateUpdate(
+        identityHash,
+        appIdentity.signingKeys,
+        req
+      ),
+      "Call to setState included incorrectly signed state update"
+    );
+
+    require(
+      req.nonce > challenge.nonce,
+      "Tried to call setState with an outdated nonce version"
+    );
+
+    require(
+      req.nonce < req.nonceExpiry,
+      "Tried to call setState with nonce greater than intemediary nonce expiry");
+
+    challenge.status = req.timeout > 0 ? AppStatus.DISPUTE : AppStatus.OFF;
+    challenge.appStateHash = req.stateHash;
+    challenge.nonce = req.nonce;
+    challenge.finalizesAt = block.number + req.timeout;
+    challenge.disputeNonce = 0;
+    challenge.disputeCounter += 1;
+    challenge.latestSubmitter = msg.sender;
+  }
+
+  function correctKeysSignedTheStateUpdate(
+    bytes32 identityHash,
+    address[] memory signingKeys,
+    VirtualAppSignedStateHashUpdate memory req
+  )
+    private
+    pure
+    returns (bool)
+  {
+    bytes32 digest1 = computeStateHash(
+      identityHash,
+      req.stateHash,
+      req.nonce,
+      req.timeout
+    );
+
+    bytes32 digest2 = keccak256(
+      abi.encodePacked(
+        byte(0x19),
+        identityHash,
+        req.nonceExpiry,
+        req.timeout,
+        byte(0x01)
+      )
+    );
+
+    require(
+      signingKeys[0] == recoverKey(req.signatures, digest2, 0), "Invalid signature"
+    );
+
+    address lastSigner = address(0);
+    for (uint256 i = 1; i < signingKeys.length; i++) {
+      require(
+        signingKeys[i] == recoverKey(req.signatures, digest1, i), "Invalid signature"
+      );
+
+      require(signingKeys[i] > lastSigner, "Signers not in ascending order");
+
+      lastSigner = signingKeys[i];
+    }
+    return true;
+  }
+
+}

--- a/packages/contracts/scripts/test.sh
+++ b/packages/contracts/scripts/test.sh
@@ -3,7 +3,7 @@
 set -e
 
 function clean {
-  kill ${PID_FOR_GANACHE_CLI}
+  kill -9 ${PID_FOR_GANACHE_CLI}
 }
 
 trap clean INT TERM EXIT

--- a/packages/contracts/scripts/test.sh
+++ b/packages/contracts/scripts/test.sh
@@ -3,7 +3,7 @@
 set -e
 
 function clean {
-  kill -9 ${PID_FOR_GANACHE_CLI}
+  kill ${PID_FOR_GANACHE_CLI}
 }
 
 trap clean INT TERM EXIT

--- a/packages/machine/scripts/test.sh
+++ b/packages/machine/scripts/test.sh
@@ -3,7 +3,7 @@
 set -e
 
 function clean {
-  kill ${PID_FOR_GANACHE_CLI}
+  kill -9 ${PID_FOR_GANACHE_CLI}
 }
 
 trap clean INT TERM EXIT

--- a/packages/machine/scripts/test.sh
+++ b/packages/machine/scripts/test.sh
@@ -3,7 +3,7 @@
 set -e
 
 function clean {
-  kill -9 ${PID_FOR_GANACHE_CLI}
+  kill ${PID_FOR_GANACHE_CLI}
 }
 
 trap clean INT TERM EXIT

--- a/packages/machine/src/ethereum/eth-virtual-app-agreement-commitment.ts
+++ b/packages/machine/src/ethereum/eth-virtual-app-agreement-commitment.ts
@@ -1,0 +1,65 @@
+import ETHVirtualAppAgreement from "@counterfactual/contracts/build/contracts/ETHVirtualAppAgreement.json";
+import { AppIdentity, NetworkContext, Terms } from "@counterfactual/types";
+import { BigNumber, Interface, keccak256, solidityPack } from "ethers/utils";
+
+import { DependencyValue } from "../models/app-instance";
+
+import { MultiSendCommitment } from "./multisend-commitment";
+import { MultisigOperation, MultisigTransaction } from "./types";
+
+const iface = new Interface(ETHVirtualAppAgreement.abi);
+
+export class ETHVirtualAppAgreementCommitment extends MultiSendCommitment {
+  constructor(
+    public readonly networkContext: NetworkContext,
+    public readonly multisig: string,
+    public readonly multisigOwners: string[],
+    public readonly targetAppIdentityHash: string,
+    public readonly freeBalanceAppIdentity: AppIdentity,
+    public readonly freeBalanceTerms: Terms,
+    public readonly freeBalanceStateHash: string,
+    public readonly freeBalanceNonce: number,
+    public readonly freeBalanceTimeout: number,
+    public readonly dependencyNonce: number,
+    public readonly rootNonceValue: number,
+    public readonly expiry: BigNumber,
+    public readonly capitalProvided: BigNumber,
+    public readonly beneficiaries: string[],
+    public readonly terms?: Terms
+  ) {
+    super(
+      networkContext,
+      multisig,
+      multisigOwners,
+      freeBalanceAppIdentity,
+      freeBalanceTerms,
+      freeBalanceStateHash,
+      freeBalanceNonce,
+      freeBalanceTimeout,
+      keccak256(solidityPack(["uint256"], [dependencyNonce])),
+      DependencyValue.NOT_UNINSTALLED
+    );
+  }
+
+  public eachMultisigInput() {
+    return [this.freeBalanceInput(), this.conditionalTransactionInput()];
+  }
+
+  private conditionalTransactionInput(): MultisigTransaction {
+    return {
+      to: this.networkContext.ETHVirtualAppAgreement,
+      value: 0,
+      data: iface.functions.delegateTarget.encode([
+        {
+          registry: this.networkContext.AppRegistry,
+          // terms,
+          expiry: this.expiry,
+          appIdentityHash: this.targetAppIdentityHash,
+          capitalProvided: this.capitalProvided,
+          beneficiaries: this.beneficiaries
+        }
+      ]),
+      operation: MultisigOperation.DelegateCall
+    };
+  }
+}

--- a/packages/machine/src/ethereum/multisend-commitment.ts
+++ b/packages/machine/src/ethereum/multisend-commitment.ts
@@ -11,6 +11,7 @@ import { encodeTransactions } from "./utils/multisend-encoder";
 const appRegistryIface = new Interface(AppRegistry.abi);
 const multisendIface = new Interface(MultiSend.abi);
 
+/// A commitment to make MinimumViableMultisig perform a message call to the MultiSend contract
 export abstract class MultiSendCommitment extends MultisigCommitment {
   public abstract eachMultisigInput(): MultisigTransaction[];
 
@@ -40,6 +41,7 @@ export abstract class MultiSendCommitment extends MultisigCommitment {
     };
   }
 
+  /// A convenience function for children to include a subcall to set the free balance state
   public freeBalanceInput(): MultisigTransaction {
     return {
       to: this.networkContext.AppRegistry,

--- a/packages/machine/src/ethereum/set-state-commitment.ts
+++ b/packages/machine/src/ethereum/set-state-commitment.ts
@@ -16,7 +16,7 @@ export class SetStateCommitment extends EthereumCommitment {
   constructor(
     public readonly networkContext: NetworkContext,
     public readonly appIdentity: AppIdentity,
-    public readonly encodedAppState: string,
+    public readonly hashedAppState: string,
     public readonly appLocalNonce: number,
     public readonly timeout: number
   ) {
@@ -32,7 +32,7 @@ export class SetStateCommitment extends EthereumCommitment {
           appIdentityToHash(this.appIdentity),
           this.appLocalNonce,
           this.timeout,
-          keccak256(this.encodedAppState)
+          this.hashedAppState
         ]
       )
     );
@@ -53,7 +53,7 @@ export class SetStateCommitment extends EthereumCommitment {
     signatures: Signature[]
   ): SignedStateHashUpdate {
     return {
-      stateHash: keccak256(this.encodedAppState),
+      stateHash: this.hashedAppState,
       nonce: this.appLocalNonce,
       timeout: this.timeout,
       signatures: signaturesToBytesSortedBySignerAddress(

--- a/packages/machine/src/ethereum/types.ts
+++ b/packages/machine/src/ethereum/types.ts
@@ -1,8 +1,12 @@
 import { Signature } from "ethers/utils";
 
 export abstract class EthereumCommitment {
-  public abstract hashToSign(): string;
-  public abstract transaction(sigs: Signature[]): Transaction;
+  // todo(ldct): hack hack hack
+  public abstract hashToSign(signerIsIntermediary?: boolean): string;
+  public abstract transaction(
+    signatures: Signature[],
+    intermediarySignature?: Signature
+  ): Transaction;
 }
 
 export enum MultisigOperation {

--- a/packages/machine/src/ethereum/types.ts
+++ b/packages/machine/src/ethereum/types.ts
@@ -2,12 +2,12 @@ import { Signature } from "ethers/utils";
 
 export abstract class EthereumCommitment {
   // todo(xuanji): EthereumCommitment was designed under the assumption that
-  //  `hashToSign` returns the same hash for different signers. However, in the
-  //  install-virtual-app protocol, the hash that the intermediary signs is
-  //  different from the one the other participants sign. The optional
-  //  `signerIsIntermediary` flag is a hack that is only used by the
-  //  `install-virtual-app protocol`. `intermediarySignature` in `transaction`
-  //  is the same kind of hack.
+  // `hashToSign` returns the same hash for different signers. However, in the
+  // install-virtual-app protocol, the hash that the intermediary signs is
+  // different from the one the other participants sign. The optional
+  // `signerIsIntermediary` flag is a hack that is only used by the
+  // `install-virtual-app protocol`. `intermediarySignature` in `transaction`
+  // is the same kind of hack.
   public abstract hashToSign(signerIsIntermediary?: boolean): string;
   public abstract transaction(
     signatures: Signature[],

--- a/packages/machine/src/ethereum/types.ts
+++ b/packages/machine/src/ethereum/types.ts
@@ -1,7 +1,13 @@
 import { Signature } from "ethers/utils";
 
 export abstract class EthereumCommitment {
-  // todo(ldct): hack hack hack
+  // todo(xuanji): EthereumCommitment was designed under the assumption that
+  //  `hashToSign` returns the same hash for different signers. However, in the
+  //  install-virtual-app protocol, the hash that the intermediary signs is
+  //  different from the one the other participants sign. The optional
+  //  `signerIsIntermediary` flag is a hack that is only used by the
+  //  `install-virtual-app protocol`. `intermediarySignature` in `transaction`
+  //  is the same kind of hack.
   public abstract hashToSign(signerIsIntermediary?: boolean): string;
   public abstract transaction(
     signatures: Signature[],

--- a/packages/machine/src/ethereum/utils/signature.ts
+++ b/packages/machine/src/ethereum/utils/signature.ts
@@ -12,7 +12,7 @@ export function signaturesToBytes(...signatures: Signature[]): string {
     .reduce((acc, v) => acc + v, "0x");
 }
 
-function sortSignaturesBySignerAddress(
+export function sortSignaturesBySignerAddress(
   digest: string,
   signatures: Signature[]
 ): Signature[] {

--- a/packages/machine/src/ethereum/virtual-app-set-state-commitment.ts
+++ b/packages/machine/src/ethereum/virtual-app-set-state-commitment.ts
@@ -18,7 +18,7 @@ export class VirtualAppSetStateCommitment extends EthereumCommitment {
     public readonly appLocalNonceExpiry: number,
     public readonly timeout: number,
     // todo(xuanji): the following two are set to null for intermediary. This
-    //   is bad API design and should be fixed eventually.
+    // is bad API design and should be fixed eventually.
     public readonly hashedAppState?: string,
     public readonly appLocalNonce?: number
   ) {

--- a/packages/machine/src/ethereum/virtual-app-set-state-commitment.ts
+++ b/packages/machine/src/ethereum/virtual-app-set-state-commitment.ts
@@ -1,0 +1,90 @@
+import AppRegistry from "@counterfactual/contracts/build/contracts/AppRegistry.json";
+import { AppIdentity, NetworkContext } from "@counterfactual/types";
+import { Interface, keccak256, Signature, solidityPack } from "ethers/utils";
+
+import { EthereumCommitment, Transaction } from "./types";
+import { appIdentityToHash } from "./utils/app-identity";
+import {
+  signaturesToBytes,
+  sortSignaturesBySignerAddress
+} from "./utils/signature";
+
+const iface = new Interface(AppRegistry.abi);
+
+export class VirtualAppSetStateCommitment extends EthereumCommitment {
+  constructor(
+    public readonly networkContext: NetworkContext,
+    public readonly appIdentity: AppIdentity,
+    public readonly appLocalNonceExpiry: number,
+    public readonly timeout: number,
+    // set the following two to null for intermediary
+    public readonly hashedAppState?: string,
+    public readonly appLocalNonce?: number
+  ) {
+    super();
+  }
+
+  /// overrides EthereumCommitment::hashToSign
+  public hashToSign(signerIsIntermediary: boolean): string {
+    if (signerIsIntermediary) {
+      /// keep in sync with `digest2` definition
+      return keccak256(
+        solidityPack(
+          ["bytes1", "bytes32", "uint256", "uint256", "bytes32", "bytes1"],
+          [
+            "0x19",
+            appIdentityToHash(this.appIdentity),
+            this.appLocalNonceExpiry,
+            this.timeout,
+            "0x01"
+          ]
+        )
+      );
+    }
+    /// keep in sync with `digest2` definition
+    return keccak256(
+      solidityPack(
+        ["bytes1", "bytes32", "uint256", "uint256", "bytes32", "bytes1"],
+        [
+          "0x19",
+          appIdentityToHash(this.appIdentity),
+          this.appLocalNonce!,
+          this.timeout,
+          this.hashedAppState
+        ]
+      )
+    );
+  }
+
+  // overrides EthereumCommitment::Transaction
+  public transaction(
+    signatures: Signature[],
+    intermediarySignature: Signature
+  ): Transaction {
+    return {
+      to: this.networkContext.AppRegistry,
+      value: 0,
+      data: iface.functions.virtualAppSetState.encode([
+        this.appIdentity,
+        this.getSignedStateHashUpdate(signatures, intermediarySignature)
+      ])
+    };
+  }
+
+  /// keep in sync with virtualAppSetState
+  private getSignedStateHashUpdate(
+    signatures: Signature[],
+    intermediarySignature: Signature
+  ): any {
+    return {
+      stateHash: this.hashedAppState!,
+      nonce: this.appLocalNonce!,
+      timeout: this.timeout,
+      signatures: signaturesToBytes(
+        intermediarySignature,
+        ...sortSignaturesBySignerAddress(this.hashToSign(false), signatures)
+      ),
+      nonceExpiry: this.appLocalNonceExpiry
+    };
+  }
+}

--- a/packages/machine/src/ethereum/virtual-app-set-state-commitment.ts
+++ b/packages/machine/src/ethereum/virtual-app-set-state-commitment.ts
@@ -17,7 +17,8 @@ export class VirtualAppSetStateCommitment extends EthereumCommitment {
     public readonly appIdentity: AppIdentity,
     public readonly appLocalNonceExpiry: number,
     public readonly timeout: number,
-    // set the following two to null for intermediary
+    // todo(xuanji): the following two are set to null for intermediary. This
+    //   is bad API design and should be fixed eventually.
     public readonly hashedAppState?: string,
     public readonly appLocalNonce?: number
   ) {

--- a/packages/machine/src/instruction-executor.ts
+++ b/packages/machine/src/instruction-executor.ts
@@ -118,7 +118,7 @@ export class InstructionExecutor {
       network: this.network,
       outbox: [],
       inbox: [],
-      stateChannel: sc,
+      stateChannelsMap: sc,
       commitment: undefined,
       signature: undefined
     };
@@ -145,7 +145,7 @@ export class InstructionExecutor {
       }
     }
 
-    if (context.stateChannel === undefined) {
+    if (context.stateChannelsMap === undefined) {
       throw Error(
         `After protocol ${
           msg.protocol
@@ -159,6 +159,6 @@ export class InstructionExecutor {
     //
     // const diff = sc.diff(context.stateChannel)
 
-    return context.stateChannel;
+    return context.stateChannelsMap;
   }
 }

--- a/packages/machine/src/models/eth-virtual-app-agreement-instance.ts
+++ b/packages/machine/src/models/eth-virtual-app-agreement-instance.ts
@@ -1,0 +1,49 @@
+import { Terms } from "@counterfactual/types";
+
+export type ETHVirtualAppAgreementJson = {
+  multisigAddress: string;
+  terms: Terms;
+  appSeqNo: number;
+  rootNonceValue: number;
+  expiry: number;
+  capitalProvided: number;
+};
+
+export class ETHVirtualAppAgreementInstance {
+  private readonly json: ETHVirtualAppAgreementJson;
+
+  constructor(
+    public multisigAddress: string,
+    public terms: Terms,
+    public appSeqNo: number,
+    public rootNonceValue: number,
+    // todo(ldct): bignumberify
+    public expiry: number,
+    public capitalProvided: number
+  ) {
+    this.json = {
+      multisigAddress,
+      terms,
+      appSeqNo,
+      rootNonceValue,
+      expiry,
+      capitalProvided
+    };
+  }
+
+  public toJson(): ETHVirtualAppAgreementJson {
+    return JSON.parse(JSON.stringify(this.json));
+  }
+
+  public static fromJson(json: ETHVirtualAppAgreementJson) {
+    const ret = new ETHVirtualAppAgreementInstance(
+      json.multisigAddress,
+      json.terms,
+      json.appSeqNo,
+      json.rootNonceValue,
+      json.expiry,
+      json.capitalProvided
+    );
+    return ret;
+  }
+}

--- a/packages/machine/src/models/eth-virtual-app-agreement-instance.ts
+++ b/packages/machine/src/models/eth-virtual-app-agreement-instance.ts
@@ -17,8 +17,9 @@ export class ETHVirtualAppAgreementInstance {
     public terms: Terms,
     public appSeqNo: number,
     public rootNonceValue: number,
-    // todo(ldct): bignumberify
     public expiry: number,
+    // todo(xuanji): The following field is a js `number`, which is
+    // unsafe since even 1 ETH will exceed `Number.MAX_SAFE_INTEGER`
     public capitalProvided: number
   ) {
     this.json = {

--- a/packages/machine/src/models/index.ts
+++ b/packages/machine/src/models/index.ts
@@ -1,4 +1,15 @@
 import { AppInstance, AppInstanceJson } from "./app-instance";
+import {
+  ETHVirtualAppAgreementInstance,
+  ETHVirtualAppAgreementJson
+} from "./eth-virtual-app-agreement-instance";
 import { StateChannel, StateChannelJSON } from "./state-channel";
 
-export { AppInstance, AppInstanceJson, StateChannel, StateChannelJSON };
+export {
+  AppInstance,
+  AppInstanceJson,
+  ETHVirtualAppAgreementInstance,
+  ETHVirtualAppAgreementJson,
+  StateChannel,
+  StateChannelJSON
+};

--- a/packages/machine/src/models/state-channel.ts
+++ b/packages/machine/src/models/state-channel.ts
@@ -14,6 +14,10 @@ import {
 } from "../ethereum/utils/free-balance";
 
 import { AppInstance, AppInstanceJson } from "./app-instance";
+import {
+  ETHVirtualAppAgreementInstance,
+  ETHVirtualAppAgreementJson
+} from "./eth-virtual-app-agreement-instance";
 
 // TODO: Hmmm this code should probably be somewhere else?
 const HARD_CODED_ASSUMPTIONS = {
@@ -41,6 +45,10 @@ export type StateChannelJSON = {
   readonly multisigAddress: string;
   readonly multisigOwners: string[];
   readonly appInstances: [string, AppInstanceJson][];
+  readonly ETHVirtualAppAgreementInstances: [
+    string,
+    ETHVirtualAppAgreementJson
+  ][];
   readonly freeBalanceAppIndexes: [number, string][];
   readonly monotonicNumInstalledApps: number;
 };
@@ -83,6 +91,10 @@ export class StateChannel {
       string,
       AppInstance
     >([]),
+    readonly ethVirtualAppAgreementInstances: ReadonlyMap<
+      string,
+      ETHVirtualAppAgreementInstance
+    > = new Map<string, ETHVirtualAppAgreementInstance>([]),
     private readonly freeBalanceAppIndexes: ReadonlyMap<
       AssetType,
       string
@@ -170,6 +182,7 @@ export class StateChannel {
       this.multisigAddress,
       this.multisigOwners,
       appInstances,
+      this.ethVirtualAppAgreementInstances,
       freeBalanceAppIndexes,
       this.monotonicNumInstalledApps + 1
     );
@@ -188,16 +201,19 @@ export class StateChannel {
       this.multisigAddress,
       this.multisigOwners,
       appInstances,
+      this.ethVirtualAppAgreementInstances,
       this.freeBalanceAppIndexes,
       this.monotonicNumInstalledApps
     );
   }
 
-  public installApp(
-    appInstance: AppInstance,
+  public installETHVirtualAppAgreementInstance(
+    evaaInstance: ETHVirtualAppAgreementInstance,
     aliceBalanceDecrement: BigNumber,
     bobBalanceDecrement: BigNumber
   ) {
+    /// Decrement from FB
+
     const fb = this.getFreeBalanceFor(AssetType.ETH);
     const currentFBState = fb.state;
 
@@ -207,6 +223,55 @@ export class StateChannel {
     if (aliceBalance.lt(Zero) || bobBalance.lt(Zero)) {
       throw Error(INSUFFICIENT_FUNDS);
     }
+
+    /// Add modified FB to appInstances
+
+    const appInstances = new Map<string, AppInstance>(
+      this.appInstances.entries()
+    );
+
+    appInstances.set(
+      fb.identityHash,
+      fb.setState({ ...currentFBState, aliceBalance, bobBalance })
+    );
+
+    // Add to ethVirtualAppAgreementInstances
+
+    const evaaInstances = new Map<string, ETHVirtualAppAgreementInstance>(
+      this.ethVirtualAppAgreementInstances.entries()
+    );
+
+    // todo(ldct: what key?)
+    evaaInstances.set("", evaaInstance);
+
+    return new StateChannel(
+      this.multisigAddress,
+      this.multisigOwners,
+      this.appInstances,
+      evaaInstances,
+      this.freeBalanceAppIndexes,
+      this.monotonicNumInstalledApps + 1
+    );
+  }
+
+  public installApp(
+    appInstance: AppInstance,
+    aliceBalanceDecrement: BigNumber,
+    bobBalanceDecrement: BigNumber
+  ) {
+    /// Decrement from FB
+
+    const fb = this.getFreeBalanceFor(AssetType.ETH);
+    const currentFBState = fb.state;
+
+    const aliceBalance = currentFBState.aliceBalance.sub(aliceBalanceDecrement);
+    const bobBalance = currentFBState.bobBalance.sub(bobBalanceDecrement);
+
+    if (aliceBalance.lt(Zero) || bobBalance.lt(Zero)) {
+      throw Error(INSUFFICIENT_FUNDS);
+    }
+
+    /// Add modified FB and new AppInstance to appInstances
 
     const appInstances = new Map<string, AppInstance>(
       this.appInstances.entries()
@@ -223,6 +288,7 @@ export class StateChannel {
       this.multisigAddress,
       this.multisigOwners,
       appInstances,
+      this.ethVirtualAppAgreementInstances,
       this.freeBalanceAppIndexes,
       this.monotonicNumInstalledApps + 1
     );
@@ -256,6 +322,7 @@ export class StateChannel {
       this.multisigAddress,
       this.multisigOwners,
       appInstances,
+      this.ethVirtualAppAgreementInstances,
       this.freeBalanceAppIndexes,
       this.monotonicNumInstalledApps
     );
@@ -271,7 +338,14 @@ export class StateChannel {
         }
       ),
       freeBalanceAppIndexes: Array.from(this.freeBalanceAppIndexes.entries()),
-      monotonicNumInstalledApps: this.monotonicNumInstalledApps
+      monotonicNumInstalledApps: this.monotonicNumInstalledApps,
+      ETHVirtualAppAgreementInstances: [
+        ...this.ethVirtualAppAgreementInstances.entries()
+      ].map(
+        (appInstanceEntry): [string, ETHVirtualAppAgreementJson] => {
+          return [appInstanceEntry[0], appInstanceEntry[1].toJson()];
+        }
+      )
     };
   }
 
@@ -280,11 +354,21 @@ export class StateChannel {
       json.multisigAddress,
       json.multisigOwners,
       new Map(
-        [...Object.values(json.appInstances)].map(
+        [...Object.values(json.appInstances || [])].map(
           (appInstanceEntry): [string, AppInstance] => {
             return [
               appInstanceEntry[0],
               AppInstance.fromJson(appInstanceEntry[1])
+            ];
+          }
+        )
+      ),
+      new Map(
+        [...Object.values(json.ETHVirtualAppAgreementInstances || [])].map(
+          (appInstanceEntry): [string, ETHVirtualAppAgreementInstance] => {
+            return [
+              appInstanceEntry[0],
+              ETHVirtualAppAgreementInstance.fromJson(appInstanceEntry[1])
             ];
           }
         )

--- a/packages/machine/src/opcodes.ts
+++ b/packages/machine/src/opcodes.ts
@@ -16,14 +16,12 @@ export enum Opcode {
   OP_SIGN_VALIDATE,
 
   /**
-   * Sends a ClientMessage to a peer.
+   * Middleware hook to send a ProtocolMessage to a peer.
    */
   IO_SEND,
 
   /**
-   * Blocks the action execution until the next message is received by a peer.
-   * The registered middleware for this instruction *must* return the received
-   * ClientMessage from the peer.
+   * Middleware hook to receive a ProtocolMessage from a peer.
    */
   IO_WAIT
 }

--- a/packages/machine/src/protocol-types-tbd.ts
+++ b/packages/machine/src/protocol-types-tbd.ts
@@ -21,22 +21,33 @@ export interface AppStateArray
 
 export type ProtocolMessage = {
   protocol: Protocol;
-  multisigAddress: string;
   params: ProtocolParameters;
   fromAddress: string;
   toAddress: string;
   seq: number;
   signature?: Signature;
+  signature2?: Signature;
+  signature3?: Signature;
 };
 
-export type SetupParams = {};
+export type SetupParams = {
+  initiatingAddress: string;
+  respondingAddress: string;
+  multisigAddress: string;
+};
 
 export type UpdateParams = {
+  initiatingAddress: string;
+  respondingAddress: string;
+  multisigAddress: string;
   appIdentityHash: string;
   newState: AppState;
 };
 
 export type InstallParams = {
+  initiatingAddress: string;
+  respondingAddress: string;
+  multisigAddress: string;
   aliceBalanceDecrement: BigNumber;
   bobBalanceDecrement: BigNumber;
   signingKeys: string[];
@@ -48,12 +59,26 @@ export type InstallParams = {
 
 export type UninstallParams = {
   appIdentityHash: string;
+  initiatingAddress: string;
+  respondingAddress: string;
+  multisigAddress: string;
   aliceBalanceIncrement: BigNumber;
   bobBalanceIncrement: BigNumber;
 };
 
 export type InstallVirtualAppParams = {
-  /* TODO: @xuanji */
+  initiatingAddress: string;
+  respondingAddress: string;
+  multisig1Address: string;
+  multisig2Address: string;
+  intermediaryAddress: string;
+  signingKeys: string[];
+  defaultTimeout: number;
+  appInterface: AppInterface;
+  initialState: AppState;
+  aliceBalanceDecrement: BigNumber;
+  bobBalanceDecrement: BigNumber;
+  terms: Terms;
 };
 
 type ProtocolParameters =

--- a/packages/machine/src/protocol/install-virtual-app.ts
+++ b/packages/machine/src/protocol/install-virtual-app.ts
@@ -1,71 +1,389 @@
-import { StateChannel } from "../models";
+// import { NetworkContext } from "@counterfactual/types";
+
+import { ETHVirtualAppAgreementCommitment } from "@counterfactual/machine/src/ethereum/eth-virtual-app-agreement-commitment";
+import { VirtualAppSetStateCommitment } from "@counterfactual/machine/src/ethereum/virtual-app-set-state-commitment";
+import { AssetType, NetworkContext } from "@counterfactual/types";
+import { BigNumber } from "ethers/utils";
+
+import {
+  AppInstance,
+  ETHVirtualAppAgreementInstance,
+  StateChannel
+} from "../models";
 import { Opcode } from "../opcodes";
-import { ProtocolMessage } from "../protocol-types-tbd";
+import {
+  InstallVirtualAppParams,
+  ProtocolMessage
+} from "../protocol-types-tbd";
 import { Context } from "../types";
+
+// hardcoded assumption: all installed virtual apps can go through this many update operations
+const NONCE_EXPIRY = 65536;
 
 /**
  * @description This exchange is described at the following URL:
- *
- * FIXME: @xuanji pls add
- *
  */
-// FIXME: Not fully implemented yet
 export const INSTALL_VIRTUAL_APP_PROTOCOL = {
   0: [
-    (
-      message: ProtocolMessage,
-      context: Context,
-      stateChannel: StateChannel
-    ) => {
-      // copy client message
-      context.outbox.push(message);
-      context.outbox[0].seq = 1;
-      // context.outbox[0].toAddress = message.data.intermediary;
-    },
+    proposeStateTransition1,
 
-    // send to intermediary
-    Opcode.IO_SEND
+    // Sign `context.commitment.getHash()` and `context.commitment2.getHash(false)`
+    Opcode.OP_SIGN,
+
+    // M1
+    (message: ProtocolMessage, context: Context) => {
+      const params2 = message.params as InstallVirtualAppParams;
+      context.outbox.push({
+        ...message,
+        signature: context.signature, // s1
+        signature2: context.signature2, // s5
+        seq: 1,
+        toAddress: params2.intermediaryAddress
+      });
+    },
+    Opcode.IO_SEND,
+
+    // wait for M5
+    Opcode.IO_WAIT
   ],
 
   1: [
-    (
-      message: ProtocolMessage,
-      context: Context,
-      stateChannel: StateChannel
-    ) => {
-      context.outbox.push(message);
+    proposeStateTransition2,
+
+    // Sign three commitments; pass `true` to hashToSign if asked
+    Opcode.OP_SIGN,
+
+    // M2
+    (message: ProtocolMessage, context: Context) => {
+      const params2 = message.params as InstallVirtualAppParams;
+      context.outbox[0] = message;
       context.outbox[0].seq = 2;
-      // context.outbox[0].fromAddress = message.data.initiating;
-      // context.outbox[0].toAddress = message.data.responding;
+      context.outbox[0].fromAddress = params2.intermediaryAddress;
+      context.outbox[0].toAddress = params2.respondingAddress;
+      context.outbox[0].signature = message.signature2; // s5
+      context.outbox[0].signature2 = context.signature; // s3
+    },
+    Opcode.IO_SEND,
+
+    // wait for M3
+    Opcode.IO_WAIT,
+
+    // M4
+    (message: ProtocolMessage, context: Context) => {
+      const params2 = message.params as InstallVirtualAppParams;
+      context.outbox[0] = message;
+      context.outbox[0].seq = 4;
+      context.outbox[0].fromAddress = params2.intermediaryAddress;
+      context.outbox[0].toAddress = params2.respondingAddress;
+      context.outbox[0].signature = context.signature3; // s6
+    },
+    Opcode.IO_SEND,
+
+    // M5
+    (message: ProtocolMessage, context: Context) => {
+      const params2 = message.params as InstallVirtualAppParams;
+      context.outbox[0] = message;
+      context.outbox[0].seq = 5;
+      context.outbox[0].fromAddress = params2.intermediaryAddress;
+      context.outbox[0].toAddress = params2.initiatingAddress;
+      context.outbox[0].signature = context.signature3; // s6
+      context.outbox[0].signature2 = context.signature2; // s2
+      context.outbox[0].signature3 = context.inbox[0].signature2; // s7
+    },
+    Opcode.IO_SEND
+  ],
+
+  2: [
+    proposeStateTransition3,
+
+    // Sign two commitments
+    Opcode.OP_SIGN,
+
+    // M3
+    (message: ProtocolMessage, context: Context) => {
+      const params2 = message.params as InstallVirtualAppParams;
+      context.outbox[0] = message;
+      context.outbox[0].seq = 3;
+      context.outbox[0].fromAddress = params2.respondingAddress;
+      context.outbox[0].toAddress = params2.intermediaryAddress;
+      context.outbox[0].signature = context.signature; // s4
+      context.outbox[0].signature2 = context.signature2; // s7
     },
 
     Opcode.IO_SEND,
 
-    // wait for the install countersign
-    Opcode.IO_WAIT,
-
-    () => {}
-
-    // // send the self-remove
-    // Opcode.IO_SEND,
-    // Opcode.IO_SEND
-  ],
-
-  2: [
-    (
-      message: ProtocolMessage,
-      context: Context,
-      stateChannel: StateChannel
-    ) => {
-      context.outbox.push(message);
-      context.outbox[0].seq = 3;
-      // context.outbox[0].fromAddress = message.data.responding;
-      // context.outbox[0].toAddress = message.data.intermediary;
-    },
-
-    Opcode.IO_SEND
-
-    // // wait for self-remove
-    // Opcode.IO_WAIT
+    // wait for M4
+    Opcode.IO_WAIT
   ]
 };
+
+function proposeStateTransition3(message: ProtocolMessage, context: Context) {
+  const {
+    signingKeys,
+    defaultTimeout,
+    appInterface,
+    initialState,
+    aliceBalanceDecrement,
+    bobBalanceDecrement,
+    terms,
+    multisig2Address
+  } = message.params as InstallVirtualAppParams;
+  const targetAppInstance = new AppInstance(
+    "0x00",
+    signingKeys,
+    defaultTimeout,
+    appInterface,
+    {
+      assetType: 0,
+      limit: new BigNumber(0),
+      token: ""
+    },
+    // KEY: Sets it to be a virtual app
+    true,
+    // KEY: The app sequence number
+    // TODO: Should validate that the proposed app sequence number is also
+    //       the computed value here and is ALSO still the number compute
+    //       inside the installApp function below
+    0, // virtual app instances do not have appSeqNo
+    0, // or rootNonceValue
+    initialState,
+    // KEY: Set the app nonce to be 0
+    0,
+    defaultTimeout
+  );
+  context.targetVirtualAppInstance = targetAppInstance;
+
+  const rightEthVirtualAppAgreementInstance = new ETHVirtualAppAgreementInstance(
+    context.stateChannel.get(multisig2Address)!.multisigAddress,
+    terms,
+    context.stateChannel.get(multisig2Address)!.numInstalledApps + 1,
+    context.stateChannel.get(multisig2Address)!.rootNonceValue,
+    100,
+    aliceBalanceDecrement.add(bobBalanceDecrement).toNumber()
+  );
+
+  const newStateChannel = context.stateChannel
+    .get(multisig2Address)!
+    .installETHVirtualAppAgreementInstance(
+      rightEthVirtualAppAgreementInstance,
+      aliceBalanceDecrement,
+      bobBalanceDecrement
+    );
+  context.stateChannel.set(multisig2Address, newStateChannel);
+
+  // s4
+  context.commitment = constructETHVirtualAppAgreementCommitment(
+    context.network,
+    newStateChannel,
+    targetAppInstance.identityHash,
+    rightEthVirtualAppAgreementInstance
+  );
+
+  // s7
+  context.commitment2 = new VirtualAppSetStateCommitment(
+    context.network,
+    targetAppInstance.identity,
+    NONCE_EXPIRY,
+    targetAppInstance.defaultTimeout,
+    targetAppInstance.hashOfLatestState,
+    0
+  );
+}
+
+function proposeStateTransition1(message: ProtocolMessage, context: Context) {
+  const {
+    signingKeys,
+    defaultTimeout,
+    appInterface,
+    initialState,
+    aliceBalanceDecrement,
+    bobBalanceDecrement,
+    terms,
+    multisig1Address
+  } = message.params as InstallVirtualAppParams;
+
+  const targetAppInstance = new AppInstance(
+    "0x00",
+    signingKeys,
+    defaultTimeout,
+    appInterface,
+    {
+      assetType: 0,
+      limit: new BigNumber(0),
+      token: ""
+    },
+    // KEY: Sets it to be a virtual app
+    true,
+    // KEY: The app sequence number
+    // TODO: Should validate that the proposed app sequence number is also
+    //       the computed value here and is ALSO still the number compute
+    //       inside the installApp function below
+    0, // virtual app instances do not have appSeqNo
+    0, // or rootNonceValue
+    initialState,
+    // KEY: Set the app nonce to be 0
+    0,
+    defaultTimeout
+  );
+  context.targetVirtualAppInstance = targetAppInstance;
+
+  const leftETHVirtualAppAgreementInstance = new ETHVirtualAppAgreementInstance(
+    context.stateChannel.get(multisig1Address)!.multisigAddress,
+    terms,
+    context.stateChannel.get(multisig1Address)!.numInstalledApps + 1,
+    context.stateChannel.get(multisig1Address)!.rootNonceValue,
+    100,
+    aliceBalanceDecrement.add(bobBalanceDecrement).toNumber()
+  );
+
+  const newStateChannel = context.stateChannel
+    .get(multisig1Address)!
+    .installETHVirtualAppAgreementInstance(
+      leftETHVirtualAppAgreementInstance,
+      aliceBalanceDecrement,
+      bobBalanceDecrement
+    );
+  context.stateChannel.set(multisig1Address, newStateChannel);
+
+  context.commitment = constructETHVirtualAppAgreementCommitment(
+    context.network,
+    newStateChannel,
+    targetAppInstance.identityHash,
+    leftETHVirtualAppAgreementInstance
+  );
+
+  context.commitment2 = new VirtualAppSetStateCommitment(
+    context.network,
+    targetAppInstance.identity,
+    NONCE_EXPIRY,
+    targetAppInstance.defaultTimeout,
+    targetAppInstance.hashOfLatestState,
+    0
+  );
+}
+
+function constructETHVirtualAppAgreementCommitment(
+  network: NetworkContext,
+  stateChannel: StateChannel,
+  targetHash: string,
+  ethVirtualAppAgreementInstance: ETHVirtualAppAgreementInstance
+) {
+  const freeBalance = stateChannel.getFreeBalanceFor(AssetType.ETH);
+
+  return new ETHVirtualAppAgreementCommitment(
+    network,
+    stateChannel.multisigAddress,
+    stateChannel.multisigOwners,
+    targetHash,
+    freeBalance.identity,
+    freeBalance.terms,
+    freeBalance.hashOfLatestState,
+    freeBalance.nonce,
+    freeBalance.timeout,
+    freeBalance.appSeqNo,
+    freeBalance.rootNonceValue,
+    new BigNumber(ethVirtualAppAgreementInstance.expiry),
+    new BigNumber(ethVirtualAppAgreementInstance.capitalProvided),
+    []
+  );
+}
+
+function proposeStateTransition2(message: ProtocolMessage, context: Context) {
+  const {
+    multisig1Address,
+    multisig2Address,
+    signingKeys,
+    defaultTimeout,
+    appInterface,
+    initialState,
+    aliceBalanceDecrement,
+    bobBalanceDecrement,
+    terms
+  } = message.params as InstallVirtualAppParams;
+
+  const targetAppInstance = new AppInstance(
+    "0x00",
+    signingKeys,
+    defaultTimeout,
+    appInterface,
+    {
+      assetType: 0,
+      limit: new BigNumber(0),
+      token: ""
+    },
+    // KEY: Sets it to be a virtual app
+    true,
+    // KEY: The app sequence number
+    // TODO: Should validate that the proposed app sequence number is also
+    //       the computed value here and is ALSO still the number compute
+    //       inside the installApp function below
+    0, // virtual app instances do not have appSeqNo
+    0, // or rootNonceValue
+    initialState,
+    // KEY: Set the app nonce to be 0
+    0,
+    defaultTimeout
+  );
+
+  const leftEthVirtualAppAgreementInstance = new ETHVirtualAppAgreementInstance(
+    context.stateChannel.get(multisig1Address)!.multisigAddress,
+    terms,
+    context.stateChannel.get(multisig1Address)!.numInstalledApps + 1,
+    context.stateChannel.get(multisig1Address)!.rootNonceValue,
+    100,
+    aliceBalanceDecrement.add(bobBalanceDecrement).toNumber()
+  );
+
+  const rightEthVirtualAppAgreementInstance = new ETHVirtualAppAgreementInstance(
+    context.stateChannel.get(multisig2Address)!.multisigAddress,
+    terms,
+    context.stateChannel.get(multisig2Address)!.numInstalledApps + 1,
+    context.stateChannel.get(multisig2Address)!.rootNonceValue,
+    100,
+    aliceBalanceDecrement.add(bobBalanceDecrement).toNumber()
+  );
+
+  // S2
+  context.commitment = constructETHVirtualAppAgreementCommitment(
+    context.network,
+    context.stateChannel.get(multisig1Address)!,
+    targetAppInstance.identityHash,
+    leftEthVirtualAppAgreementInstance
+  );
+
+  // S3
+  context.commitment2 = constructETHVirtualAppAgreementCommitment(
+    context.network,
+    context.stateChannel.get(multisig1Address)!,
+    targetAppInstance.identityHash,
+    rightEthVirtualAppAgreementInstance
+  );
+
+  // S6
+  const newStateChannel1 = context.stateChannel
+    .get(multisig1Address)!
+    .installETHVirtualAppAgreementInstance(
+      leftEthVirtualAppAgreementInstance,
+      aliceBalanceDecrement,
+      bobBalanceDecrement
+    );
+  context.stateChannel.set(multisig1Address, newStateChannel1);
+
+  const newStateChannel2 = context.stateChannel
+    .get(multisig2Address)!
+    .installETHVirtualAppAgreementInstance(
+      leftEthVirtualAppAgreementInstance,
+      aliceBalanceDecrement,
+      bobBalanceDecrement
+    );
+  context.stateChannel.set(multisig2Address, newStateChannel2);
+
+  context.commitment3 = new VirtualAppSetStateCommitment(
+    context.network,
+    targetAppInstance.identity,
+    NONCE_EXPIRY,
+    targetAppInstance.defaultTimeout,
+    "",
+    0
+  );
+}

--- a/packages/machine/src/protocol/install-virtual-app.ts
+++ b/packages/machine/src/protocol/install-virtual-app.ts
@@ -154,22 +154,22 @@ function proposeStateTransition3(message: ProtocolMessage, context: Context) {
   context.targetVirtualAppInstance = targetAppInstance;
 
   const rightEthVirtualAppAgreementInstance = new ETHVirtualAppAgreementInstance(
-    context.stateChannel.get(multisig2Address)!.multisigAddress,
+    context.stateChannelsMap.get(multisig2Address)!.multisigAddress,
     terms,
-    context.stateChannel.get(multisig2Address)!.numInstalledApps + 1,
-    context.stateChannel.get(multisig2Address)!.rootNonceValue,
+    context.stateChannelsMap.get(multisig2Address)!.numInstalledApps + 1,
+    context.stateChannelsMap.get(multisig2Address)!.rootNonceValue,
     100,
     aliceBalanceDecrement.add(bobBalanceDecrement).toNumber()
   );
 
-  const newStateChannel = context.stateChannel
+  const newStateChannel = context.stateChannelsMap
     .get(multisig2Address)!
     .installETHVirtualAppAgreementInstance(
       rightEthVirtualAppAgreementInstance,
       aliceBalanceDecrement,
       bobBalanceDecrement
     );
-  context.stateChannel.set(multisig2Address, newStateChannel);
+  context.stateChannelsMap.set(multisig2Address, newStateChannel);
 
   // s4
   context.commitment = constructETHVirtualAppAgreementCommitment(
@@ -228,22 +228,22 @@ function proposeStateTransition1(message: ProtocolMessage, context: Context) {
   context.targetVirtualAppInstance = targetAppInstance;
 
   const leftETHVirtualAppAgreementInstance = new ETHVirtualAppAgreementInstance(
-    context.stateChannel.get(multisig1Address)!.multisigAddress,
+    context.stateChannelsMap.get(multisig1Address)!.multisigAddress,
     terms,
-    context.stateChannel.get(multisig1Address)!.numInstalledApps + 1,
-    context.stateChannel.get(multisig1Address)!.rootNonceValue,
+    context.stateChannelsMap.get(multisig1Address)!.numInstalledApps + 1,
+    context.stateChannelsMap.get(multisig1Address)!.rootNonceValue,
     100,
     aliceBalanceDecrement.add(bobBalanceDecrement).toNumber()
   );
 
-  const newStateChannel = context.stateChannel
+  const newStateChannel = context.stateChannelsMap
     .get(multisig1Address)!
     .installETHVirtualAppAgreementInstance(
       leftETHVirtualAppAgreementInstance,
       aliceBalanceDecrement,
       bobBalanceDecrement
     );
-  context.stateChannel.set(multisig1Address, newStateChannel);
+  context.stateChannelsMap.set(multisig1Address, newStateChannel);
 
   context.commitment = constructETHVirtualAppAgreementCommitment(
     context.network,
@@ -326,19 +326,19 @@ function proposeStateTransition2(message: ProtocolMessage, context: Context) {
   );
 
   const leftEthVirtualAppAgreementInstance = new ETHVirtualAppAgreementInstance(
-    context.stateChannel.get(multisig1Address)!.multisigAddress,
+    context.stateChannelsMap.get(multisig1Address)!.multisigAddress,
     terms,
-    context.stateChannel.get(multisig1Address)!.numInstalledApps + 1,
-    context.stateChannel.get(multisig1Address)!.rootNonceValue,
+    context.stateChannelsMap.get(multisig1Address)!.numInstalledApps + 1,
+    context.stateChannelsMap.get(multisig1Address)!.rootNonceValue,
     100,
     aliceBalanceDecrement.add(bobBalanceDecrement).toNumber()
   );
 
   const rightEthVirtualAppAgreementInstance = new ETHVirtualAppAgreementInstance(
-    context.stateChannel.get(multisig2Address)!.multisigAddress,
+    context.stateChannelsMap.get(multisig2Address)!.multisigAddress,
     terms,
-    context.stateChannel.get(multisig2Address)!.numInstalledApps + 1,
-    context.stateChannel.get(multisig2Address)!.rootNonceValue,
+    context.stateChannelsMap.get(multisig2Address)!.numInstalledApps + 1,
+    context.stateChannelsMap.get(multisig2Address)!.rootNonceValue,
     100,
     aliceBalanceDecrement.add(bobBalanceDecrement).toNumber()
   );
@@ -346,7 +346,7 @@ function proposeStateTransition2(message: ProtocolMessage, context: Context) {
   // S2
   context.commitment = constructETHVirtualAppAgreementCommitment(
     context.network,
-    context.stateChannel.get(multisig1Address)!,
+    context.stateChannelsMap.get(multisig1Address)!,
     targetAppInstance.identityHash,
     leftEthVirtualAppAgreementInstance
   );
@@ -354,29 +354,29 @@ function proposeStateTransition2(message: ProtocolMessage, context: Context) {
   // S3
   context.commitment2 = constructETHVirtualAppAgreementCommitment(
     context.network,
-    context.stateChannel.get(multisig1Address)!,
+    context.stateChannelsMap.get(multisig1Address)!,
     targetAppInstance.identityHash,
     rightEthVirtualAppAgreementInstance
   );
 
   // S6
-  const newStateChannel1 = context.stateChannel
+  const newStateChannel1 = context.stateChannelsMap
     .get(multisig1Address)!
     .installETHVirtualAppAgreementInstance(
       leftEthVirtualAppAgreementInstance,
       aliceBalanceDecrement,
       bobBalanceDecrement
     );
-  context.stateChannel.set(multisig1Address, newStateChannel1);
+  context.stateChannelsMap.set(multisig1Address, newStateChannel1);
 
-  const newStateChannel2 = context.stateChannel
+  const newStateChannel2 = context.stateChannelsMap
     .get(multisig2Address)!
     .installETHVirtualAppAgreementInstance(
       leftEthVirtualAppAgreementInstance,
       aliceBalanceDecrement,
       bobBalanceDecrement
     );
-  context.stateChannel.set(multisig2Address, newStateChannel2);
+  context.stateChannelsMap.set(multisig2Address, newStateChannel2);
 
   context.commitment3 = new VirtualAppSetStateCommitment(
     context.network,

--- a/packages/machine/src/protocol/install.ts
+++ b/packages/machine/src/protocol/install.ts
@@ -84,24 +84,24 @@ function proposeStateTransition(message: ProtocolMessage, context: Context) {
     // TODO: Should validate that the proposed app sequence number is also
     //       the computed value here and is ALSO still the number compute
     //       inside the installApp function below
-    context.stateChannel.get(multisigAddress)!.numInstalledApps + 1,
-    context.stateChannel.get(multisigAddress)!.rootNonceValue,
+    context.stateChannelsMap.get(multisigAddress)!.numInstalledApps + 1,
+    context.stateChannelsMap.get(multisigAddress)!.rootNonceValue,
     initialState,
     // KEY: Set the nonce to be 0
     0,
     defaultTimeout
   );
 
-  const newStateChannel = context.stateChannel
+  const newStateChannel = context.stateChannelsMap
     .get(multisigAddress)!
     .installApp(appInstance, aliceBalanceDecrement, bobBalanceDecrement);
-  context.stateChannel.set(multisigAddress, newStateChannel);
+  context.stateChannelsMap.set(multisigAddress, newStateChannel);
 
   const appIdentityHash = appInstance.identityHash;
 
   context.commitment = constructInstallOp(
     context.network,
-    context.stateChannel.get(multisigAddress)!,
+    context.stateChannelsMap.get(multisigAddress)!,
     appIdentityHash
   );
 

--- a/packages/machine/src/protocol/setup.ts
+++ b/packages/machine/src/protocol/setup.ts
@@ -62,13 +62,13 @@ export const SETUP_PROTOCOL = {
 
 function proposeStateTransition(message: ProtocolMessage, context: Context) {
   const { multisigAddress } = message.params as SetupParams;
-  const sc = context.stateChannel.get(multisigAddress)!;
+  const sc = context.stateChannelsMap.get(multisigAddress)!;
   if (sc === undefined) {
-    console.log("sc keys=", context.stateChannel.keys());
+    console.log("sc keys=", context.stateChannelsMap.keys());
     throw Error(`no such channel at multisig address ${multisigAddress}`);
   }
   const newStateChannel = sc.setupChannel(context.network);
-  context.stateChannel.set(multisigAddress, newStateChannel);
+  context.stateChannelsMap.set(multisigAddress, newStateChannel);
   context.commitment = constructSetupOp(context.network, newStateChannel);
 }
 

--- a/packages/machine/src/protocol/uninstall.ts
+++ b/packages/machine/src/protocol/uninstall.ts
@@ -72,10 +72,10 @@ function proposeStateTransition(message: ProtocolMessage, context: Context) {
     multisigAddress
   } = message.params as UninstallParams;
 
-  const newStateChannel = context.stateChannel
+  const newStateChannel = context.stateChannelsMap
     .get(multisigAddress)!
     .uninstallApp(appIdentityHash, aliceBalanceIncrement, bobBalanceIncrement);
-  context.stateChannel.set!(multisigAddress, newStateChannel);
+  context.stateChannelsMap.set!(multisigAddress, newStateChannel);
 
   context.commitment = constructUninstallOp(
     context.network,

--- a/packages/machine/src/protocol/uninstall.ts
+++ b/packages/machine/src/protocol/uninstall.ts
@@ -64,26 +64,22 @@ export const UNINSTALL_PROTOCOL = {
   ]
 };
 
-function proposeStateTransition(
-  message: ProtocolMessage,
-  context: Context,
-  stateChannel: StateChannel
-) {
+function proposeStateTransition(message: ProtocolMessage, context: Context) {
   const {
     appIdentityHash,
     aliceBalanceIncrement,
-    bobBalanceIncrement
+    bobBalanceIncrement,
+    multisigAddress
   } = message.params as UninstallParams;
 
-  context.stateChannel = stateChannel.uninstallApp(
-    appIdentityHash,
-    aliceBalanceIncrement,
-    bobBalanceIncrement
-  );
+  const newStateChannel = context.stateChannel
+    .get(multisigAddress)!
+    .uninstallApp(appIdentityHash, aliceBalanceIncrement, bobBalanceIncrement);
+  context.stateChannel.set!(multisigAddress, newStateChannel);
 
   context.commitment = constructUninstallOp(
     context.network,
-    context.stateChannel,
+    newStateChannel,
     appIdentityHash
   );
 

--- a/packages/machine/src/protocol/update.ts
+++ b/packages/machine/src/protocol/update.ts
@@ -66,10 +66,10 @@ function proposeStateTransition(message: ProtocolMessage, context: Context) {
     newState,
     multisigAddress
   } = message.params as UpdateParams;
-  const newStateChannel = context.stateChannel
+  const newStateChannel = context.stateChannelsMap
     .get(multisigAddress)!
     .setState(appIdentityHash, newState);
-  context.stateChannel.set(multisigAddress, newStateChannel);
+  context.stateChannelsMap.set(multisigAddress, newStateChannel);
   context.commitment = constructUpdateOp(
     context.network,
     newStateChannel,

--- a/packages/machine/src/protocol/update.ts
+++ b/packages/machine/src/protocol/update.ts
@@ -60,22 +60,25 @@ export const UPDATE_PROTOCOL = {
   ]
 };
 
-function proposeStateTransition(
-  message: ProtocolMessage,
-  context: Context,
-  stateChannel: StateChannel
-) {
-  const { appIdentityHash, newState } = message.params as UpdateParams;
-  context.stateChannel = stateChannel.setState(appIdentityHash, newState);
+function proposeStateTransition(message: ProtocolMessage, context: Context) {
+  const {
+    appIdentityHash,
+    newState,
+    multisigAddress
+  } = message.params as UpdateParams;
+  const newStateChannel = context.stateChannel
+    .get(multisigAddress)!
+    .setState(appIdentityHash, newState);
+  context.stateChannel.set(multisigAddress, newStateChannel);
   context.commitment = constructUpdateOp(
     context.network,
-    context.stateChannel,
+    newStateChannel,
     appIdentityHash
   );
   context.appIdentityHash = appIdentityHash;
 }
 
-export function constructUpdateOp(
+function constructUpdateOp(
   network: NetworkContext,
   stateChannel: StateChannel,
   appIdentityHash: string

--- a/packages/machine/src/protocol/utils/signature-forwarder.ts
+++ b/packages/machine/src/protocol/utils/signature-forwarder.ts
@@ -1,11 +1,9 @@
-import { StateChannel } from "../../models";
 import { ProtocolMessage } from "../../protocol-types-tbd";
 import { Context } from "../../types";
 
 export function prepareToSendSignature(
   message: ProtocolMessage,
-  context: Context,
-  stateChannel: StateChannel
+  context: Context
 ) {
   context.outbox.push({
     ...message,

--- a/packages/machine/src/types.ts
+++ b/packages/machine/src/types.ts
@@ -3,7 +3,7 @@ import { Signature } from "ethers/utils";
 
 import { Transaction } from "./ethereum/types";
 import { EthereumCommitment } from "./ethereum/utils";
-import { StateChannel } from "./models";
+import { AppInstance, StateChannel } from "./models";
 import { Opcode } from "./opcodes";
 import { ProtocolMessage } from "./protocol-types-tbd";
 
@@ -25,14 +25,25 @@ export type Middleware = {
 
 export type Instruction = Function | Opcode;
 
+/// TODO(ldct): the following fields are hacked in to make install-virtual-app work:
+/// - commitment2, signature2: the intermediary needs to generate three signatures:
+///   two sigs authorizing ETHVirtualAppAgreements, and one authorizing virtualAppSetState.
+/// - targetVirtualAppInstance: this is a state modification that should be returned to called, but the current
+///   mechanism for returning stuff like this is to modify the `statechannel` parameter. But this parameter
+///   is already used for the ledger channel (we write the ETHVirtualAppAgreement instance into it).
 export interface Context {
   network: NetworkContext;
   outbox: ProtocolMessage[];
   inbox: ProtocolMessage[];
-  stateChannel: StateChannel;
+  stateChannel: Map<string, StateChannel>;
   commitment?: EthereumCommitment;
+  commitment2?: EthereumCommitment;
+  commitment3?: EthereumCommitment;
   signature?: Signature;
   appIdentityHash?: string;
+  signature2?: Signature;
+  signature3?: Signature;
+  targetVirtualAppInstance?: AppInstance;
 }
 
 export { ProtocolMessage, Opcode, Transaction };

--- a/packages/machine/src/types.ts
+++ b/packages/machine/src/types.ts
@@ -25,7 +25,7 @@ export type Middleware = {
 
 export type Instruction = Function | Opcode;
 
-/// TODO(ldct): the following fields are hacked in to make install-virtual-app work:
+/// TODO(xuanji): the following fields are hacked in to make install-virtual-app work:
 /// - commitment2, signature2: the intermediary needs to generate three signatures:
 ///   two sigs authorizing ETHVirtualAppAgreements, and one authorizing virtualAppSetState.
 /// - targetVirtualAppInstance: this is a state modification that should be returned to called, but the current
@@ -35,7 +35,7 @@ export interface Context {
   network: NetworkContext;
   outbox: ProtocolMessage[];
   inbox: ProtocolMessage[];
-  stateChannel: Map<string, StateChannel>;
+  stateChannelsMap: Map<string, StateChannel>;
   commitment?: EthereumCommitment;
   commitment2?: EthereumCommitment;
   commitment3?: EthereumCommitment;

--- a/packages/machine/test/integration/install-then-set-state.spec.ts
+++ b/packages/machine/test/integration/install-then-set-state.spec.ts
@@ -9,7 +9,7 @@ import { AssetType, NetworkContext } from "@counterfactual/types";
 import { Contract, Wallet } from "ethers";
 import { AddressZero, WeiPerEther, Zero } from "ethers/constants";
 import { JsonRpcProvider } from "ethers/providers";
-import { Interface, parseEther } from "ethers/utils";
+import { Interface, keccak256, parseEther } from "ethers/utils";
 import { BuildArtifact } from "truffle";
 
 import { InstallCommitment, SetStateCommitment } from "../../src/ethereum";
@@ -138,7 +138,7 @@ describe("Scenario: install AppInstance, set state, put on-chain", () => {
       const setStateCommitment = new SetStateCommitment(
         network,
         appInstance.identity,
-        appInstance.encodedLatestState,
+        keccak256(appInstance.encodedLatestState),
         appInstance.nonce + 1,
         appInstance.timeout
       );

--- a/packages/machine/test/integration/setup-then-set-state.spec.ts
+++ b/packages/machine/test/integration/setup-then-set-state.spec.ts
@@ -8,7 +8,7 @@ import { AssetType, NetworkContext } from "@counterfactual/types";
 import { Contract, Wallet } from "ethers";
 import { AddressZero, WeiPerEther, Zero } from "ethers/constants";
 import { JsonRpcProvider } from "ethers/providers";
-import { Interface } from "ethers/utils";
+import { Interface, keccak256 } from "ethers/utils";
 import { BuildArtifact } from "truffle";
 
 import { SetStateCommitment, SetupCommitment } from "../../src/ethereum";
@@ -105,7 +105,7 @@ describe("Scenario: Setup, set state on free balance, go on chain", () => {
       const setStateCommitment = new SetStateCommitment(
         network,
         freeBalanceETH.identity,
-        freeBalanceETH.encodedLatestState,
+        keccak256(freeBalanceETH.encodedLatestState),
         freeBalanceETH.nonce,
         freeBalanceETH.timeout
       );

--- a/packages/machine/test/mocks.ts
+++ b/packages/machine/test/mocks.ts
@@ -9,6 +9,7 @@ export function generateRandomNetworkContext(): NetworkContext {
     MultiSend: getAddress(hexlify(randomBytes(20))),
     NonceRegistry: getAddress(hexlify(randomBytes(20))),
     AppRegistry: getAddress(hexlify(randomBytes(20))),
-    ETHBalanceRefund: getAddress(hexlify(randomBytes(20)))
+    ETHBalanceRefund: getAddress(hexlify(randomBytes(20))),
+    ETHVirtualAppAgreement: getAddress(hexlify(randomBytes(20)))
   };
 }

--- a/packages/machine/test/unit/ethereum/set-state-commitment.spec.ts
+++ b/packages/machine/test/unit/ethereum/set-state-commitment.spec.ts
@@ -59,7 +59,7 @@ describe("Set State Commitment", () => {
     commitment = new SetStateCommitment(
       networkContext,
       appInstance.identity,
-      appInstance.encodedLatestState,
+      keccak256(appInstance.encodedLatestState),
       appInstance.nonce,
       appInstance.timeout
     );

--- a/packages/machine/test/unit/instruction-executor.spec.ts
+++ b/packages/machine/test/unit/instruction-executor.spec.ts
@@ -50,15 +50,25 @@ describe("InstructionExecutor", () => {
     let fb: AppInstance;
 
     beforeAll(() => {
+      // extract the commitment passed to the OP_SIGN middleware for testing
+      // purposes
       instructionExecutor.middlewares.add(
         Opcode.OP_SIGN,
         (_, __, context: Context) => {
           commitment = context.commitment as SetupCommitment;
-          stateChannelAfterSetup = context.stateChannel;
+          stateChannelAfterSetup = context.stateChannel.get("0x00")!;
         }
       );
 
-      instructionExecutor.runSetupProtocol(stateChannelBeforeSetup);
+      const scm = new Map<string, StateChannel>([
+        ["0x00", stateChannelBeforeSetup]
+      ]);
+
+      instructionExecutor.runSetupProtocol(scm, {
+        initiatingAddress: "0x00",
+        respondingAddress: "0x00",
+        multisigAddress: "0x00"
+      });
 
       fb = stateChannelAfterSetup.getFreeBalanceFor(AssetType.ETH);
     });

--- a/packages/machine/test/unit/instruction-executor.spec.ts
+++ b/packages/machine/test/unit/instruction-executor.spec.ts
@@ -56,7 +56,7 @@ describe("InstructionExecutor", () => {
         Opcode.OP_SIGN,
         (_, __, context: Context) => {
           commitment = context.commitment as SetupCommitment;
-          stateChannelAfterSetup = context.stateChannel.get("0x00")!;
+          stateChannelAfterSetup = context.stateChannelsMap.get("0x00")!;
         }
       );
 

--- a/packages/node/src/request-handler.ts
+++ b/packages/node/src/request-handler.ts
@@ -113,8 +113,9 @@ export class RequestHandler {
         ]);
         const { protocol } = message;
         if (protocol === Protocol.Setup) {
+          const params = message.params as SetupParams;
           await this.store.setSetupCommitmentForMultisig(
-            message.multisigAddress,
+            params.multisigAddress,
             transaction
           );
         } else {

--- a/packages/node/src/request-handler.ts
+++ b/packages/node/src/request-handler.ts
@@ -5,6 +5,7 @@ import {
   Protocol,
   ProtocolMessage
 } from "@counterfactual/machine";
+import { SetupParams } from "@counterfactual/machine/dist/src/protocol-types-tbd";
 import { Address, NetworkContext, Node } from "@counterfactual/types";
 import EventEmitter from "eventemitter3";
 
@@ -14,7 +15,6 @@ import { addMultisig } from "./methods/multisig-operations";
 import { NodeMessage } from "./node";
 import { IMessagingService, IStoreService } from "./services";
 import { Store } from "./store";
-import { SetupParams } from "@counterfactual/machine/dist/src/protocol-types-tbd";
 
 /**
  * This class registers handlers for requests to get or set some information

--- a/packages/node/src/request-handler.ts
+++ b/packages/node/src/request-handler.ts
@@ -14,6 +14,7 @@ import { addMultisig } from "./methods/multisig-operations";
 import { NodeMessage } from "./node";
 import { IMessagingService, IStoreService } from "./services";
 import { Store } from "./store";
+import { SetupParams } from "@counterfactual/machine/dist/src/protocol-types-tbd";
 
 /**
  * This class registers handlers for requests to get or set some information

--- a/packages/node/test/integration/utils.ts
+++ b/packages/node/test/integration/utils.ts
@@ -169,7 +169,8 @@ export const EMPTY_NETWORK: NetworkContext = {
   ETHBucket: AddressZero,
   MultiSend: AddressZero,
   NonceRegistry: AddressZero,
-  StateChannelTransaction: AddressZero
+  StateChannelTransaction: AddressZero,
+  ETHVirtualAppAgreement: AddressZero
 };
 
 export function generateGetStateRequest(

--- a/packages/playground-server/src/node.ts
+++ b/packages/playground-server/src/node.ts
@@ -28,7 +28,8 @@ const node = new Node(
     ETHBucket: AddressZero,
     MultiSend: AddressZero,
     NonceRegistry: AddressZero,
-    StateChannelTransaction: AddressZero
+    StateChannelTransaction: AddressZero,
+    ETHVirtualAppAgreement: AddressZero
   },
   {
     STORE_KEY_PREFIX: "store"

--- a/packages/playground/src/components/node-listener/node-listener.tsx
+++ b/packages/playground/src/components/node-listener/node-listener.tsx
@@ -79,7 +79,8 @@ export class NodeListener {
       ETHBucket: addressZero,
       MultiSend: addressZero,
       NonceRegistry: addressZero,
-      StateChannelTransaction: addressZero
+      StateChannelTransaction: addressZero,
+      ETHVirtualAppAgreement: addressZero
     };
 
     CounterfactualNode.create({

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -29,6 +29,7 @@ export interface NetworkContext {
   MultiSend: string;
   NonceRegistry: string;
   StateChannelTransaction: string;
+  ETHVirtualAppAgreement: string;
 }
 
 export {


### PR DESCRIPTION
This PR adds commitments and protocol steps for the install-virtual-app protocol.

- adds `MixinVirtualAppSetState.sol`, adding a method `virtualAppSetState ` to the app registry that is similar to `setState`. The only difference is that the first signature, instead of signing something that allows the app state to be set to a particular value and version number, signs something that allows it to be set to anything as long as the version number is below a certain value (chosen as `65536` in the client-side code). This means that non-intermediary participants can set the app version number ("nonce") to values in the range `0, 1, ... 65536` without interacting with the intermediary, and that when it comes time to uninstall a virtual app, all participants (including the intermediary) can sign an update at version number `65537` which supercedes all previous updates
- adds `ETHVirtualAppAgreementCommitment`, an `EthereumCommitment` representing commitments to call the `ETHVirtualAppAgreement::delegateTarget` function
- adds `VirtualAppSetStateCommitment`, an `EthereumCommitment` representing commitments to call the `virtualAppSetState` function on the app registry
- adds a field `ETHVirtualAppAgreementCommitmentInstances` to the state channel model (and to firebase), mirroring the `appInstances` field

## generalizations made that affect other protocols

- `context.stateChannel` is gone, since the intermediary deals with 2 or 3 `StateChannel` instances (called the "left channel" and the "right channel"). It is replaced by a `Map<string, StateChannel>` with keys being the multisig address of a channel. This matches the way the node stores `StateChannel` instances in memory
- `ProtocolMessage.multisigAddress` is gone, for the same reason. multisig addresses have been folded into the various `<ProtocolName>Param` types. Notably, the `InstallVirtualAppParams` type has two multisig address fields

## API hacks

I changed some APIs in a very hacky way to get this working. The reason they needed changing is similar in kind to the reason the changes in the above section were made. Care needs to be taken to properly plan a good API.

- `EthereumCommitment::hashToSign()` can no longer return a single hash, since the hash that the intermediary signs is different from the one the other participants sign. The hacky solution was to pass an optional `signerIsIntermediary` flag that is only used by the install-virtual-app protocol. Obviously this is extremely ugly.
- Similarly, `EthereumCommitment:: transaction` takes an optional `intermediarySignature` field, since the intermediary signature must be placed at the front of the signatures bytestring
- the fields `{commitment, signature}{2, 3}` were added to instruction executor `Context` since the intermediary generates and signs 3 commitments
- `signature{2, 3}` was added to `ProtocolMessage` since messages contain up to 3 signatures. Note that some of these signatures are copied from other messages (i.e., the message sender "forwards" a signature they receive).
- A `VirtualAppSetStateCommitment` commitment takes two optional parameters, `hashedAppState` and `appLocalNonce`. This is because the current `EthereumCommitment` ties the concept of a "thing to sign" and a "transaction that can be done" into one obejct (these optional parameters are needed for the "transaction that can be done" but not the "thing that the intermediary needs to sign". Note, they are part of the "thing that the non-intermediary parties need to sign".) 

## other todo items

note: some of these could be done in a PR after this one as they are not technically required for the install-virtual-app protocol to work

- make `ETHVirtualAppAgreement.sol` cancellable
- bignumberify the fields `expiry` and `capitalProvided` of `ETHVirtualAppAgreementInstance` (note: this is nontrivial as these fields go into firebase, so we need to convert bignumbers to/from JSON)
- change the in-firebase representations of `appInstances` and `ETHVirtualAppAgreementInstances`; they should probably be javascript objects instead of arrays of key-value pairs
- place the target virtual app into a `StateChannel` instance; generally hook everything up so that the installation of a virtual app is writteable into firebase under some key. note that we cannot use "multisig" as the key anymore since there is no on-chain multisig.

