### PR TITLE
[contracts, machine] Remove appInterfaceHash from AppIdentity

### DIFF
--- a/packages/contracts/contracts/libs/LibStateChannelApp.sol
+++ b/packages/contracts/contracts/libs/LibStateChannelApp.sol
@@ -26,7 +26,7 @@ contract LibStateChannelApp {
   struct AppIdentity {
     address owner;
     address[] signingKeys;
-    address appAddress;
+    address appDefinitionAddress;
     bytes32 termsHash;
     uint256 defaultTimeout;
   }

--- a/packages/contracts/contracts/libs/LibStateChannelApp.sol
+++ b/packages/contracts/contracts/libs/LibStateChannelApp.sol
@@ -26,7 +26,7 @@ contract LibStateChannelApp {
   struct AppIdentity {
     address owner;
     address[] signingKeys;
-    bytes32 appInterfaceHash;
+    address appAddress;
     bytes32 termsHash;
     uint256 defaultTimeout;
   }

--- a/packages/contracts/contracts/mixins/MAppRegistryCore.sol
+++ b/packages/contracts/contracts/mixins/MAppRegistryCore.sol
@@ -19,17 +19,17 @@ contract MAppRegistryCore {
 
   /// @notice Verify the hash of ap AppInterface is a bytes32
   /// @param appInterface the AppInterface being checked
-  /// @param appInterfaceHash the hash to check against
+  /// @param appAddress the address to check against
   /// @return a boolean dictating the equality of the hashed AppInterface and the hash
   modifier doAppInterfaceCheck(
     LibStateChannelApp.AppInterface memory appInterface,
-    bytes32 appInterfaceHash
+    address appAddress
   ) {
     // TODO: This is inefficient from a gas point of view since we could just include
     // the hash of appInterface in the call to appIdentityToHash. Cleanup in the fututre.
     require(
-      keccak256(abi.encode(appInterface)) == appInterfaceHash,
-      "Call to AppRegistry included mismatched appInterface and appInterfaceHash"
+      appInterface.addr == appAddress,
+      "Call to AppRegistry included mismatched appAddress"
     );
     _;
   }

--- a/packages/contracts/contracts/mixins/MAppRegistryCore.sol
+++ b/packages/contracts/contracts/mixins/MAppRegistryCore.sol
@@ -19,17 +19,17 @@ contract MAppRegistryCore {
 
   /// @notice Verify the hash of ap AppInterface is a bytes32
   /// @param appInterface the AppInterface being checked
-  /// @param appAddress the address to check against
+  /// @param appDefinitionAddress the address to check against
   /// @return a boolean dictating the equality of the hashed AppInterface and the hash
   modifier doAppInterfaceCheck(
     LibStateChannelApp.AppInterface memory appInterface,
-    address appAddress
+    address appDefinitionAddress
   ) {
     // TODO: This is inefficient from a gas point of view since we could just include
     // the hash of appInterface in the call to appIdentityToHash. Cleanup in the fututre.
     require(
-      appInterface.addr == appAddress,
-      "Call to AppRegistry included mismatched appAddress"
+      appInterface.addr == appDefinitionAddress,
+      "Call to AppRegistry included mismatched appDefinitionAddress"
     );
     _;
   }

--- a/packages/contracts/contracts/mixins/MixinSetResolution.sol
+++ b/packages/contracts/contracts/mixins/MixinSetResolution.sol
@@ -26,7 +26,7 @@ contract MixinSetResolution is
     bytes memory terms
   )
     public
-    doAppInterfaceCheck(appInterface, appIdentity.appAddress)
+    doAppInterfaceCheck(appInterface, appIdentity.appDefinitionAddress)
     doTermsCheck(terms, appIdentity.termsHash)
   {
     bytes32 identityHash = appIdentityToHash(appIdentity);

--- a/packages/contracts/contracts/mixins/MixinSetResolution.sol
+++ b/packages/contracts/contracts/mixins/MixinSetResolution.sol
@@ -26,7 +26,7 @@ contract MixinSetResolution is
     bytes memory terms
   )
     public
-    doAppInterfaceCheck(appInterface, appIdentity.appInterfaceHash)
+    doAppInterfaceCheck(appInterface, appIdentity.appAddress)
     doTermsCheck(terms, appIdentity.termsHash)
   {
     bytes32 identityHash = appIdentityToHash(appIdentity);

--- a/packages/contracts/contracts/mixins/MixinSetStateWithAction.sol
+++ b/packages/contracts/contracts/mixins/MixinSetStateWithAction.sol
@@ -45,7 +45,7 @@ contract MixinSetStateWithAction is
     SignedAction memory action
   )
     public
-    doAppInterfaceCheck(appInterface, appIdentity.appAddress)
+    doAppInterfaceCheck(appInterface, appIdentity.appDefinitionAddress)
   {
     bytes32 identityHash = appIdentityToHash(appIdentity);
 

--- a/packages/contracts/contracts/mixins/MixinSetStateWithAction.sol
+++ b/packages/contracts/contracts/mixins/MixinSetStateWithAction.sol
@@ -45,7 +45,7 @@ contract MixinSetStateWithAction is
     SignedAction memory action
   )
     public
-    doAppInterfaceCheck(appInterface, appIdentity.appInterfaceHash)
+    doAppInterfaceCheck(appInterface, appIdentity.appAddress)
   {
     bytes32 identityHash = appIdentityToHash(appIdentity);
 

--- a/packages/contracts/test/eth-virtual-app-agreement.spec.ts
+++ b/packages/contracts/test/eth-virtual-app-agreement.spec.ts
@@ -135,7 +135,7 @@ contract("ETHVirtualAppAgreement", (accounts: string[]) => {
     const appIdentity = {
       owner: await unlockedAccount.getAddress(),
       signingKeys: [],
-      appAddress: appInterface.addr,
+      appDefinitionAddress: appInterface.addr,
       termsHash: keccak256(encodedTerms),
       defaultTimeout: 10
     };
@@ -146,7 +146,7 @@ contract("ETHVirtualAppAgreement", (accounts: string[]) => {
           `tuple(
             address owner,
             address[] signingKeys,
-            address appAddress,
+            address appDefinitionAddress,
             bytes32 termsHash,
             uint256 defaultTimeout
           )`

--- a/packages/contracts/test/eth-virtual-app-agreement.spec.ts
+++ b/packages/contracts/test/eth-virtual-app-agreement.spec.ts
@@ -135,20 +135,7 @@ contract("ETHVirtualAppAgreement", (accounts: string[]) => {
     const appIdentity = {
       owner: await unlockedAccount.getAddress(),
       signingKeys: [],
-      appInterfaceHash: keccak256(
-        defaultAbiCoder.encode(
-          [
-            `tuple(
-              address addr,
-              bytes4 getTurnTaker,
-              bytes4 applyAction,
-              bytes4 resolve,
-              bytes4 isStateTerminal
-            )`
-          ],
-          [appInterface]
-        )
-      ),
+      appAddress: appInterface.addr,
       termsHash: keccak256(encodedTerms),
       defaultTimeout: 10
     };
@@ -159,7 +146,7 @@ contract("ETHVirtualAppAgreement", (accounts: string[]) => {
           `tuple(
             address owner,
             address[] signingKeys,
-            bytes32 appInterfaceHash,
+            address appAddress,
             bytes32 termsHash,
             uint256 defaultTimeout
           )`

--- a/packages/contracts/test/utils/index.ts
+++ b/packages/contracts/test/utils/index.ts
@@ -112,7 +112,7 @@ export class AppInstance {
     return {
       owner: this.owner,
       signingKeys: this.signingKeys,
-      appInterfaceHash: this.appInterface.hashOfPackedEncoding(),
+      appAddress: this.appInterface.addr,
       termsHash: this.terms.hashOfPackedEncoding(),
       defaultTimeout: this.defaultTimeout
     };
@@ -133,7 +133,7 @@ export class AppInstance {
           `tuple(
             address owner,
             address[] signingKeys,
-            bytes32 appInterfaceHash,
+            address appAddress,
             bytes32 termsHash,
             uint256 defaultTimeout
           )`

--- a/packages/contracts/test/utils/index.ts
+++ b/packages/contracts/test/utils/index.ts
@@ -112,7 +112,7 @@ export class AppInstance {
     return {
       owner: this.owner,
       signingKeys: this.signingKeys,
-      appAddress: this.appInterface.addr,
+      appDefinitionAddress: this.appInterface.addr,
       termsHash: this.terms.hashOfPackedEncoding(),
       defaultTimeout: this.defaultTimeout
     };
@@ -133,7 +133,7 @@ export class AppInstance {
           `tuple(
             address owner,
             address[] signingKeys,
-            address appAddress,
+            address appDefinitionAddress,
             bytes32 termsHash,
             uint256 defaultTimeout
           )`

--- a/packages/dapp-high-roller/src/data/types.ts
+++ b/packages/dapp-high-roller/src/data/types.ts
@@ -34,7 +34,7 @@ export interface Transaction {
 export interface AppIdentity {
   owner: string;
   signingKeys: string[];
-  appAddress: string;
+  appDefinitionAddress: string;
   termsHash: string;
   defaultTimeout: number;
 }

--- a/packages/dapp-high-roller/src/data/types.ts
+++ b/packages/dapp-high-roller/src/data/types.ts
@@ -34,7 +34,7 @@ export interface Transaction {
 export interface AppIdentity {
   owner: string;
   signingKeys: string[];
-  appInterfaceHash: string;
+  appAddress: string;
   termsHash: string;
   defaultTimeout: number;
 }

--- a/packages/machine/src/ethereum/utils/encodings.ts
+++ b/packages/machine/src/ethereum/utils/encodings.ts
@@ -21,7 +21,7 @@ export const APP_IDENTITY = `
   tuple(
     address owner,
     address[] signingKeys,
-    bytes32 appInterfaceHash,
+    address appAddress,
     bytes32 termsHash,
     uint256 defaultTimeout
   )`;

--- a/packages/machine/src/ethereum/utils/encodings.ts
+++ b/packages/machine/src/ethereum/utils/encodings.ts
@@ -21,7 +21,7 @@ export const APP_IDENTITY = `
   tuple(
     address owner,
     address[] signingKeys,
-    address appAddress,
+    address appDefinitionAddress,
     bytes32 termsHash,
     uint256 defaultTimeout
   )`;

--- a/packages/machine/src/ethereum/utils/free-balance.ts
+++ b/packages/machine/src/ethereum/utils/free-balance.ts
@@ -8,7 +8,7 @@ import {
   keccak256
 } from "ethers/utils";
 
-import { APP_INTERFACE, TERMS } from "./encodings";
+import { TERMS } from "./encodings";
 
 // FIXME: Use this when it returns named version.
 // export const freeBalanceStateEncoding = formatParamType(
@@ -36,15 +36,6 @@ export function getFreeBalanceAppInterface(addr: string): AppInterface {
     stateEncoding: freeBalanceStateEncoding,
     actionEncoding: undefined // because no actions exist for ETHBucket
   };
-}
-
-export function getFreeBalanceAppInterfaceHash(ethBucketAppAddress: string) {
-  return keccak256(
-    defaultAbiCoder.encode(
-      [APP_INTERFACE],
-      [getFreeBalanceAppInterface(ethBucketAppAddress)]
-    )
-  );
 }
 
 export const freeBalanceTerms = {

--- a/packages/machine/src/models/app-instance.ts
+++ b/packages/machine/src/models/app-instance.ts
@@ -124,7 +124,7 @@ export class AppInstance {
     return {
       owner: this.json.multisigAddress,
       signingKeys: this.json.signingKeys,
-      appAddress: this.json.appInterface.addr,
+      appDefinitionAddress: this.json.appInterface.addr,
       termsHash: keccak256(encodedTerms),
       defaultTimeout: this.json.defaultTimeout
     };

--- a/packages/machine/src/models/app-instance.ts
+++ b/packages/machine/src/models/app-instance.ts
@@ -3,7 +3,7 @@ import { defaultAbiCoder, keccak256, solidityPack } from "ethers/utils";
 import { Memoize } from "typescript-memoize";
 
 import { appIdentityToHash } from "../ethereum/utils/app-identity";
-import { APP_INTERFACE, TERMS } from "../ethereum/utils/encodings";
+import { TERMS } from "../ethereum/utils/encodings";
 import { AppState } from "../protocol-types-tbd";
 
 /**
@@ -120,15 +120,11 @@ export class AppInstance {
 
   @Memoize()
   public get identity(): AppIdentity {
-    const encodedAppInterface = defaultAbiCoder.encode(
-      [APP_INTERFACE],
-      [this.json.appInterface]
-    );
     const encodedTerms = defaultAbiCoder.encode([TERMS], [this.json.terms]);
     return {
       owner: this.json.multisigAddress,
       signingKeys: this.json.signingKeys,
-      appInterfaceHash: keccak256(encodedAppInterface),
+      appAddress: this.json.appInterface.addr,
       termsHash: keccak256(encodedTerms),
       defaultTimeout: this.json.defaultTimeout
     };

--- a/packages/machine/test/unit/ethereum/install-commitment.spec.ts
+++ b/packages/machine/test/unit/ethereum/install-commitment.spec.ts
@@ -167,12 +167,18 @@ describe("InstallCommitment", () => {
 
         it("should build the expected AppIdentity argument", () => {
           const [
-            [owner, signingKeys, appAddress, termsHash, defaultTimeout]
+            [
+              owner,
+              signingKeys,
+              appDefinitionAddress,
+              termsHash,
+              defaultTimeout
+            ]
           ] = calldata.args;
           const expected = freeBalanceETH.identity;
           expect(owner).toBe(expected.owner);
           expect(signingKeys).toEqual(expected.signingKeys);
-          expect(appAddress).toBe(expected.appAddress);
+          expect(appDefinitionAddress).toBe(expected.appDefinitionAddress);
           expect(termsHash).toBe(expected.termsHash);
           expect(defaultTimeout).toEqual(bigNumberify(expected.defaultTimeout));
         });

--- a/packages/machine/test/unit/ethereum/install-commitment.spec.ts
+++ b/packages/machine/test/unit/ethereum/install-commitment.spec.ts
@@ -167,12 +167,12 @@ describe("InstallCommitment", () => {
 
         it("should build the expected AppIdentity argument", () => {
           const [
-            [owner, signingKeys, appInterfaceHash, termsHash, defaultTimeout]
+            [owner, signingKeys, appAddress, termsHash, defaultTimeout]
           ] = calldata.args;
           const expected = freeBalanceETH.identity;
           expect(owner).toBe(expected.owner);
           expect(signingKeys).toEqual(expected.signingKeys);
-          expect(appInterfaceHash).toBe(expected.appInterfaceHash);
+          expect(appAddress).toBe(expected.appAddress);
           expect(termsHash).toBe(expected.termsHash);
           expect(defaultTimeout).toEqual(bigNumberify(expected.defaultTimeout));
         });

--- a/packages/machine/test/unit/ethereum/set-state-commitment.spec.ts
+++ b/packages/machine/test/unit/ethereum/set-state-commitment.spec.ts
@@ -100,13 +100,15 @@ describe("Set State Commitment", () => {
       const [
         owner,
         signingKeys,
-        appAddress,
+        appDefinitionAddress,
         termsHash,
         defaultTimeout
       ] = desc.args[0];
       expect(owner).toBe(appInstance.identity.owner);
       expect(signingKeys).toEqual(appInstance.identity.signingKeys);
-      expect(appAddress).toBe(appInstance.identity.appAddress);
+      expect(appDefinitionAddress).toBe(
+        appInstance.identity.appDefinitionAddress
+      );
       expect(termsHash).toBe(appInstance.identity.termsHash);
       expect(defaultTimeout).toEqual(
         bigNumberify(appInstance.identity.defaultTimeout)

--- a/packages/machine/test/unit/ethereum/set-state-commitment.spec.ts
+++ b/packages/machine/test/unit/ethereum/set-state-commitment.spec.ts
@@ -100,13 +100,13 @@ describe("Set State Commitment", () => {
       const [
         owner,
         signingKeys,
-        appInterfaceHash,
+        appAddress,
         termsHash,
         defaultTimeout
       ] = desc.args[0];
       expect(owner).toBe(appInstance.identity.owner);
       expect(signingKeys).toEqual(appInstance.identity.signingKeys);
-      expect(appInterfaceHash).toBe(appInstance.identity.appInterfaceHash);
+      expect(appAddress).toBe(appInstance.identity.appAddress);
       expect(termsHash).toBe(appInstance.identity.termsHash);
       expect(defaultTimeout).toEqual(
         bigNumberify(appInstance.identity.defaultTimeout)

--- a/packages/machine/test/unit/ethereum/uninstall-commitment.spec.ts
+++ b/packages/machine/test/unit/ethereum/uninstall-commitment.spec.ts
@@ -132,14 +132,20 @@ describe("Uninstall Commitment", () => {
 
         it("should build the expected AppIdentity argument", () => {
           const [
-            [owner, signingKeys, appAddress, termsHash, defaultTimeout]
+            [
+              owner,
+              signingKeys,
+              appDefinitionAddress,
+              termsHash,
+              defaultTimeout
+            ]
           ] = calldata.args;
 
           const expected = freeBalanceETH.identity;
 
           expect(owner).toBe(expected.owner);
           expect(signingKeys).toEqual(expected.signingKeys);
-          expect(appAddress).toBe(expected.appAddress);
+          expect(appDefinitionAddress).toBe(expected.appDefinitionAddress);
           expect(termsHash).toBe(expected.termsHash);
           expect(defaultTimeout).toEqual(bigNumberify(expected.defaultTimeout));
         });

--- a/packages/machine/test/unit/ethereum/uninstall-commitment.spec.ts
+++ b/packages/machine/test/unit/ethereum/uninstall-commitment.spec.ts
@@ -132,14 +132,14 @@ describe("Uninstall Commitment", () => {
 
         it("should build the expected AppIdentity argument", () => {
           const [
-            [owner, signingKeys, appInterfaceHash, termsHash, defaultTimeout]
+            [owner, signingKeys, appAddress, termsHash, defaultTimeout]
           ] = calldata.args;
 
           const expected = freeBalanceETH.identity;
 
           expect(owner).toBe(expected.owner);
           expect(signingKeys).toEqual(expected.signingKeys);
-          expect(appInterfaceHash).toBe(expected.appInterfaceHash);
+          expect(appAddress).toBe(expected.appAddress);
           expect(termsHash).toBe(expected.termsHash);
           expect(defaultTimeout).toEqual(bigNumberify(expected.defaultTimeout));
         });

--- a/packages/types/src/app-instance.ts
+++ b/packages/types/src/app-instance.ts
@@ -25,7 +25,7 @@ export interface Transaction {
 export interface AppIdentity {
   owner: string;
   signingKeys: string[];
-  appInterfaceHash: string;
+  appAddress: string;
   termsHash: string;
   defaultTimeout: number;
 }

--- a/packages/types/src/app-instance.ts
+++ b/packages/types/src/app-instance.ts
@@ -25,7 +25,7 @@ export interface Transaction {
 export interface AppIdentity {
   owner: string;
   signingKeys: string[];
-  appAddress: string;
+  appDefinitionAddress: string;
   termsHash: string;
   defaultTimeout: number;
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2654,7 +2654,7 @@ async-eventemitter@^0.2.2:
   dependencies:
     async "^2.4.0"
 
-"async-eventemitter@github:ahultgren/async-eventemitter#fa06e39e56786ba541c180061dbf2c0a5bbf951c":
+async-eventemitter@ahultgren/async-eventemitter#fa06e39e56786ba541c180061dbf2c0a5bbf951c:
   version "0.2.3"
   resolved "https://codeload.github.com/ahultgren/async-eventemitter/tar.gz/fa06e39e56786ba541c180061dbf2c0a5bbf951c"
   dependencies:
@@ -6412,10 +6412,10 @@ ethereum-common@^0.0.18:
   resolved "https://registry.yarnpkg.com/ethereum-common/-/ethereum-common-0.0.18.tgz#2fdc3576f232903358976eb39da783213ff9523f"
   integrity sha1-L9w1dvIykDNYl26znaeDIT/5Uj8=
 
-ethereum-waffle@2.0.0-beta.6:
-  version "2.0.0-beta.6"
-  resolved "https://registry.yarnpkg.com/ethereum-waffle/-/ethereum-waffle-2.0.0-beta.6.tgz#8594d677001582fe8fff28807bb3a7fd83b88312"
-  integrity sha512-FXQkgXB/cwIQorWd1GWXjQ0AyKmzSUwYDrIpMDHcb60BCuqoVGAQif8iCELNHJNkJvPzcaBAWwXnqPab9NzaaA==
+ethereum-waffle@2.0.0-beta.8:
+  version "2.0.0-beta.8"
+  resolved "https://registry.yarnpkg.com/ethereum-waffle/-/ethereum-waffle-2.0.0-beta.8.tgz#bf661771670ba489b9530c1df609d6638b671d40"
+  integrity sha512-k7fYmXJBpUCvWXh1zXEgEF1iC4TfghUwuk23ybAHjBGEw+1ydaw3xgovVl91Bexsu4f6NOa16rKSRsU9LsIqIg==
   dependencies:
     ethers "^4.0.0"
     ganache-core "2.2.1"


### PR DESCRIPTION
Since #477 we no longer need this value to be a part of the `AppIdentity` object. Instead, we only need the `address`.