### PR TITLE
[node] Update term referring to Node's own address

### DIFF
--- a/packages/node/src/events/install/controller.ts
+++ b/packages/node/src/events/install/controller.ts
@@ -15,7 +15,7 @@ export async function installEventController(
   const params = { ...nodeMsg.data };
   delete params.proposal;
   if (nodeMsg.data.proposal) {
-    await setAppInstanceIDForProposeInstall(this.selfAddress, this.store, {
+    await setAppInstanceIDForProposeInstall(this.address, this.store, {
       ...params,
       peerAddress: nodeMsg.from!
     });
@@ -23,7 +23,7 @@ export async function installEventController(
     await install(
       this.store,
       this.instructionExecutor,
-      this.selfAddress,
+      this.address,
       params.peerAddress,
       params
     );

--- a/packages/node/src/methods/app-instance/install/controller.ts
+++ b/packages/node/src/methods/app-instance/install/controller.ts
@@ -16,7 +16,7 @@ export default async function installAppInstanceController(
   params: Node.InstallParams
 ): Promise<Node.InstallResult> {
   const [peerAddress] = await getPeersAddressFromAppInstanceID(
-    this.selfAddress,
+    this.address,
     this.store,
     params.appInstanceId
   );
@@ -24,13 +24,13 @@ export default async function installAppInstanceController(
   const appInstance = await install(
     this.store,
     this.instructionExecutor,
-    this.selfAddress,
+    this.address,
     peerAddress,
     params
   );
 
   const installApprovalMsg: NodeMessage = {
-    from: this.selfAddress,
+    from: this.address,
     event: Node.EventName.INSTALL,
     data: {
       appInstanceId: appInstance.id,

--- a/packages/node/src/methods/app-instance/propose-install-virtual/controller.ts
+++ b/packages/node/src/methods/app-instance/propose-install-virtual/controller.ts
@@ -20,13 +20,13 @@ export default async function proposeInstallVirtualAppInstanceController(
   }
 
   const appInstanceId = await createProposedAppInstance(
-    this.selfAddress,
+    this.address,
     this.store,
     params
   );
 
   const proposalMsg: NodeMessage = {
-    from: this.selfAddress,
+    from: this.address,
     event: Node.EventName.INSTALL,
     data: {
       ...params,

--- a/packages/node/src/methods/app-instance/propose-install/controller.ts
+++ b/packages/node/src/methods/app-instance/propose-install/controller.ts
@@ -22,13 +22,13 @@ export async function proposeInstallAppInstanceController(
   }
 
   const appInstanceId = await createProposedAppInstance(
-    this.selfAddress,
+    this.address,
     this.store,
     params
   );
 
   const proposalMsg: NodeMessage = {
-    from: this.selfAddress,
+    from: this.address,
     event: Node.EventName.INSTALL,
     data: {
       ...params,

--- a/packages/node/src/methods/state-channel/create/controller.ts
+++ b/packages/node/src/methods/state-channel/create/controller.ts
@@ -25,12 +25,10 @@ export default async function createMultisigController(
     this.networkContext
   );
 
-  const [peerAddress] = params.owners.filter(
-    owner => owner !== this.selfAddress
-  );
+  const [peerAddress] = params.owners.filter(owner => owner !== this.address);
 
   const multisigCreatedMsg: NodeMessage = {
-    from: this.selfAddress,
+    from: this.address,
     event: Node.EventName.CREATE_MULTISIG,
     // TODO: define interface for cross-Node payloads
     data: {

--- a/packages/node/src/request-handler.ts
+++ b/packages/node/src/request-handler.ts
@@ -25,7 +25,7 @@ export class RequestHandler {
   private events = new Map();
   store: Store;
   constructor(
-    readonly selfAddress: Address,
+    readonly address: Address,
     readonly incoming: EventEmitter,
     readonly outgoing: EventEmitter,
     readonly storeService: IStoreService,


### PR DESCRIPTION
### Description

This drops `self` in referring to a Node's address to eliminate redundancy.

- [x] Deploy preview is functional
