### PR TITLE
[monorepo] Replace peerAddress with respondingAddress

### DIFF
--- a/packages/cf.js/API_REFERENCE.md
+++ b/packages/cf.js/API_REFERENCE.md
@@ -46,7 +46,7 @@
         - `encodings:`[`AppABIEncodings`](#data-type-appabiencodings)
     - Instance methods
         - `async proposeInstall({
-                peerAddress: Address,
+                respondingAddress: Address,
                 asset: BlockchainAsset,
                 myDeposit: BigNumberish,
                 peerDeposit: BigNumberish,
@@ -54,7 +54,7 @@
            }): Promise<AppInstanceID>`
            - [Node method](#method-proposeinstall)
         - `async proposeInstallVirtual({
-                peerAddress: Address,
+                respondingAddress: Address,
                 asset: BlockchainAsset,
                 myDeposit: BigNumberish,
                 peerDeposit: BigNumberish,
@@ -148,8 +148,8 @@ Result:
 Requests that a peer start the install protocol for an app instance. At the same time, authorize the installation of that app instance, and generate and return a fresh ID for it. If the peer accepts and the install protocol completes, its ID should be the generated appInstanceId.
 
 Params:
-- `peerAddress: string`
-    - Address of the peer to request installation of the app with
+- `respondingAddress: string`
+    - Address of the peer responding to the installation request of the app
 - `appId: string`
     - On-chain address of App Definition contract
 - `abiEncodings:`[`AppABIEncodings`](#data-type-appabiencodings)
@@ -177,8 +177,8 @@ Errors: (TODO)
 Requests that a peer start the install protocol for a virtual app instance. At the same time, authorize the installation of that app instance, and generate and return a fresh ID for it. If the peer accepts and the install protocol completes, its ID should be the generated appInstanceId.
 
 Params:
-- `peerAddress: string`
-    - Address of the peer to request installation of the app with
+- `respondingAddress: string`
+    - Address of the peer responding to the installation request of the app
 - `appId: string`
     - On-chain address of App Definition contract
 - `abiEncodings:`[`AppABIEncodings`](#data-type-appabiencodings)

--- a/packages/cf.js/src/app-factory.ts
+++ b/packages/cf.js/src/app-factory.ts
@@ -57,7 +57,7 @@ export class AppFactory {
    */
   async proposeInstall(params: {
     /** Address of peer to install instance with */
-    peerAddress: Address;
+    respondingAddress: Address;
     /** Asset to use for deposit */
     asset: BlockchainAsset;
     /** Amount to be deposited by you */
@@ -80,7 +80,7 @@ export class AppFactory {
         peerDeposit,
         myDeposit,
         asset: params.asset,
-        peerAddress: params.peerAddress,
+        respondingAddress: params.respondingAddress,
         initialState: params.initialState,
         appId: this.appId,
         abiEncodings: this.encodings
@@ -99,7 +99,7 @@ export class AppFactory {
    */
   async proposeInstallVirtual(params: {
     /** Address of peer to install instance with */
-    peerAddress: Address;
+    respondingAddress: Address;
     /** Asset to use for deposit */
     asset: BlockchainAsset;
     /** Amount to be deposited by you */
@@ -124,7 +124,7 @@ export class AppFactory {
         peerDeposit,
         myDeposit,
         asset: params.asset,
-        peerAddress: params.peerAddress,
+        respondingAddress: params.respondingAddress,
         initialState: params.initialState,
         intermediaries: params.intermediaries,
         appId: this.appId,

--- a/packages/cf.js/test/app-factory.spec.ts
+++ b/packages/cf.js/test/app-factory.spec.ts
@@ -48,7 +48,7 @@ describe("CF.js AppFactory", () => {
         });
       });
       const appInstanceId = await appFactory.proposeInstall({
-        peerAddress: "0x0101010101010101010101010101010101010101",
+        respondingAddress: "0x0101010101010101010101010101010101010101",
         asset: {
           assetType: AssetType.ETH
         },
@@ -88,7 +88,7 @@ describe("CF.js AppFactory", () => {
         }
       );
       const appInstanceId = await appFactory.proposeInstallVirtual({
-        peerAddress: "0x0101010101010101010101010101010101010101",
+        respondingAddress: "0x0101010101010101010101010101010101010101",
         asset: {
           assetType: AssetType.ETH
         },
@@ -104,7 +104,7 @@ describe("CF.js AppFactory", () => {
     it("throws an error if BigNumber param invalid", async done => {
       try {
         await appFactory.proposeInstall({
-          peerAddress: "0x0101010101010101010101010101010101010101",
+          respondingAddress: "0x0101010101010101010101010101010101010101",
           asset: {
             assetType: AssetType.ETH
           },

--- a/packages/dapp-high-roller/src/components/app-wager/app-wager.tsx
+++ b/packages/dapp-high-roller/src/components/app-wager/app-wager.tsx
@@ -56,7 +56,7 @@ export class AppWager {
 
     try {
       await this.appFactory.proposeInstallVirtual({
-        peerAddress: this.opponent.address as string,
+        respondingAddress: this.opponent.address as string,
         asset: {
           assetType: 0 /* AssetType.ETH */
         },

--- a/packages/dapp-high-roller/src/data/types.ts
+++ b/packages/dapp-high-roller/src/data/types.ts
@@ -139,7 +139,7 @@ export namespace Node {
   };
 
   export type ProposeInstallParams = {
-    peerAddress: Address;
+    respondingAddress: Address;
     appId: Address;
     abiEncodings: AppABIEncodings;
     asset: BlockchainAsset;
@@ -309,14 +309,14 @@ export namespace cf {
       provider: cf.Provider
     ): AppFactory;
     proposeInstall(parameters: {
-      peerAddress: Address;
+      respondingAddress: Address;
       asset: BlockchainAsset;
       myDeposit: BigNumberish;
       peerDeposit: BigNumberish;
       initialState: AppState;
     }): Promise<AppInstanceID>;
     proposeInstallVirtual(parameters: {
-      peerAddress: Address;
+      respondingAddress: Address;
       asset: BlockchainAsset;
       myDeposit: BigNumberish;
       peerDeposit: BigNumberish;

--- a/packages/node/src/events/install/controller.ts
+++ b/packages/node/src/events/install/controller.ts
@@ -17,14 +17,14 @@ export async function installEventController(
   if (nodeMsg.data.proposal) {
     await setAppInstanceIDForProposeInstall(this.selfAddress, this.store, {
       ...params,
-      peerAddress: nodeMsg.from!
+      respondingAddress: nodeMsg.from!
     });
   } else {
     await install(
       this.store,
       this.instructionExecutor,
       this.selfAddress,
-      params.peerAddress,
+      params.respondingAddress,
       params
     );
   }

--- a/packages/node/src/events/install/operation.ts
+++ b/packages/node/src/events/install/operation.ts
@@ -11,7 +11,7 @@ export async function setAppInstanceIDForProposeInstall(
 ) {
   const channel = await getChannelFromPeerAddress(
     selfAddress,
-    params.peerAddress,
+    params.respondingAddress,
     store
   );
   const proposedAppInstance = new ProposedAppInstanceInfo(

--- a/packages/node/src/methods/app-instance/install/controller.ts
+++ b/packages/node/src/methods/app-instance/install/controller.ts
@@ -15,7 +15,7 @@ export default async function installAppInstanceController(
   this: RequestHandler,
   params: Node.InstallParams
 ): Promise<Node.InstallResult> {
-  const [peerAddress] = await getPeersAddressFromAppInstanceID(
+  const [respondingAddress] = await getPeersAddressFromAppInstanceID(
     this.selfAddress,
     this.store,
     params.appInstanceId
@@ -25,7 +25,7 @@ export default async function installAppInstanceController(
     this.store,
     this.instructionExecutor,
     this.selfAddress,
-    peerAddress,
+    respondingAddress,
     params
   );
 
@@ -38,7 +38,7 @@ export default async function installAppInstanceController(
     }
   };
 
-  await this.messagingService.send(peerAddress, installApprovalMsg);
+  await this.messagingService.send(respondingAddress, installApprovalMsg);
   return {
     appInstance
   };

--- a/packages/node/src/methods/app-instance/propose-install-virtual/controller.ts
+++ b/packages/node/src/methods/app-instance/propose-install-virtual/controller.ts
@@ -35,7 +35,7 @@ export default async function proposeInstallVirtualAppInstanceController(
     }
   };
 
-  await this.messagingService.send(params.peerAddress, proposalMsg);
+  await this.messagingService.send(params.respondingAddress, proposalMsg);
 
   return {
     appInstanceId

--- a/packages/node/src/methods/app-instance/propose-install/controller.ts
+++ b/packages/node/src/methods/app-instance/propose-install/controller.ts
@@ -37,7 +37,7 @@ export async function proposeInstallAppInstanceController(
     }
   };
 
-  await this.messagingService.send(params.peerAddress, proposalMsg);
+  await this.messagingService.send(params.respondingAddress, proposalMsg);
 
   return {
     appInstanceId
@@ -59,7 +59,7 @@ export async function createProposedAppInstance(
   const appInstanceId = generateUUID();
   const channel = await getChannelFromPeerAddress(
     selfAddress,
-    params.peerAddress,
+    params.respondingAddress,
     store
   );
 

--- a/packages/node/src/methods/state-channel/create/controller.ts
+++ b/packages/node/src/methods/state-channel/create/controller.ts
@@ -25,7 +25,9 @@ export default async function createMultisigController(
     this.networkContext
   );
 
-  const [respondingAddress] = params.owners.filter(owner => owner !== this.address);
+  const [respondingAddress] = params.owners.filter(
+    owner => owner !== this.address
+  );
 
   const multisigCreatedMsg: NodeMessage = {
     from: this.address,

--- a/packages/node/src/methods/state-channel/create/controller.ts
+++ b/packages/node/src/methods/state-channel/create/controller.ts
@@ -25,7 +25,7 @@ export default async function createMultisigController(
     this.networkContext
   );
 
-  const [peerAddress] = params.owners.filter(
+  const [respondingAddress] = params.owners.filter(
     owner => owner !== this.selfAddress
   );
 
@@ -38,7 +38,7 @@ export default async function createMultisigController(
       owners: params.owners
     }
   };
-  await this.messagingService.send(peerAddress, multisigCreatedMsg);
+  await this.messagingService.send(respondingAddress, multisigCreatedMsg);
   return {
     multisigAddress
   };

--- a/packages/node/src/services.ts
+++ b/packages/node/src/services.ts
@@ -3,7 +3,7 @@ import * as firebase from "firebase/app";
 import "firebase/database";
 
 export interface IMessagingService {
-  send(peerAddress: Address, msg: any);
+  send(respondingAddress: Address, msg: any);
   receive(address: Address, callback: (msg: any) => void);
 }
 
@@ -56,9 +56,9 @@ class FirebaseMessagingService implements IMessagingService {
     private readonly messagingServerKey: string
   ) {}
 
-  async send(peerAddress: Address, msg: object) {
+  async send(respondingAddress: Address, msg: object) {
     await this.firebase
-      .ref(`${this.messagingServerKey}/${peerAddress}`)
+      .ref(`${this.messagingServerKey}/${respondingAddress}`)
       .set(msg);
   }
 

--- a/packages/node/src/utils.ts
+++ b/packages/node/src/utils.ts
@@ -13,10 +13,10 @@ export function orderedAddressesHash(addresses: Address[]): string {
 
 export async function getChannelFromPeerAddress(
   selfAddress: Address,
-  peerAddress: Address,
+  respondingAddress: Address,
   store: Store
 ): Promise<StateChannel> {
-  const ownersHash = orderedAddressesHash([selfAddress, peerAddress]);
+  const ownersHash = orderedAddressesHash([selfAddress, respondingAddress]);
   const multisigAddress = await store.getMultisigAddressFromOwnersHash(
     ownersHash
   );

--- a/packages/node/test/integration/get-app-instances.spec.ts
+++ b/packages/node/test/integration/get-app-instances.spec.ts
@@ -57,18 +57,18 @@ describe("Node method follows spec - getAppInstances", () => {
 
   it("can accept a valid call to get non-empty list of app instances", async done => {
     // the peer with whom an installation proposal is being made
-    const peerAddress = new Wallet(process.env.B_PRIVATE_KEY!).address;
+    const respondingAddress = new Wallet(process.env.B_PRIVATE_KEY!).address;
 
     // first, a channel must be opened for it to have an app instance
     const multisigAddress = await getNewMultisig(node, [
       node.address,
-      peerAddress
+      respondingAddress
     ]);
     expect(multisigAddress).toBeDefined();
 
     // second, an app instance must be proposed to be installed into that channel
     const appInstanceInstallationProposalRequest = makeInstallProposalRequest(
-      peerAddress
+      respondingAddress
     );
 
     // third, the pending app instance needs to be installed

--- a/packages/node/test/integration/get-state.spec.ts
+++ b/packages/node/test/integration/get-state.spec.ts
@@ -58,16 +58,16 @@ describe("Node method follows spec - getAppInstances", () => {
 
   it("returns the right state for an installed AppInstance", async () => {
     // the peer with whom an installation proposal is being made
-    const peerAddress = getAddress(hexlify(randomBytes(20)));
+    const respondingAddress = getAddress(hexlify(randomBytes(20)));
 
     const multisigAddress = await getNewMultisig(node, [
       node.address,
-      peerAddress
+      respondingAddress
     ]);
     expect(multisigAddress).toBeDefined();
 
     const appInstanceInstallationProposalRequest = makeInstallProposalRequest(
-      peerAddress
+      respondingAddress
     );
 
     const proposalResult = await node.call(

--- a/packages/node/test/integration/utils.ts
+++ b/packages/node/test/integration/utils.ts
@@ -88,10 +88,10 @@ async function getApps(
 }
 
 export function makeInstallProposalRequest(
-  peerAddress: Address
+  respondingAddress: Address
 ): NodeTypes.MethodRequest {
   const params: NodeTypes.ProposeInstallParams = {
-    peerAddress: peerAddress as Address,
+    respondingAddress: respondingAddress as Address,
     appId: AddressZero,
     abiEncodings: {
       stateEncoding: "tuple(address foo, uint256 bar)",
@@ -116,10 +116,10 @@ export function makeInstallProposalRequest(
 }
 
 export function makeInstallVirtualProposalRequest(
-  peerAddress: Address,
+  respondingAddress: Address,
   intermediaries: Address[]
 ): NodeTypes.MethodRequest {
-  const installProposalParams = makeInstallProposalRequest(peerAddress)
+  const installProposalParams = makeInstallProposalRequest(respondingAddress)
     .params as NodeTypes.ProposeInstallParams;
 
   const installVirtualParams: NodeTypes.ProposeInstallVirtualParams = {

--- a/packages/node/test/services/mock-messaging-service.ts
+++ b/packages/node/test/services/mock-messaging-service.ts
@@ -3,7 +3,7 @@ import { Address } from "@counterfactual/types";
 import { IMessagingService } from "../../src/services";
 
 class MockMessagingService implements IMessagingService {
-  send(peerAddress: Address, msg: object) {}
+  send(respondingAddress: Address, msg: object) {}
   receive(address: Address, callback: (msg: object) => void) {}
 }
 

--- a/packages/playground/src/data/counterfactual.ts
+++ b/packages/playground/src/data/counterfactual.ts
@@ -19,7 +19,7 @@ declare class Node {
   on(event: string, callback: (res: any) => void): void;
   emit(event: string, req: NodeTypes.MethodRequest): void;
   readonly address: string;
-  send(peerAddress: Address, msg: object): Promise<void>;
+  send(respondingAddress: Address, msg: object): Promise<void>;
   get(key: string): Promise<any>;
   set(key: string, value: any): Promise<any>;
 }

--- a/packages/playground/src/data/firebase.ts
+++ b/packages/playground/src/data/firebase.ts
@@ -11,9 +11,9 @@ class FirebaseMessagingService implements IMessagingService {
     private readonly messagingServerKey: string
   ) {}
 
-  async send(peerAddress: Address, msg: object) {
+  async send(respondingAddress: Address, msg: object) {
     await this.firebase
-      .ref(`${this.messagingServerKey}/${peerAddress}`)
+      .ref(`${this.messagingServerKey}/${respondingAddress}`)
       .set(msg);
   }
 

--- a/packages/types/src/node-protocol.ts
+++ b/packages/types/src/node-protocol.ts
@@ -70,7 +70,7 @@ export namespace Node {
   };
 
   export type ProposeInstallParams = {
-    peerAddress: Address;
+    respondingAddress: Address;
     appId: Address;
     abiEncodings: AppABIEncodings;
     asset: BlockchainAsset;

--- a/packages/types/src/node.ts
+++ b/packages/types/src/node.ts
@@ -70,7 +70,7 @@ export namespace Node {
   };
 
   export type ProposeInstallParams = {
-    peerAddress: Address;
+    respondingAddress: Address;
     appId: Address;
     abiEncodings: AppABIEncodings;
     asset: BlockchainAsset;


### PR DESCRIPTION
### Description

To be consistent, this replaces the term `peerAddress` with `respondingAddress` to align with and reflect the recent term that was updated in the machine.

- [x] Deploy preview is functional
