### PR TITLE
[monorepo] miscellaneous cleanup

### DIFF
--- a/packages/cf.js/src/utils/signature.ts
+++ b/packages/cf.js/src/utils/signature.ts
@@ -7,22 +7,30 @@ import {
 } from "ethers/utils";
 
 export function signaturesToBytes(...signatures: Signature[]): string {
-  const signaturesHexString = signatures
+  return signatures
     .map(joinSignature)
     .map(s => s.substr(2))
-    .join("");
-  return `0x${signaturesHexString}`;
+    .reduce((acc, v) => acc + v, "0x");
 }
 
-export function signaturesToSortedBytes(
-  digest: Bytes32,
-  ...signatures: Signature[]
-): string {
-  const sigs = signatures.slice();
-  sigs.sort((sigA, sigB) => {
+function sortSignaturesBySignerAddress(
+  digest: string,
+  signatures: Signature[]
+): Signature[] {
+  const ret = signatures.slice();
+  ret.sort((sigA, sigB) => {
     const addrA = recoverAddress(digest, signaturesToBytes(sigA));
     const addrB = recoverAddress(digest, signaturesToBytes(sigB));
     return new BigNumber(addrA).lt(addrB) ? -1 : 1;
   });
-  return signaturesToBytes(...sigs);
+  return ret;
+}
+
+export function signaturesToBytesSortedBySignerAddress(
+  digest: Bytes32,
+  ...signatures: Signature[]
+): string {
+  return signaturesToBytes(
+    ...sortSignaturesBySignerAddress(digest, signatures)
+  );
 }

--- a/packages/cf.js/test/utils/signature.spec.ts
+++ b/packages/cf.js/test/utils/signature.spec.ts
@@ -1,6 +1,9 @@
 import { keccak256, SigningKey, toUtf8Bytes } from "ethers/utils";
 
-import { signaturesToBytes, signaturesToSortedBytes } from "../../src/utils";
+import {
+  signaturesToBytes,
+  signaturesToBytesSortedBySignerAddress
+} from "../../src/utils";
 
 const privateKey =
   "0x0123456789012345678901234567890123456789012345678901234567890123";
@@ -27,7 +30,9 @@ describe("Utils / signature", async () => {
   });
 
   it("can convert signatures to sorted bytes", () => {
-    expect(signaturesToSortedBytes(digests[0], ...signatures)).toEqual(
+    expect(
+      signaturesToBytesSortedBySignerAddress(digests[0], ...signatures)
+    ).toEqual(
       "0x60bd9ccc9dc25ec2d7277ff67da3452d7c8ccf8eb766fffa469f223519ad794e6725f4251f6f51953a0682fe935a1cc075f8c79114cbbc472bda7a009aa9c24a1be8a215dbd1bdee474c9ac2877644cc90006a8634cf3d0ef3645475f8933f871929b3cf1ed0ac9f6cfb5005c67a5fad6838e77da00a5c081c40b894b9cb3c6a5e1c1682d103015d56a15e5bb1901c8fced10291e6cffcab7f580a628337943a760b2bb85c1b9b961c4e01512ac13791d6b28a1bbf8bb7d787b23bda20fc981225131c"
     );
   });

--- a/packages/machine/src/ethereum/multisend-commitment.ts
+++ b/packages/machine/src/ethereum/multisend-commitment.ts
@@ -4,14 +4,14 @@ import { AppIdentity, Terms } from "@counterfactual/types";
 import { HashZero } from "ethers/constants";
 import { Interface } from "ethers/utils";
 
-import { MultisigTransactionCommitment } from "./multisig-commitment";
+import { MultisigCommitment } from "./multisig-commitment";
 import { MultisigOperation, MultisigTransaction } from "./types";
 import { encodeTransactions } from "./utils/multisend-encoder";
 
 const appRegistryIface = new Interface(AppRegistry.abi);
 const multisendIface = new Interface(MultiSend.abi);
 
-export abstract class MultiSendCommitment extends MultisigTransactionCommitment {
+export abstract class MultiSendCommitment extends MultisigCommitment {
   public abstract eachMultisigInput(): MultisigTransaction[];
 
   constructor(

--- a/packages/machine/src/ethereum/multisig-commitment.ts
+++ b/packages/machine/src/ethereum/multisig-commitment.ts
@@ -2,9 +2,10 @@ import MinimumViableMultisig from "@counterfactual/contracts/build/contracts/Min
 import { Interface, keccak256, Signature, solidityPack } from "ethers/utils";
 
 import { EthereumCommitment, MultisigTransaction, Transaction } from "./types";
-import { signaturesToSortedBytes } from "./utils/signature";
+import { signaturesToBytesSortedBySignerAddress } from "./utils/signature";
 
-export abstract class MultisigTransactionCommitment extends EthereumCommitment {
+/// A commitment to make MinimumViableMultisig perform a message call
+export abstract class MultisigCommitment extends EthereumCommitment {
   constructor(
     readonly multisigAddress: string,
     readonly multisigOwners: string[]
@@ -17,7 +18,10 @@ export abstract class MultisigTransactionCommitment extends EthereumCommitment {
   public transaction(sigs: Signature[]): Transaction {
     const multisigInput = this.getTransactionDetails();
 
-    const signatureBytes = signaturesToSortedBytes(this.hashToSign(), ...sigs);
+    const signatureBytes = signaturesToBytesSortedBySignerAddress(
+      this.hashToSign(),
+      ...sigs
+    );
 
     const txData = new Interface(
       MinimumViableMultisig.abi

--- a/packages/machine/src/ethereum/set-state-commitment.ts
+++ b/packages/machine/src/ethereum/set-state-commitment.ts
@@ -8,7 +8,7 @@ import { Interface, keccak256, Signature, solidityPack } from "ethers/utils";
 
 import { EthereumCommitment, Transaction } from "./types";
 import { appIdentityToHash } from "./utils/app-identity";
-import { signaturesToSortedBytes } from "./utils/signature";
+import { signaturesToBytesSortedBySignerAddress } from "./utils/signature";
 
 const iface = new Interface(AppRegistry.abi);
 
@@ -56,7 +56,10 @@ export class SetStateCommitment extends EthereumCommitment {
       stateHash: keccak256(this.encodedAppState),
       nonce: this.appLocalNonce,
       timeout: this.timeout,
-      signatures: signaturesToSortedBytes(this.hashToSign(), ...signatures)
+      signatures: signaturesToBytesSortedBySignerAddress(
+        this.hashToSign(),
+        ...signatures
+      )
     };
   }
 }

--- a/packages/machine/src/ethereum/setup-commitment.ts
+++ b/packages/machine/src/ethereum/setup-commitment.ts
@@ -9,13 +9,13 @@ import {
 
 import { DependencyValue } from "../models/app-instance";
 
-import { MultisigTransactionCommitment } from "./multisig-commitment";
+import { MultisigCommitment } from "./multisig-commitment";
 import { MultisigOperation, MultisigTransaction } from "./types";
 import { appIdentityToHash } from "./utils/app-identity";
 
 const iface = new Interface(StateChannelTransaction.abi);
 
-export class SetupCommitment extends MultisigTransactionCommitment {
+export class SetupCommitment extends MultisigCommitment {
   public constructor(
     public readonly networkContext: NetworkContext,
     public readonly multisigAddress: string,

--- a/packages/machine/src/ethereum/utils/signature.ts
+++ b/packages/machine/src/ethereum/utils/signature.ts
@@ -12,15 +12,24 @@ export function signaturesToBytes(...signatures: Signature[]): string {
     .reduce((acc, v) => acc + v, "0x");
 }
 
-export function signaturesToSortedBytes(
+function sortSignaturesBySignerAddress(
   digest: string,
-  ...signatures: Signature[]
-): string {
-  const sigs = signatures.slice();
-  sigs.sort((sigA, sigB) => {
+  signatures: Signature[]
+): Signature[] {
+  const ret = signatures.slice();
+  ret.sort((sigA, sigB) => {
     const addrA = recoverAddress(digest, signaturesToBytes(sigA));
     const addrB = recoverAddress(digest, signaturesToBytes(sigB));
     return new BigNumber(addrA).lt(addrB) ? -1 : 1;
   });
-  return signaturesToBytes(...sigs);
+  return ret;
+}
+
+export function signaturesToBytesSortedBySignerAddress(
+  digest: string,
+  ...signatures: Signature[]
+): string {
+  return signaturesToBytes(
+    ...sortSignaturesBySignerAddress(digest, signatures)
+  );
 }

--- a/packages/machine/src/instruction-executor.ts
+++ b/packages/machine/src/instruction-executor.ts
@@ -104,7 +104,7 @@ export class InstructionExecutor {
       outbox: [],
       inbox: [],
       stateChannel: sc,
-      operation: undefined,
+      commitment: undefined,
       signature: undefined
     };
 

--- a/packages/machine/src/opcodes.ts
+++ b/packages/machine/src/opcodes.ts
@@ -1,8 +1,6 @@
 export enum Opcode {
   /**
-   * Saves the new state upon completion of a protocol, using the state from
-   * STATE_TRANSITION_PROPOSE. Assumes all messages have been exchanged and
-   * the state has gone through PROPOSE and PREPARE already.
+   * Currently unused.
    */
   STATE_TRANSITION_COMMIT,
 
@@ -12,8 +10,8 @@ export enum Opcode {
   OP_SIGN,
 
   /**
-   * Ensures a signature is both correclty signed and is representative of a
-   * correctly formed cf operation.
+   * todo(ldct): replace all occurrences of this by javascript code that does
+   * some actual ecrecover and validation work
    */
   OP_SIGN_VALIDATE,
 

--- a/packages/machine/src/protocol-types-tbd.ts
+++ b/packages/machine/src/protocol-types-tbd.ts
@@ -10,8 +10,6 @@ import { Protocol } from "./types";
 // around in protocol messages and include this in transaction data in disputes,
 // we impose some restrictions on the type; they must be serializable both as
 // JSON and as solidity structs.
-// todo(ldct): top-level arrays are probably illegal since they are not
-// structs...
 export type AppState = {
   [x: string]: string | BigNumberish | boolean | AppState | AppStateArray;
 };

--- a/packages/machine/src/protocol/install.ts
+++ b/packages/machine/src/protocol/install.ts
@@ -19,7 +19,7 @@ export const INSTALL_PROTOCOL = {
     // Compute the next state of the channel
     proposeStateTransition,
 
-    // Decide whether or not to sign the transition
+    // Sign `context.commitment.hashToSign`
     Opcode.OP_SIGN,
 
     // Wrap the signature into a message to be sent
@@ -100,14 +100,14 @@ function proposeStateTransition(
     bobBalanceDecrement
   );
 
-  context.operation = constructInstallOp(
+  context.commitment = constructInstallOp(
     context.network,
     context.stateChannel,
     appInstance.identityHash
   );
 }
 
-export function constructInstallOp(
+function constructInstallOp(
   network: NetworkContext,
   stateChannel: StateChannel,
   appIdentityHash: string

--- a/packages/machine/src/protocol/setup.ts
+++ b/packages/machine/src/protocol/setup.ts
@@ -19,7 +19,7 @@ export const SETUP_PROTOCOL = {
     // Compute the next state of the channel
     proposeStateTransition,
 
-    // Decide whether or not to sign the transition
+    // Sign `context.commitment.hashToSign`
     Opcode.OP_SIGN,
 
     // Wrap the signature into a message to be sent
@@ -65,7 +65,7 @@ function proposeStateTransition(
   state: StateChannel
 ) {
   context.stateChannel = state.setupChannel(context.network);
-  context.operation = constructSetupOp(context.network, context.stateChannel);
+  context.commitment = constructSetupOp(context.network, context.stateChannel);
 }
 
 export function constructSetupOp(

--- a/packages/machine/src/protocol/uninstall.ts
+++ b/packages/machine/src/protocol/uninstall.ts
@@ -23,7 +23,7 @@ export const UNINSTALL_PROTOCOL = {
     // Compute the next state of the channel
     proposeStateTransition,
 
-    // Decide whether or not to sign the transition
+    // Sign `context.commitment.hashToSign`
     Opcode.OP_SIGN,
 
     // Wrap the signature into a message to be sent
@@ -80,7 +80,7 @@ function proposeStateTransition(
     bobBalanceIncrement
   );
 
-  context.operation = constructUninstallOp(
+  context.commitment = constructUninstallOp(
     context.network,
     context.stateChannel,
     appIdentityHash

--- a/packages/machine/src/protocol/update.ts
+++ b/packages/machine/src/protocol/update.ts
@@ -19,7 +19,7 @@ export const UPDATE_PROTOCOL = {
     // Compute the next state of the channel
     proposeStateTransition,
 
-    // Decide whether or not to sign the transition
+    // Sign `context.commitment.hashToSign`
     Opcode.OP_SIGN,
 
     // Wrap the signature into a message to be sent
@@ -66,7 +66,7 @@ function proposeStateTransition(
 ) {
   const { appIdentityHash, newState } = message.params as UpdateParams;
   context.stateChannel = state.setState(appIdentityHash, newState);
-  context.operation = constructUpdateOp(
+  context.commitment = constructUpdateOp(
     context.network,
     context.stateChannel,
     appIdentityHash

--- a/packages/machine/src/types.ts
+++ b/packages/machine/src/types.ts
@@ -29,6 +29,6 @@ export interface Context {
   outbox: ProtocolMessage[];
   inbox: ProtocolMessage[];
   stateChannel: StateChannel;
-  operation?: EthereumCommitment;
+  commitment?: EthereumCommitment;
   signature?: Signature;
 }

--- a/packages/machine/test/mocks.ts
+++ b/packages/machine/test/mocks.ts
@@ -1,3 +1,14 @@
-export class MockResponseSink {
-  sendResponse = () => {};
+import { NetworkContext } from "@counterfactual/types";
+import { getAddress, hexlify, randomBytes } from "ethers/utils";
+
+/// todo(ldct): make this random but deterministically generated from some seed
+export function generateRandomNetworkContext(): NetworkContext {
+  return {
+    ETHBucket: getAddress(hexlify(randomBytes(20))),
+    StateChannelTransaction: getAddress(hexlify(randomBytes(20))),
+    MultiSend: getAddress(hexlify(randomBytes(20))),
+    NonceRegistry: getAddress(hexlify(randomBytes(20))),
+    AppRegistry: getAddress(hexlify(randomBytes(20))),
+    ETHBalanceRefund: getAddress(hexlify(randomBytes(20)))
+  };
 }

--- a/packages/machine/test/unit/ethereum/set-state-commitment.spec.ts
+++ b/packages/machine/test/unit/ethereum/set-state-commitment.spec.ts
@@ -1,5 +1,5 @@
 import AppRegistry from "@counterfactual/contracts/build/contracts/AppRegistry.json";
-import { AssetType, NetworkContext } from "@counterfactual/types";
+import { AssetType } from "@counterfactual/types";
 import { AddressZero } from "ethers/constants";
 import {
   bigNumberify,
@@ -16,6 +16,7 @@ import { SetStateCommitment } from "../../../src/ethereum";
 import { Transaction } from "../../../src/ethereum/types";
 import { appIdentityToHash } from "../../../src/ethereum/utils/app-identity";
 import { AppInstance } from "../../../src/models";
+import { generateRandomNetworkContext } from "../../mocks";
 
 /**
  * This test suite decodes a constructed SetState Commitment transaction object
@@ -27,14 +28,7 @@ describe("Set State Commitment", () => {
   let tx: Transaction;
 
   // Dummy network context
-  const networkContext: NetworkContext = {
-    ETHBucket: getAddress(hexlify(randomBytes(20))),
-    StateChannelTransaction: getAddress(hexlify(randomBytes(20))),
-    MultiSend: getAddress(hexlify(randomBytes(20))),
-    NonceRegistry: getAddress(hexlify(randomBytes(20))),
-    AppRegistry: getAddress(hexlify(randomBytes(20))),
-    ETHBalanceRefund: getAddress(hexlify(randomBytes(20)))
-  };
+  const networkContext = generateRandomNetworkContext();
 
   const appInstance = new AppInstance(
     getAddress(hexlify(randomBytes(20))),

--- a/packages/machine/test/unit/ethereum/setup-commitment.spec.ts
+++ b/packages/machine/test/unit/ethereum/setup-commitment.spec.ts
@@ -1,5 +1,5 @@
 import StateChannelTransaction from "@counterfactual/contracts/build/contracts/StateChannelTransaction.json";
-import { AssetType, NetworkContext } from "@counterfactual/types";
+import { AssetType } from "@counterfactual/types";
 import {
   bigNumberify,
   getAddress,
@@ -13,6 +13,7 @@ import { SetupCommitment } from "../../../src/ethereum";
 import { MultisigTransaction } from "../../../src/ethereum/types";
 import { appIdentityToHash } from "../../../src/ethereum/utils/app-identity";
 import { StateChannel } from "../../../src/models";
+import { generateRandomNetworkContext } from "../../mocks";
 
 /**
  * This test suite decodes a constructed SetupCommitment transaction object according
@@ -27,14 +28,7 @@ describe("SetupCommitment", () => {
   let tx: MultisigTransaction;
 
   // Dummy network context
-  const networkContext: NetworkContext = {
-    ETHBucket: getAddress(hexlify(randomBytes(20))),
-    StateChannelTransaction: getAddress(hexlify(randomBytes(20))),
-    MultiSend: getAddress(hexlify(randomBytes(20))),
-    NonceRegistry: getAddress(hexlify(randomBytes(20))),
-    AppRegistry: getAddress(hexlify(randomBytes(20))),
-    ETHBalanceRefund: getAddress(hexlify(randomBytes(20)))
-  };
+  const networkContext = generateRandomNetworkContext();
 
   // General interaction testing values
   const interaction = {

--- a/packages/machine/test/unit/ethereum/uninstall-commitment.spec.ts
+++ b/packages/machine/test/unit/ethereum/uninstall-commitment.spec.ts
@@ -1,11 +1,7 @@
 import AppRegistry from "@counterfactual/contracts/build/contracts/AppRegistry.json";
 import MultiSend from "@counterfactual/contracts/build/contracts/MultiSend.json";
 import NonceRegistry from "@counterfactual/contracts/build/contracts/NonceRegistry.json";
-import {
-  AssetType,
-  ETHBucketAppState,
-  NetworkContext
-} from "@counterfactual/types";
+import { AssetType, ETHBucketAppState } from "@counterfactual/types";
 import { HashZero, One, WeiPerEther, Zero } from "ethers/constants";
 import {
   bigNumberify,
@@ -22,6 +18,7 @@ import { UninstallCommitment } from "../../../src/ethereum";
 import { MultisigTransaction } from "../../../src/ethereum/types";
 import { decodeMultisendCalldata } from "../../../src/ethereum/utils/multisend-decoder";
 import { StateChannel } from "../../../src/models";
+import { generateRandomNetworkContext } from "../../mocks";
 
 /**
  * This test suite decodes a constructed Uninstall Commitment transaction object
@@ -32,14 +29,7 @@ describe("Uninstall Commitment", () => {
   let tx: MultisigTransaction;
 
   // Dummy network context
-  const networkContext: NetworkContext = {
-    ETHBucket: getAddress(hexlify(randomBytes(20))),
-    StateChannelTransaction: getAddress(hexlify(randomBytes(20))),
-    MultiSend: getAddress(hexlify(randomBytes(20))),
-    NonceRegistry: getAddress(hexlify(randomBytes(20))),
-    AppRegistry: getAddress(hexlify(randomBytes(20))),
-    ETHBalanceRefund: getAddress(hexlify(randomBytes(20)))
-  };
+  const networkContext = generateRandomNetworkContext();
 
   // General interaction testing values
   const interaction = {

--- a/packages/machine/test/unit/instruction-executor.spec.ts
+++ b/packages/machine/test/unit/instruction-executor.spec.ts
@@ -6,17 +6,11 @@ import { InstructionExecutor } from "../../src/instruction-executor";
 import { AppInstance, StateChannel } from "../../src/models";
 import { Opcode } from "../../src/opcodes";
 import { Context } from "../../src/types";
+import { generateRandomNetworkContext } from "../mocks";
 
 describe("InstructionExecutor", () => {
   // Dummy network context
-  const networkContext = {
-    ETHBucket: getAddress(hexlify(randomBytes(20))),
-    StateChannelTransaction: getAddress(hexlify(randomBytes(20))),
-    MultiSend: getAddress(hexlify(randomBytes(20))),
-    NonceRegistry: getAddress(hexlify(randomBytes(20))),
-    AppRegistry: getAddress(hexlify(randomBytes(20))),
-    ETHBalanceRefund: getAddress(hexlify(randomBytes(20)))
-  };
+  const networkContext = generateRandomNetworkContext();
 
   // General interaction testing values
   const interaction = {
@@ -35,6 +29,8 @@ describe("InstructionExecutor", () => {
   let instructionExecutor: InstructionExecutor;
 
   beforeAll(() => {
+    // extract the commitment passed to the OP_SIGN middleware for testing
+    // purposes
     instructionExecutor = new InstructionExecutor(networkContext);
 
     // We must register _some_ middleware for each opcode or the machine
@@ -57,7 +53,7 @@ describe("InstructionExecutor", () => {
       instructionExecutor.middlewares.add(
         Opcode.OP_SIGN,
         (_, __, context: Context) => {
-          commitment = context.operation as SetupCommitment;
+          commitment = context.commitment as SetupCommitment;
           channel = context.stateChannel;
         }
       );

--- a/packages/node/test/integration/utils.ts
+++ b/packages/node/test/integration/utils.ts
@@ -5,6 +5,7 @@ import {
   AppState,
   AssetType,
   BlockchainAsset,
+  NetworkContext,
   Node as NodeTypes
 } from "@counterfactual/types";
 import { AddressZero, One, Zero } from "ethers/constants";
@@ -132,7 +133,7 @@ export function confirmProposedAppInstanceOnNode(
   // expect(proposalParams.initialState).toEqual(appInstanceInitialState);
 }
 
-export const EMPTY_NETWORK = {
+export const EMPTY_NETWORK: NetworkContext = {
   AppRegistry: AddressZero,
   ETHBalanceRefund: AddressZero,
   ETHBucket: AddressZero,


### PR DESCRIPTION
These are mostly pulled out from #419.

- rename `signaturesToSortedBytes` to `signaturesToBytesSortedBySignerAddress`
- rename `MultisigTransactionCommitment` to `MultisigCommitment`
- rename `Context::operation` to `Context::commitment`
- mark `STATE_TRANSITION_COMMIT` and `OP_SIGN_VALIDATE` as unused/deprecated via comments
- specify that `OP_SIGN` should not be doing any decision-making
- delete `MockResponseSink` (unused)
- abstract out the random-address `NetworkContext`s
- enforce type of `EMPTY_NETWORK`