### PR TITLE
[Documentation] Fix README files regarding yarn version and package links

### DIFF
--- a/packages/cf.js/README.md
+++ b/packages/cf.js/README.md
@@ -1,4 +1,4 @@
-# [@counterfactual/cf.js](https://github.com/counterfactual/monorepo/packages/cf.js) <img align="right" src="https://static1.squarespace.com/static/59ee6243268b96cc1fb2b14a/t/5af73bca1ae6cf80fc1cc250/1529369816810/?format=1500w" height="80px" />
+# [@counterfactual/cf.js](https://github.com/counterfactual/monorepo/tree/master/packages/cf.js) <img align="right" src="https://static1.squarespace.com/static/59ee6243268b96cc1fb2b14a/t/5af73bca1ae6cf80fc1cc250/1529369816810/?format=1500w" height="80px" />
 
 CF.js is a library that enables web applications to communicate with a user's Counterfactual-enabled wallet. It allows developers to install and interact with apps on the Counterfactual network.
 
@@ -10,7 +10,7 @@ CF.js is a library that enables web applications to communicate with a user's Co
 
 ## Experimental Usage
 
-**Make sure you have Yarn v1.10.1**. Refer to [Yarn's installation guide](https://yarnpkg.com/lang/en/docs/install/) for setup instructions for your operating system.
+**Make sure you have Yarn v1.10.1 installed or higher**. Refer to [Yarn's installation guide](https://yarnpkg.com/lang/en/docs/install/) for setup instructions for your operating system.
 
 To install the dependencies:
 
@@ -27,4 +27,5 @@ yarn build
 ```
 
 ## API Reference
+
 [Found here](API_REFERENCE.md)

--- a/packages/cf.js/README.md
+++ b/packages/cf.js/README.md
@@ -1,4 +1,4 @@
-# [@counterfactual/cf.js](https://github.com/counterfactual/monorepo/tree/master/packages/cf.js) <img align="right" src="https://static1.squarespace.com/static/59ee6243268b96cc1fb2b14a/t/5af73bca1ae6cf80fc1cc250/1529369816810/?format=1500w" height="80px" />
+# [@counterfactual/cf.js](https://github.com/counterfactual/monorepo/tree/master/packages/cf.js) <img align="right" src="../../logo.svg" height="80px" />
 
 CF.js is a library that enables web applications to communicate with a user's Counterfactual-enabled wallet. It allows developers to install and interact with apps on the Counterfactual network.
 

--- a/packages/contracts/README.md
+++ b/packages/contracts/README.md
@@ -1,4 +1,4 @@
-# [@counterfactual/contracts](https://github.com/counterfactual/monorepo/tree/master/packages/contracts) <img align="right" src="https://static1.squarespace.com/static/59ee6243268b96cc1fb2b14a/t/5af73bca1ae6cf80fc1cc250/1529369816810/?format=1500w" height="80px" />
+# [@counterfactual/contracts](https://github.com/counterfactual/monorepo/tree/master/packages/contracts) <img align="right" src="../../logo.svg" height="80px" />
 
 Counterfactual is a general framework for building state channel applications. An overview of the principles and objectives of this framework can be found at the [Counterfactual specifications repo](https://github.com/counterfactual/specs).
 

--- a/packages/contracts/README.md
+++ b/packages/contracts/README.md
@@ -1,10 +1,10 @@
-# [@counterfactual/contracts](https://github.com/counterfactual/monorepo/packages/contracts) <img align="right" src="https://static1.squarespace.com/static/59ee6243268b96cc1fb2b14a/t/5af73bca1ae6cf80fc1cc250/1529369816810/?format=1500w" height="80px" />
+# [@counterfactual/contracts](https://github.com/counterfactual/monorepo/tree/master/packages/contracts) <img align="right" src="https://static1.squarespace.com/static/59ee6243268b96cc1fb2b14a/t/5af73bca1ae6cf80fc1cc250/1529369816810/?format=1500w" height="80px" />
 
 Counterfactual is a general framework for building state channel applications. An overview of the principles and objectives of this framework can be found at the [Counterfactual specifications repo](https://github.com/counterfactual/specs).
 
 ## Development
 
-**Make sure you have Yarn v1.10.1**. Refer to [Yarn's installation guide](https://yarnpkg.com/lang/en/docs/install/) for setup instructions for your operating system.
+**Make sure you have Yarn v1.10.1 installed or higher**. Refer to [Yarn's installation guide](https://yarnpkg.com/lang/en/docs/install/) for setup instructions for your operating system.
 
 To install the dependencies:
 

--- a/packages/dapp-high-roller/README.md
+++ b/packages/dapp-high-roller/README.md
@@ -1,4 +1,4 @@
-# [High Roller](https://github.com/counterfactual/monorepo/packages/dapp-high-roller) <img align="right" src="https://static1.squarespace.com/static/59ee6243268b96cc1fb2b14a/t/5af73bca1ae6cf80fc1cc250/1529369816810/?format=1500w" height="80px" />
+# [High Roller](https://github.com/counterfactual/monorepo/tree/master/packages/dapp-high-roller) <img align="right" src="https://static1.squarespace.com/static/59ee6243268b96cc1fb2b14a/t/5af73bca1ae6cf80fc1cc250/1529369816810/?format=1500w" height="80px" />
 
 This is a demo dApp (state channel-based decentralized applications) using [CF.js](../cf.js) that runs inside of the [Playground](../playground).
 
@@ -8,7 +8,7 @@ This specific demo dApp is **High Roller**. The game pairs two players that comp
 
 For the moment, this package is available as a local app _(hosted version coming soon!)_.
 
-**Make sure you have Yarn v1.10.1**. Refer to [Yarn's installation guide](https://yarnpkg.com/lang/en/docs/install/) for setup instructions for your operating system.
+**Make sure you have Yarn v1.10.1 installed or higher**. Refer to [Yarn's installation guide](https://yarnpkg.com/lang/en/docs/install/) for setup instructions for your operating system.
 
 To install the dependencies:
 

--- a/packages/dapp-high-roller/README.md
+++ b/packages/dapp-high-roller/README.md
@@ -1,4 +1,4 @@
-# [High Roller](https://github.com/counterfactual/monorepo/tree/master/packages/dapp-high-roller) <img align="right" src="https://static1.squarespace.com/static/59ee6243268b96cc1fb2b14a/t/5af73bca1ae6cf80fc1cc250/1529369816810/?format=1500w" height="80px" />
+# [High Roller](https://github.com/counterfactual/monorepo/tree/master/packages/dapp-high-roller) <img align="right" src="../../logo.svg" height="80px" />
 
 This is a demo dApp (state channel-based decentralized applications) using [CF.js](../cf.js) that runs inside of the [Playground](../playground).
 

--- a/packages/machine/README.md
+++ b/packages/machine/README.md
@@ -1,4 +1,4 @@
-# [@counterfactual/machine](https://github.com/counterfactual/monorepo/tree/master/packages/machine) <img align="right" src="https://static1.squarespace.com/static/59ee6243268b96cc1fb2b14a/t/5af73bca1ae6cf80fc1cc250/1529369816810/?format=1500w" height="80px" />
+# [@counterfactual/machine](https://github.com/counterfactual/monorepo/tree/master/packages/machine) <img align="right" src="../../logo.svg" height="80px" />
 
 This is the TypeScript implementation of the [Counterfactual protocol](https://github.com/counterfactual/specs/blob/master/v0/protocols.md). It is responsible for executing the Counterfactual protocols [specified here](https://specs.counterfactual.com) and producing correctly constructed signed commitments that correspond to state transitions of the users' state channels.
 

--- a/packages/machine/README.md
+++ b/packages/machine/README.md
@@ -1,4 +1,4 @@
-# [@counterfactual/machine](https://github.com/counterfactual/monorepo/packages/machine) <img align="right" src="https://static1.squarespace.com/static/59ee6243268b96cc1fb2b14a/t/5af73bca1ae6cf80fc1cc250/1529369816810/?format=1500w" height="80px" />
+# [@counterfactual/machine](https://github.com/counterfactual/monorepo/tree/master/packages/machine) <img align="right" src="https://static1.squarespace.com/static/59ee6243268b96cc1fb2b14a/t/5af73bca1ae6cf80fc1cc250/1529369816810/?format=1500w" height="80px" />
 
 This is the TypeScript implementation of the [Counterfactual protocol](https://github.com/counterfactual/specs/blob/master/v0/protocols.md). It is responsible for executing the Counterfactual protocols [specified here](https://specs.counterfactual.com) and producing correctly constructed signed commitments that correspond to state transitions of the users' state channels.
 
@@ -16,7 +16,7 @@ Note that because of this architecture, the machine becomes embeddable and its s
 
 ## Usage
 
-**Make sure you have Yarn v1.10.1**. Refer to [Yarn's installation guide](https://yarnpkg.com/lang/en/docs/install/) for setup instructions for your operating system.
+**Make sure you have Yarn v1.10.1 installed or higher**. Refer to [Yarn's installation guide](https://yarnpkg.com/lang/en/docs/install/) for setup instructions for your operating system.
 
 To install the dependencies:
 
@@ -46,4 +46,4 @@ To run only specific tests:
 yarn test <pattern that jest can recognize>
 ```
 
-will run tests in files whose filename matches  `<pattern>` (see [Jest's CLI reference](https://jestjs.io/docs/en/cli.html#running-from-the-command-line)).
+will run tests in files whose filename matches `<pattern>` (see [Jest's CLI reference](https://jestjs.io/docs/en/cli.html#running-from-the-command-line)).

--- a/packages/playground-server/README.md
+++ b/packages/playground-server/README.md
@@ -1,4 +1,4 @@
-# [Playground Server](https://github.com/counterfactual/monorepo/packages/playground-server) <img align="right" src="https://static1.squarespace.com/static/59ee6243268b96cc1fb2b14a/t/5af73bca1ae6cf80fc1cc250/1529369816810/?format=1500w" height="80px" />
+# [Playground Server](https://github.com/counterfactual/monorepo/packages/playground-server) <img align="right" src="../../logo.svg" height="80px" />
 
 The Playground Server provides several services for the Playground, including:
 

--- a/packages/playground/README.md
+++ b/packages/playground/README.md
@@ -1,4 +1,4 @@
-# [Playground Demo](https://github.com/counterfactual/monorepo/packages/playground) <img align="right" src="https://static1.squarespace.com/static/59ee6243268b96cc1fb2b14a/t/5af73bca1ae6cf80fc1cc250/1529369816810/?format=1500w" height="80px" />
+# [Playground Demo](https://github.com/counterfactual/monorepo/tree/master/packages/playground) <img align="right" src="https://static1.squarespace.com/static/59ee6243268b96cc1fb2b14a/t/5af73bca1ae6cf80fc1cc250/1529369816810/?format=1500w" height="80px" />
 
 This is an environment to run dApps (state channel-based decentralized applications) using [CF.js](../cf.js). It allows to showcase different demo apps, presenting a variety of use cases where state channels are applicable.
 
@@ -6,7 +6,7 @@ This is an environment to run dApps (state channel-based decentralized applicati
 
 For the moment, this package is available as a local app _(hosted version coming soon!)_.
 
-**Make sure you have Yarn v1.10.1**. Refer to [Yarn's installation guide](https://yarnpkg.com/lang/en/docs/install/) for setup instructions for your operating system.
+**Make sure you have Yarn v1.10.1 installed or higher**. Refer to [Yarn's installation guide](https://yarnpkg.com/lang/en/docs/install/) for setup instructions for your operating system.
 
 To install the dependencies:
 

--- a/packages/playground/README.md
+++ b/packages/playground/README.md
@@ -1,4 +1,4 @@
-# [Playground Demo](https://github.com/counterfactual/monorepo/tree/master/packages/playground) <img align="right" src="https://static1.squarespace.com/static/59ee6243268b96cc1fb2b14a/t/5af73bca1ae6cf80fc1cc250/1529369816810/?format=1500w" height="80px" />
+# [Playground Demo](https://github.com/counterfactual/monorepo/tree/master/packages/playground) <img align="right" src="../../logo.svg" height="80px" />
 
 This is an environment to run dApps (state channel-based decentralized applications) using [CF.js](../cf.js). It allows to showcase different demo apps, presenting a variety of use cases where state channels are applicable.
 

--- a/packages/typescript-typings/README.md
+++ b/packages/typescript-typings/README.md
@@ -1,4 +1,4 @@
-# [@counterfactual/typescript-typings](https://github.com/counterfactual/monorepo/packages/typescript-typings) <img align="right" src="https://static1.squarespace.com/static/59ee6243268b96cc1fb2b14a/t/5af73bca1ae6cf80fc1cc250/1529369816810/?format=1500w" height="80px" />
+# [@counterfactual/typescript-typings](https://github.com/counterfactual/monorepo/packages/typescript-typings) <img align="right" src="../../logo.svg" height="80px" />
 
 Type repository for external packages used by Counterfactual's Typescript code. This is automatically imported by all packages in the monorepo as a kind of stub for any packages we need that are not typed in the way that we would like.
 


### PR DESCRIPTION
### Description

I updated the wording for **Make sure you have Yarn v1.10.1 installed or higher** a few days ago but didn't update it for all of the README.md files, this completes that.

Also I noticed that Header links for each README was pointing to an incorrect URL that was returning a 404. Fixed that as well.

There is still an issue with images in the top right of each README. I am not sure what image is supposed to be there. The src points to https://static1.squarespace.com/static/59ee6243268b96cc1fb2b14a/t/5af73bca1ae6cf80fc1cc250/1529369816810/?format=1500w

However this returns a `Website Expired` page when visited. 
