### PR TITLE
[node] Initial implementation of IO_SEND

### DIFF
--- a/packages/node/src/events/protocol-message/controller.ts
+++ b/packages/node/src/events/protocol-message/controller.ts
@@ -12,6 +12,17 @@ export default async function protocolMessageEventController(
   requestHandler: RequestHandler,
   nodeMsg: NodeMessageWrappedProtocolMessage
 ) {
+  // FIXME: Take into account the protocols sequence length. More
+  //        generally this if statement is trying to capture the notion:
+  //        "do not restart a protocol if a message is received from another
+  //         client mid-protocol execution (assume IO_WAIT is listening)"
+  //
+  //        An alternative might be that IO_WAIT is hooked onto toms event
+  //        listeniner inside the instructionExecutor that emits noise
+  //        when dispatchReceivedMessage receives a message for an in-progress
+  //        protocol execution.
+  if (nodeMsg.data.seq === 2) return;
+
   await requestHandler.instructionExecutor.dispatchReceivedMessage(
     nodeMsg.data,
     new Map<string, StateChannel>(

--- a/packages/node/src/node.ts
+++ b/packages/node/src/node.ts
@@ -6,7 +6,7 @@ import {
   ProtocolMessage
 } from "@counterfactual/machine";
 import { NetworkContext, Node as NodeTypes } from "@counterfactual/types";
-import { AddressZero } from "ethers/constants";
+import { AddressZero, HashZero } from "ethers/constants";
 import { SigningKey } from "ethers/utils";
 import EventEmitter from "eventemitter3";
 
@@ -90,21 +90,41 @@ export class Node {
       Opcode.OP_SIGN,
       async (message: ProtocolMessage, next: Function, context: Context) => {
         if (!context.commitment) {
+          // TODO: I think this should be inside the machine for all protocols
           throw Error(
             "Reached OP_SIGN middleware without generated commitment."
           );
         }
-        context.signature = this.signer.signDigest(
-          context.commitment.hashToSign()
-        );
+        context.signature = {
+          v: -1,
+          r: HashZero,
+          s: HashZero
+        };
+        // TODO: Replace the above hack with the below
+        // context.signature = this.signer.signDigest(
+        //   context.commitment.hashToSign()
+        // );
         next();
       }
     );
   }
 
   private registerIoMiddleware() {
-    // TODO:
-    this.instructionExecutor.register(Opcode.IO_SEND, () => {});
+    this.instructionExecutor.register(
+      Opcode.IO_SEND,
+      async (message: ProtocolMessage, next: Function, context: Context) => {
+        await this.messagingService.send(context.outbox[0].toAddress, {
+          from: this.address,
+          event: NODE_EVENTS.PROTOCOL_MESSAGE_EVENT,
+          data: context.outbox[0]
+        });
+        next();
+      }
+    );
+
+    // TODO: Currently this mocks the response for all protocols as the below
+    //       mocked ProtocolMessage object. Next task is to listen for a real
+    //       message from a counterparty.
     this.instructionExecutor.register(
       Opcode.IO_WAIT,
       (message: ProtocolMessage, next: Function, context: Context) => {
@@ -121,8 +141,8 @@ export class Node {
           },
           signature: {
             v: -1,
-            r: "",
-            s: ""
+            r: HashZero,
+            s: HashZero
           }
         });
       }


### PR DESCRIPTION
This implements `IO_SEND` and adds some supporting mocks to ensure
it actually works.

So what is going on here is that real messages are being sent _from_ nodes however when they are expecting to receive the message, they aren't actually listening yet (that is a forthcoming PR or commit for `IO_WAIT`). Instead, that behaviour is mocked out.