### PR TITLE
[node-provider] Adds debug mode and log messages

### DIFF
--- a/packages/node-provider/src/node-provider.ts
+++ b/packages/node-provider/src/node-provider.ts
@@ -23,6 +23,10 @@ export default class NodeProvider implements INodeProvider {
     this.isConnected = false;
     this.eventEmitter = new EventEmitter();
 
+    this.detectDebugMode();
+  }
+
+  private detectDebugMode() {
     if (process && process.env.CF_NODE_PROVIDER_DEBUG) {
       this.debugMode = "shell";
       this.debugEmitter = (source: string, message: string, data?: any) => {

--- a/packages/node-provider/src/node-provider.ts
+++ b/packages/node-provider/src/node-provider.ts
@@ -41,9 +41,10 @@ export default class NodeProvider implements INodeProvider {
       this.debugMode = "browser";
       this.debugEmitter = (source: string, message: string, data?: any) => {
         console.log(
-          ["%c[NodeProvider]", `%c#${source}()`, message].join(" "),
+          ["%c[NodeProvider]", `%c#${source}()`, `%c${message}`].join(" "),
           "color: gray;",
-          "color: green;"
+          "color: green;",
+          "color: black;"
         );
 
         if (data) {

--- a/packages/node-provider/src/node-provider.ts
+++ b/packages/node-provider/src/node-provider.ts
@@ -27,30 +27,32 @@ export default class NodeProvider implements INodeProvider {
   }
 
   private detectDebugMode() {
-    if (process && process.env.CF_NODE_PROVIDER_DEBUG) {
-      this.debugMode = "shell";
-      this.debugEmitter = (source: string, message: string, data?: any) => {
-        console.log(`[NodeProvider] ${source}(): ${message}`);
-        if (data) {
-          console.log("   ", data);
-        }
-      };
-    } else if (
-      window.localStorage.getItem("cf:node-provider:debug") === "true"
-    ) {
-      this.debugMode = "browser";
-      this.debugEmitter = (source: string, message: string, data?: any) => {
-        console.log(
-          ["%c[NodeProvider]", `%c#${source}()`, `%c${message}`].join(" "),
-          "color: gray;",
-          "color: green;",
-          "color: black;"
-        );
+    try {
+      if (process && process.env.CF_NODE_PROVIDER_DEBUG) {
+        this.debugMode = "shell";
+        this.debugEmitter = (source: string, message: string, data?: any) => {
+          console.log(`[NodeProvider] ${source}(): ${message}`);
+          if (data) {
+            console.log("   ", data);
+          }
+        };
+      }
+    } catch {
+      if (window.localStorage.getItem("cf:node-provider:debug") === "true") {
+        this.debugMode = "browser";
+        this.debugEmitter = (source: string, message: string, data?: any) => {
+          console.log(
+            ["%c[NodeProvider]", `%c#${source}()`, `%c${message}`].join(" "),
+            "color: gray;",
+            "color: green;",
+            "color: black;"
+          );
 
-        if (data) {
-          console.log("   ", data);
-        }
-      };
+          if (data) {
+            console.log("   ", data);
+          }
+        };
+      }
     }
   }
 


### PR DESCRIPTION
This PR adds support for debugging the `node-provider` package.

- If an environment variable `CF_NODE_PROVIDER_DEBUG` is detected, a log handler suited for shell-based consoles will take care of printing messages.
- If a key in `window.localStorage` called `cf:node-provider:debug` is set to `true` in the **dApp's** context, a formatted/coloured log handler will print messages in the browser's console.

### Sample

![image](https://user-images.githubusercontent.com/118913/51000070-b9a58700-150a-11e9-94d3-a69ea59ed6a0.png)
