### PR TITLE
[playground-server] [playground] Creates and sends a token upon account registration

### DIFF
--- a/packages/playground-server/src/controllers/create-account.ts
+++ b/packages/playground-server/src/controllers/create-account.ts
@@ -1,3 +1,4 @@
+import { sign } from "jsonwebtoken";
 import { Context } from "koa";
 import "koa-body"; // Needed for ctx.request.body to be detected by TS, see: https://github.com/dlau/koa-body/issues/109
 
@@ -25,11 +26,16 @@ export default function createAccount() {
       multisigAddress: multisig.multisigAddress
     });
 
+    // Create token.
+    const token = sign(user, process.env.NODE_PRIVATE_KEY as string, {
+      expiresIn: "1Y"
+    });
+
     const response = {
       ok: true,
       data: {
-        ...multisig,
-        user
+        user,
+        token
       }
     } as ApiResponse;
 

--- a/packages/playground-server/src/types.ts
+++ b/packages/playground-server/src/types.ts
@@ -55,16 +55,10 @@ export type ApiResponse = {
   error?: ErrorResponse;
   ok: boolean;
   data?:
-    | CreateAccountResponseData
     | GetAppsResponseData
     | MatchmakeResponseData
     | LoginResponseData
     | UserResponseData;
-};
-
-export type CreateAccountResponseData = {
-  user: PlaygroundUser;
-  multisigAddress: Address;
 };
 
 export type LoginResponseData = {

--- a/packages/playground-server/test/api.spec.ts
+++ b/packages/playground-server/test/api.spec.ts
@@ -106,7 +106,8 @@ describe("playground-server", () => {
         .then(response => {
           expect(response.status).toEqual(HttpStatusCode.Created);
           expect(response.data.ok).toBe(true);
-          expect(response.data.data.multisigAddress).toBeDefined();
+          expect(response.data.data.user.multisigAddress).toBeDefined();
+          expect(response.data.data.token).toBeDefined();
           done();
         })
         .catch(({ response }) => {

--- a/packages/playground/src/components/account/account-register/account-register.tsx
+++ b/packages/playground/src/components/account/account-register/account-register.tsx
@@ -86,8 +86,10 @@ export class AccountRegister {
 
       this.updateAccount({
         ...this.changeset,
-        multisigAddress: apiResponse.multisigAddress
+        multisigAddress: apiResponse.user.multisigAddress
       });
+
+      window.localStorage.setItem("playground:user:token", apiResponse.token);
 
       this.history.push("/deposit");
     } catch (e) {

--- a/packages/playground/src/data/playground-api-client.ts
+++ b/packages/playground/src/data/playground-api-client.ts
@@ -1,7 +1,6 @@
 import {
   ApiResponse,
   CreateAccountRequest,
-  CreateAccountResponseData,
   ErrorResponse,
   GetAppsResponseData,
   LoginRequest,
@@ -59,10 +58,9 @@ async function get(endpoint: string, token?: string): Promise<ApiResponse> {
 export default class PlaygroundAPIClient {
   public static async createAccount(
     data: CreateAccountRequest
-  ): Promise<CreateAccountResponseData> {
+  ): Promise<LoginResponseData> {
     try {
-      return (await post("create-account", data))
-        .data as CreateAccountResponseData;
+      return (await post("create-account", data)).data as LoginResponseData;
     } catch (e) {
       return Promise.reject(e);
     }


### PR DESCRIPTION
This PR implements the creation and local storage of a token upon account registration. The `/api/create-account` endpoint now includes a `token` property in its response.

On the client-side, the AccountRegister component picks up the property and pushes it to `localStorage`, under the key `playground:user:token`.