### PR TITLE
[dapp-high-roller] Remove old DICE_PATH consts in high roller dapp

### DIFF
--- a/packages/dapp-high-roller/src/components/app-game-player/app-game-player.tsx
+++ b/packages/dapp-high-roller/src/components/app-game-player/app-game-player.tsx
@@ -2,8 +2,6 @@ import { Component, Prop } from "@stencil/core";
 
 import { PlayerType } from "../../enums/enums";
 
-const DICE_PATH = "./assets/images/dice/TYPE/Dice-TYPE-0";
-
 @Component({
   tag: "app-game-player",
   styleUrl: "app-game-player.scss",

--- a/packages/dapp-high-roller/src/components/app-game/app-game.tsx
+++ b/packages/dapp-high-roller/src/components/app-game/app-game.tsx
@@ -3,9 +3,6 @@ import { RouterHistory } from "@stencil/router";
 
 import { GameState, PlayerType } from "../../enums/enums";
 
-const DARK_PATH = "./assets/images/dice/Dark/Dice-Dark-0";
-const LIGHT_PATH = "./assets/images/dice/Light/Dice-Light-0";
-
 // dice sound effect attributions:
 // http://soundbible.com/182-Shake-And-Roll-Dice.html
 // http://soundbible.com/181-Roll-Dice-2.html


### PR DESCRIPTION
### Description

Remove old DICE_PATH consts in high roller dapp

### Related issues

- [ ] Deploy preview is functional
