### PR TITLE
[playground] [dapp-high-roller] [dapp-tic-tac-toe] Implements user data sharing across postMessage for dApps

### DIFF
--- a/packages/dapp-high-roller/src/components/app-root/app-root.tsx
+++ b/packages/dapp-high-roller/src/components/app-root/app-root.tsx
@@ -22,11 +22,32 @@ export class AppRoot {
 
   constructor() {
     this.state = {
+      user: {},
       appInstance: null,
       appFactory: null,
       updateAppInstance: this.updateAppInstance.bind(this),
       updateAppFactory: this.updateAppFactory.bind(this)
     };
+  }
+
+  async componentDidLoad() {
+    window.addEventListener("message", (event: MessageEvent) => {
+      if (
+        typeof event.data === "string" &&
+        event.data.startsWith("playground:response:user")
+      ) {
+        const [, data] = event.data.split("|");
+        const user = JSON.parse(data);
+        this.updateUser(user);
+        console.log(this.state);
+      }
+    });
+
+    window.parent.postMessage("playground:request:user", "*");
+  }
+
+  updateUser(user: any) {
+    this.state = { ...this.state, user };
   }
 
   updateAppInstance(appInstance: AppInstance) {

--- a/packages/dapp-high-roller/src/components/app-wager/app-wager.tsx
+++ b/packages/dapp-high-roller/src/components/app-wager/app-wager.tsx
@@ -5,7 +5,6 @@ import { RouterHistory } from "@stencil/router";
 
 import CounterfactualTunnel from "../../data/counterfactual";
 import { Address, AppInstanceID, cf } from "../../data/types";
-import { getProp } from "../../utils/utils";
 
 // FIXME: Figure out how to import @counterfactual-types
 // const { AssetType } = commonTypes;
@@ -34,14 +33,14 @@ export class AppWager {
   @State() isError: boolean = false;
   @State() isWaiting: boolean = false;
   @State() error: any;
+  @Prop() user: any;
 
   @Prop() updateAppInstance: (
     appInstance: { id: AppInstanceID }
   ) => void = () => {};
 
   async componentWillLoad() {
-    // TODO: figure out how the Playground UI provides Dapps their user data
-    this.myName = getProp("myName", this);
+    this.myName = this.user.username;
 
     return await this.matchmake();
   }
@@ -73,26 +72,18 @@ export class AppWager {
   }
 
   async matchmake(/* timeout: number */): Promise<any> {
-    // TODO: make an ajax call to the playground server when not in standalone mode
-
-    // TODO: This token should be obtained from LocalStorage.
-    const token =
-      "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6IjQ5OGRhZTNmLWNmYjctNGNmNC05OTZiLWZiNDI5NDI3ZGQ4NSIsInVzZXJuYW1lIjoiam9lbCIsImVtYWlsIjoiZXN0dWRpb0Bqb2VsYWxlamFuZHJvLmNvbSIsImFkZHJlc3MiOiIweDBmNjkzY2M5NTZkZjU5ZGVjMjRiYjFjNjA1YWM5NGNhZGNlNjAxNGQiLCJtdWx0aXNpZ0FkZHJlc3MiOiIweDE0NTczMjUzMTkxRDJDMjUxQTg1Y0JBMTQ1NjY0RWUwYUViNDA4NjgiLCJpYXQiOjE1NDcwODU4MTcsImV4cCI6MTU3ODY0MzQxN30.AQ-ataiWl9emPRWtHVinEXYgyHHZquP9DOXLjmcTKJI";
+    const { token } = this.user;
 
     try {
-      const response = await fetch(
-        "https://server.playground-staging.counterfactual.com/api/matchmake",
-        {
-          method: "POST",
-          headers: {
-            Authorization: `Bearer ${token}`
-          }
+      const response = await fetch("http://localhost:9000/api/matchmake", {
+        method: "POST",
+        headers: {
+          Authorization: `Bearer ${token}`
         }
-      );
+      });
       const result = await response.json();
 
       this.opponent = result.data.opponent;
-      this.myName = result.data.user.username;
       this.intermediary = result.data.intermediary;
       this.isError = false;
       this.error = null;
@@ -181,4 +172,8 @@ export class AppWager {
   }
 }
 
-CounterfactualTunnel.injectProps(AppWager, ["appFactory", "updateAppInstance"]);
+CounterfactualTunnel.injectProps(AppWager, [
+  "appFactory",
+  "updateAppInstance",
+  "user"
+]);

--- a/packages/dapp-tic-tac-toe/src/App.js
+++ b/packages/dapp-tic-tac-toe/src/App.js
@@ -29,20 +29,33 @@ export default class App extends Component {
     };
 
     this.connect(nodeProvider);
+    this.requestUserData();
   }
 
   async connect() {
     await this.state.nodeProvider.connect();
-
-    this.setState({
-      connected: true
-    });
   }
 
   appInstanceChanged(appInstance) {
     this.setState({
       appInstance: appInstance
     });
+  }
+
+  requestUserData() {
+    window.addEventListener("message", event => {
+      if (
+        typeof event.data === "string" &&
+        event.data.startsWith("playground:response:user")
+      ) {
+        const [, data] = event.data.split("|");
+        const user = JSON.parse(data);
+        this.setState({ user, connected: true });
+        console.log(this.state);
+      }
+    });
+
+    window.parent.postMessage("playground:request:user", "*");
   }
 
   render() {
@@ -57,6 +70,7 @@ export default class App extends Component {
                 {...props}
                 gameInfo={this.state.gameInfo}
                 cfProvider={this.state.cfProvider}
+                user={this.state.user}
                 onChangeAppInstance={this.appInstanceChanged.bind(this)}
               />
             )}

--- a/packages/dapp-tic-tac-toe/src/Wager.jsx
+++ b/packages/dapp-tic-tac-toe/src/Wager.jsx
@@ -9,7 +9,6 @@ class Wager extends Component {
       error: null,
       isLoaded: false,
       isWaiting: false,
-      user: {},
       opponent: {},
       intermediary: null
     };
@@ -18,25 +17,19 @@ class Wager extends Component {
   async componentDidMount() {
     this.props.cfProvider.once("install", this.onInstall.bind(this));
 
-    // TODO: This token should be obtained from LocalStorage.
-    const token =
-      "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6IjQ5OGRhZTNmLWNmYjctNGNmNC05OTZiLWZiNDI5NDI3ZGQ4NSIsInVzZXJuYW1lIjoiam9lbCIsImVtYWlsIjoiZXN0dWRpb0Bqb2VsYWxlamFuZHJvLmNvbSIsImFkZHJlc3MiOiIweDBmNjkzY2M5NTZkZjU5ZGVjMjRiYjFjNjA1YWM5NGNhZGNlNjAxNGQiLCJtdWx0aXNpZ0FkZHJlc3MiOiIweDE0NTczMjUzMTkxRDJDMjUxQTg1Y0JBMTQ1NjY0RWUwYUViNDA4NjgiLCJpYXQiOjE1NDcwODU4MTcsImV4cCI6MTU3ODY0MzQxN30.AQ-ataiWl9emPRWtHVinEXYgyHHZquP9DOXLjmcTKJI";
+    const { token } = this.props.user;
 
     try {
-      const response = await fetch(
-        "https://server.playground-staging.counterfactual.com/api/matchmake",
-        {
-          method: "POST",
-          headers: {
-            Authorization: `Bearer ${token}`
-          }
+      const response = await fetch("http://localhost:9000/api/matchmake", {
+        method: "POST",
+        headers: {
+          Authorization: `Bearer ${token}`
         }
-      );
+      });
       const result = await response.json();
 
       this.setState({
         isLoaded: true,
-        user: result.data.user,
         opponent: result.data.opponent,
         intermediary: result.data.intermediary,
         error: result.error
@@ -97,7 +90,8 @@ class Wager extends Component {
   }
 
   onPlayClicked() {
-    const { user, opponent, intermediary } = this.state;
+    const { opponent, intermediary } = this.state;
+    const { user } = this.props;
 
     this.setState({ isWaiting: true });
 
@@ -105,7 +99,8 @@ class Wager extends Component {
   }
 
   render() {
-    const { error, isLoaded, user, isWaiting } = this.state;
+    const { error, isLoaded, isWaiting } = this.state;
+    const { user } = this.props;
 
     if (error) {
       return (


### PR DESCRIPTION
dApps no longer depend on `/api/matchmake`'s `user` part of the response, because now they can request data to the Playground via `postMessage`.

**How does this work?**

1) dApp emits a request:

```js
window.parent.postMessage("playground:request:user");
```

2) Playground receives the message and posts back:
```js
frameWindow.postMessage(["playground:response:user", JSON.stringify(user)].join("|"));
```

3) dApp receives the response while listening to the `message` event:
```js
if (message.startsWith("playground:response:user") {
  // Extract the data and store it in the dApp's local state
}
```