### PR TITLE
adjust coin size on mobile

### DIFF
--- a/packages/dapp-high-roller/src/components/app-game-coin/app-game-coin.scss
+++ b/packages/dapp-high-roller/src/components/app-game-coin/app-game-coin.scss
@@ -8,3 +8,11 @@
 	from { transform: translateY(-30vh); }
 	to { transform: translateY(130vh); }
 }
+
+
+@media screen and (max-width: 600px) {
+  .coin {
+    height: 66px;
+    width: 66px;
+  }
+}


### PR DESCRIPTION
Halves the coin size on mobile.

![coin fall](https://user-images.githubusercontent.com/2700872/50700730-29de7500-1000-11e9-8bdf-0c8c88792452.gif)
