### PR TITLE
[machine] Opcode, middleware cleanup

### DIFF
--- a/packages/machine/src/instruction-executor.ts
+++ b/packages/machine/src/instruction-executor.ts
@@ -11,12 +11,7 @@ import {
   UninstallParams,
   UpdateParams
 } from "./protocol-types-tbd";
-import {
-  Context,
-  Instruction,
-  Middleware,
-  Protocol
-} from "./types";
+import { Context, Instruction, Middleware, Protocol } from "./types";
 
 function genericProtocolMessageFields(sc: StateChannel) {
   return {

--- a/packages/machine/src/instruction-executor.ts
+++ b/packages/machine/src/instruction-executor.ts
@@ -25,14 +25,14 @@ function genericProtocolMessageFields(sc: StateChannel) {
 }
 
 export class InstructionExecutor {
-  public middleware: MiddlewareContainer;
+  public middlewares: MiddlewareContainer;
 
   constructor(public readonly network: NetworkContext) {
-    this.middleware = new MiddlewareContainer();
+    this.middlewares = new MiddlewareContainer();
   }
 
   public register(scope: Opcode, method: Middleware) {
-    this.middleware.add(scope, method);
+    this.middlewares.add(scope, method);
   }
 
   public async dispatchReceivedMessage(msg: ProtocolMessage, sc: StateChannel) {
@@ -117,7 +117,7 @@ export class InstructionExecutor {
           // TODO: it might be possible to not have to pass in sc
           instruction.call(null, msg, context, sc);
         } else {
-          await this.middleware.run(msg, instruction, context);
+          await this.middlewares.run(msg, instruction, context);
         }
         instructionPointer += 1;
       } catch (e) {

--- a/packages/machine/src/instruction-executor.ts
+++ b/packages/machine/src/instruction-executor.ts
@@ -1,6 +1,6 @@
 import { NetworkContext } from "@counterfactual/types";
 
-import { Middleware } from "./middleware";
+import { MiddlewareContainer } from "./middleware";
 import { StateChannel } from "./models";
 import { Opcode } from "./opcodes";
 import { getProtocolFromName } from "./protocol";
@@ -14,7 +14,7 @@ import {
 import {
   Context,
   Instruction,
-  InstructionMiddlewareCallback,
+  Middleware,
   Protocol
 } from "./types";
 
@@ -30,13 +30,13 @@ function genericProtocolMessageFields(sc: StateChannel) {
 }
 
 export class InstructionExecutor {
-  public middleware: Middleware;
+  public middleware: MiddlewareContainer;
 
   constructor(public readonly network: NetworkContext) {
-    this.middleware = new Middleware();
+    this.middleware = new MiddlewareContainer();
   }
 
-  public register(scope: Opcode, method: InstructionMiddlewareCallback) {
+  public register(scope: Opcode, method: Middleware) {
     this.middleware.add(scope, method);
   }
 

--- a/packages/machine/src/middleware.ts
+++ b/packages/machine/src/middleware.ts
@@ -12,7 +12,6 @@ export class MiddlewareContainer {
     [Opcode.OP_SIGN]: [],
     [Opcode.OP_SIGN_VALIDATE]: [],
     [Opcode.STATE_TRANSITION_COMMIT]: [],
-    [Opcode.STATE_TRANSITION_PROPOSE]: []
   };
 
   public add(scope: Opcode, method: Middleware) {

--- a/packages/machine/src/middleware.ts
+++ b/packages/machine/src/middleware.ts
@@ -2,12 +2,11 @@ import { Opcode } from "./opcodes";
 import { ProtocolMessage } from "./protocol-types-tbd";
 import {
   Context,
-  InstructionMiddlewareCallback,
-  InstructionMiddlewares
+  Middleware,
 } from "./types";
 
-export class Middleware {
-  public readonly middlewares: InstructionMiddlewares = {
+export class MiddlewareContainer {
+  public readonly middlewares: { [I in Opcode]: Middleware[] } = {
     [Opcode.IO_SEND]: [],
     [Opcode.IO_WAIT]: [],
     [Opcode.OP_SIGN]: [],
@@ -16,8 +15,8 @@ export class Middleware {
     [Opcode.STATE_TRANSITION_PROPOSE]: []
   };
 
-  public add(scope: Opcode, method: InstructionMiddlewareCallback) {
-    this.middlewares[scope].push({ scope, method });
+  public add(scope: Opcode, method: Middleware) {
+    this.middlewares[scope].push(method);
   }
 
   public async run(msg: ProtocolMessage, opCode: Opcode, context: Context) {
@@ -34,7 +33,7 @@ export class Middleware {
 
       const middleware = middlewares[opCode][counter];
 
-      return middleware.method(msg, callback, context);
+      return middleware(msg, callback, context);
     }
 
     const middleware = this.middlewares[opCode][0];
@@ -45,6 +44,6 @@ export class Middleware {
       );
     }
 
-    return middleware.method(msg, callback, context);
+    return middleware(msg, callback, context);
   }
 }

--- a/packages/machine/src/middleware.ts
+++ b/packages/machine/src/middleware.ts
@@ -1,9 +1,6 @@
 import { Opcode } from "./opcodes";
 import { ProtocolMessage } from "./protocol-types-tbd";
-import {
-  Context,
-  Middleware,
-} from "./types";
+import { Context, Middleware } from "./types";
 
 export class MiddlewareContainer {
   public readonly middlewares: { [I in Opcode]: Middleware[] } = {
@@ -11,7 +8,7 @@ export class MiddlewareContainer {
     [Opcode.IO_WAIT]: [],
     [Opcode.OP_SIGN]: [],
     [Opcode.OP_SIGN_VALIDATE]: [],
-    [Opcode.STATE_TRANSITION_COMMIT]: [],
+    [Opcode.STATE_TRANSITION_COMMIT]: []
   };
 
   public add(scope: Opcode, method: Middleware) {

--- a/packages/machine/src/middleware.ts
+++ b/packages/machine/src/middleware.ts
@@ -34,11 +34,7 @@ export class Middleware {
 
       const middleware = middlewares[opCode][counter];
 
-      if (middleware.scope === opCode) {
-        return middleware.method(msg, callback, context);
-      }
-
-      return callback();
+      return middleware.method(msg, callback, context);
     }
 
     const middleware = this.middlewares[opCode][0];

--- a/packages/machine/src/opcodes.ts
+++ b/packages/machine/src/opcodes.ts
@@ -1,12 +1,5 @@
 export enum Opcode {
   /**
-   * Optimistically creates the new state that will result if a protocol
-   * completes. Useful for other opcodes that may need to know about such state,
-   * for example, to generate the correct cf operation.
-   */
-  STATE_TRANSITION_PROPOSE,
-
-  /**
    * Saves the new state upon completion of a protocol, using the state from
    * STATE_TRANSITION_PROPOSE. Assumes all messages have been exchanged and
    * the state has gone through PROPOSE and PREPARE already.

--- a/packages/machine/src/types.ts
+++ b/packages/machine/src/types.ts
@@ -22,7 +22,7 @@ export type InstructionMiddlewareCallback = {
   (message: ProtocolMessage, next: Function, context: Context): void;
 };
 
-export interface InstructionMiddleware {
+interface InstructionMiddleware {
   scope: Opcode;
   method: InstructionMiddlewareCallback;
 }

--- a/packages/machine/src/types.ts
+++ b/packages/machine/src/types.ts
@@ -18,18 +18,11 @@ export type ProtocolExecutionFlow = {
   [x: number]: Instruction[];
 };
 
-export type InstructionMiddlewareCallback = {
+export type Middleware = {
   (message: ProtocolMessage, next: Function, context: Context): void;
 };
 
-interface InstructionMiddleware {
-  scope: Opcode;
-  method: InstructionMiddlewareCallback;
-}
-
 export type Instruction = Function | Opcode;
-
-export type InstructionMiddlewares = { [I in Opcode]: InstructionMiddleware[] };
 
 export interface Context {
   network: NetworkContext;

--- a/packages/machine/test/unit/instruction-executor.spec.ts
+++ b/packages/machine/test/unit/instruction-executor.spec.ts
@@ -48,7 +48,7 @@ describe("InstructionExecutor", () => {
     middleware.add(Opcode.STATE_TRANSITION_COMMIT, () => {});
   });
 
-  describe("the result of STATE_TRANSITION_PROPOSE for the Setup Protocol", () => {
+  describe("the result of proposeStateTransition for the Setup Protocol", () => {
     let commitment: SetupCommitment;
     let channel: StateChannel;
     let fb: AppInstance;

--- a/packages/machine/test/unit/instruction-executor.spec.ts
+++ b/packages/machine/test/unit/instruction-executor.spec.ts
@@ -41,11 +41,11 @@ describe("InstructionExecutor", () => {
     // will fail with an error like "While executing op number <x> at seq
     // <y> of protocol setup, execution failed with the following error.
     // TypeError: Cannot read property 'method' of undefined"
-    const { middleware } = instructionExecutor;
-    middleware.add(Opcode.OP_SIGN_VALIDATE, () => {});
-    middleware.add(Opcode.IO_SEND, () => {});
-    middleware.add(Opcode.IO_WAIT, () => {});
-    middleware.add(Opcode.STATE_TRANSITION_COMMIT, () => {});
+    const { middlewares } = instructionExecutor;
+    middlewares.add(Opcode.OP_SIGN_VALIDATE, () => {});
+    middlewares.add(Opcode.IO_SEND, () => {});
+    middlewares.add(Opcode.IO_WAIT, () => {});
+    middlewares.add(Opcode.STATE_TRANSITION_COMMIT, () => {});
   });
 
   describe("the result of proposeStateTransition for the Setup Protocol", () => {
@@ -54,7 +54,7 @@ describe("InstructionExecutor", () => {
     let fb: AppInstance;
 
     beforeAll(() => {
-      instructionExecutor.middleware.add(
+      instructionExecutor.middlewares.add(
         Opcode.OP_SIGN,
         (_, __, context: Context) => {
           commitment = context.operation as SetupCommitment;


### PR DESCRIPTION
- `Middleware` -> `MiddlewareContainer`
- `InstructionMiddlewareCallback` -> `Middleware`
- all other types deleted / inlined
- scope is now stored only in key
- delete `STATE_TRANSITION_PROPOSE` opcode