### PR TITLE
[playground-server] Fixes error control affected by CORS middleware

### DIFF
--- a/packages/playground-server/src/api.ts
+++ b/packages/playground-server/src/api.ts
@@ -31,7 +31,7 @@ export default function mountApi() {
   api
     .use(errorHandler(api))
     .use(bodyParser({ json: true }))
-    .use(cors())
+    .use(cors({ keepHeadersOnError: false }))
     .use(signatureValidator())
     .use(authentication("/api/matchmake", "/api/user"))
     .use(router.routes());

--- a/packages/playground-server/src/middleware/error.ts
+++ b/packages/playground-server/src/middleware/error.ts
@@ -42,7 +42,9 @@ function processError(error: ErrorCode | Error, ctx: Context) {
       HttpStatusCode.InternalServerError,
       ErrorCode.UnhandledError,
       {
-        ...errorObject
+        message: errorObject.message,
+        name: errorObject.name,
+        stack: errorObject.stack
       }
     );
   }


### PR DESCRIPTION
API 4xx errors were being obscured by a CORS middleware misconfiguration. This PR fixes it.