### PR TITLE
[node] Implements rejectInstall

### DIFF
--- a/packages/node/src/api-router.ts
+++ b/packages/node/src/api-router.ts
@@ -48,7 +48,6 @@ export const eventNameToImplementation = {
   [NODE_EVENTS.REJECT_INSTALL]: rejectInstallEventController,
   // TODO: implement the rest
   [NODE_EVENTS.PROPOSE_STATE]: () => {},
-  [NODE_EVENTS.REJECT_INSTALL]: () => {},
   [NODE_EVENTS.REJECT_STATE]: () => {},
   [NODE_EVENTS.UNINSTALL]: () => {},
   [NODE_EVENTS.UPDATE_STATE]: () => {}

--- a/packages/node/src/api-router.ts
+++ b/packages/node/src/api-router.ts
@@ -5,6 +5,7 @@ import {
   installEventController,
   proposeInstallEventController,
   proposeInstallVirtualEventController,
+  rejectInstallEventController,
   takeActionEventController
 } from "./events";
 import protocolMessageEventController from "./events/protocol-message/controller";
@@ -44,6 +45,7 @@ export const eventNameToImplementation = {
   [NODE_EVENTS.PROPOSE_INSTALL_VIRTUAL]: proposeInstallVirtualEventController,
   [NODE_EVENTS.TAKE_ACTION]: takeActionEventController,
   [NODE_EVENTS.PROTOCOL_MESSAGE_EVENT]: protocolMessageEventController,
+  [NODE_EVENTS.REJECT_INSTALL]: rejectInstallEventController,
   // TODO: implement the rest
   [NODE_EVENTS.PROPOSE_STATE]: () => {},
   [NODE_EVENTS.REJECT_INSTALL]: () => {},

--- a/packages/node/src/api-router.ts
+++ b/packages/node/src/api-router.ts
@@ -17,6 +17,7 @@ import {
   installAppInstanceController,
   proposeInstallAppInstanceController,
   proposeInstallVirtualAppInstanceController,
+  rejectInstallController,
   takeActionController
 } from "./methods";
 import { NODE_EVENTS } from "./types";
@@ -32,7 +33,8 @@ export const methodNameToImplementation = {
   [Node.MethodName
     .PROPOSE_INSTALL_VIRTUAL]: proposeInstallVirtualAppInstanceController,
   [Node.MethodName.PROPOSE_INSTALL]: proposeInstallAppInstanceController,
-  [Node.MethodName.TAKE_ACTION]: takeActionController
+  [Node.MethodName.TAKE_ACTION]: takeActionController,
+  [Node.MethodName.REJECT_INSTALL]: rejectInstallController
 };
 
 export const eventNameToImplementation = {

--- a/packages/node/src/events/index.ts
+++ b/packages/node/src/events/index.ts
@@ -2,6 +2,7 @@ import installEventController from "./install/controller";
 import addMultisigController from "./multisig-created/controller";
 import proposeInstallVirtualEventController from "./propose-install-virtual/controller";
 import proposeInstallEventController from "./propose-install/controller";
+import rejectInstallEventController from "./reject-install/controller";
 import takeActionEventController from "./take-action/controller";
 
 export {
@@ -9,5 +10,6 @@ export {
   installEventController,
   proposeInstallEventController,
   proposeInstallVirtualEventController,
-  takeActionEventController
+  takeActionEventController,
+  rejectInstallEventController
 };

--- a/packages/node/src/events/reject-install/controller.ts
+++ b/packages/node/src/events/reject-install/controller.ts
@@ -1,0 +1,10 @@
+import { RequestHandler } from "../../request-handler";
+import { RejectProposalMessage } from "../../types";
+
+export default async function rejectInstallEventController(
+  requestHandler: RequestHandler,
+  msg: RejectProposalMessage
+) {
+  const { appInstanceId } = msg.data;
+  await requestHandler.store.removeAppInstanceProposal(appInstanceId);
+}

--- a/packages/node/src/methods/app-instance/reject-install/controller.ts
+++ b/packages/node/src/methods/app-instance/reject-install/controller.ts
@@ -1,0 +1,31 @@
+import { Node } from "@counterfactual/types";
+
+import { RequestHandler } from "../../../request-handler";
+import { NODE_EVENTS, RejectProposalMessage } from "../../../types";
+
+export default async function rejectInstallController(
+  requestHandler: RequestHandler,
+  params: Node.RejectInstallParams
+): Promise<Node.RejectInstallResult> {
+  const { appInstanceId } = params;
+  const appInstanceInfo = await requestHandler.store.getProposedAppInstanceInfo(
+    appInstanceId
+  );
+
+  await requestHandler.store.removeAppInstanceProposal(appInstanceId);
+
+  const rejectProposalMsg: RejectProposalMessage = {
+    from: requestHandler.address,
+    event: NODE_EVENTS.REJECT_INSTALL,
+    data: {
+      appInstanceId
+    }
+  };
+
+  await requestHandler.messagingService.send(
+    appInstanceInfo.initiatingAddress,
+    rejectProposalMsg
+  );
+
+  return {};
+}

--- a/packages/node/src/methods/index.ts
+++ b/packages/node/src/methods/index.ts
@@ -3,6 +3,7 @@ import getAppInstanceStateController from "./app-instance/get-state/controller";
 import installAppInstanceController from "./app-instance/install/controller";
 import proposeInstallVirtualAppInstanceController from "./app-instance/propose-install-virtual/controller";
 import proposeInstallAppInstanceController from "./app-instance/propose-install/controller";
+import rejectInstallController from "./app-instance/reject-install/controller";
 import takeActionController from "./app-instance/take-action/controller";
 import getProposedAppInstancesController from "./proposed-app-instance/get-all/controller";
 import createMultisigController from "./state-channel/create/controller";
@@ -17,5 +18,6 @@ export {
   installAppInstanceController,
   proposeInstallAppInstanceController,
   proposeInstallVirtualAppInstanceController,
-  takeActionController
+  takeActionController,
+  rejectInstallController
 };

--- a/packages/node/src/store.ts
+++ b/packages/node/src/store.ts
@@ -283,6 +283,9 @@ export class Store {
         this.storeKeyPrefix
       }/${DB_NAMESPACE_APP_INSTANCE_ID_TO_PROPOSED_APP_INSTANCE}`
     )) as { [appInstanceId: string]: ProposedAppInstanceInfoJSON };
+    if (!proposedAppInstancesJson) {
+      return [];
+    }
     return Array.from(Object.values(proposedAppInstancesJson)).map(
       proposedAppInstanceJson => {
         return ProposedAppInstanceInfo.fromJson(proposedAppInstanceJson);

--- a/packages/node/src/store.ts
+++ b/packages/node/src/store.ts
@@ -232,6 +232,23 @@ export class Store {
     ]);
   }
 
+  public async removeAppInstanceProposal(appInstanceId: string) {
+    await this.storeService.set([
+      {
+        key: `${
+          this.storeKeyPrefix
+        }/${DB_NAMESPACE_APP_INSTANCE_ID_TO_PROPOSED_APP_INSTANCE}/${appInstanceId}`,
+        value: null
+      },
+      {
+        key: `${
+          this.storeKeyPrefix
+        }/${DB_NAMESPACE_APP_INSTANCE_ID_TO_MULTISIG_ADDRESS}/${appInstanceId}`,
+        value: null
+      }
+    ]);
+  }
+
   public async getAppInstanceInfo(
     appInstanceId: string
   ): Promise<AppInstanceInfo> {

--- a/packages/node/src/types.ts
+++ b/packages/node/src/types.ts
@@ -66,3 +66,9 @@ export interface TakeActionMessage extends NodeMessage {
     appInstanceId: string;
   };
 }
+
+export interface RejectProposalMessage extends NodeMessage {
+  data: {
+    appInstanceId: string;
+  };
+}

--- a/packages/node/test/integration/reject-install.spec.ts
+++ b/packages/node/test/integration/reject-install.spec.ts
@@ -1,0 +1,137 @@
+import { Node as NodeTypes } from "@counterfactual/types";
+import { Provider } from "ethers/providers";
+import FirebaseServer from "firebase-server";
+import { instance, mock } from "ts-mockito";
+import { v4 as generateUUID } from "uuid";
+
+import { IMessagingService, IStoreService, Node, NodeConfig } from "../../src";
+import {
+  NODE_EVENTS,
+  ProposeMessage,
+  RejectProposalMessage
+} from "../../src/types";
+
+import TestFirebaseServiceFactory from "./services/firebase-service";
+import {
+  confirmProposedAppInstanceOnNode,
+  EMPTY_NETWORK,
+  getInstalledAppInstances,
+  getNewMultisig,
+  getProposedAppInstanceInfo,
+  getProposedAppInstances,
+  makeInstallProposalRequest,
+  makeRejectInstallRequest
+} from "./utils";
+
+describe("Node method follows spec - proposeInstall", () => {
+  let firebaseServiceFactory: TestFirebaseServiceFactory;
+  let firebaseServer: FirebaseServer;
+  let messagingService: IMessagingService;
+  let nodeA: Node;
+  let storeServiceA: IStoreService;
+  let nodeB: Node;
+  let storeServiceB: IStoreService;
+  let nodeConfig: NodeConfig;
+  let mockProvider: Provider;
+  let provider;
+
+  beforeAll(async () => {
+    firebaseServiceFactory = new TestFirebaseServiceFactory(
+      process.env.FIREBASE_DEV_SERVER_HOST!,
+      process.env.FIREBASE_DEV_SERVER_PORT!
+    );
+    firebaseServer = firebaseServiceFactory.createServer();
+    messagingService = firebaseServiceFactory.createMessagingService(
+      process.env.FIREBASE_MESSAGING_SERVER_KEY!
+    );
+    nodeConfig = {
+      STORE_KEY_PREFIX: process.env.FIREBASE_STORE_PREFIX_KEY!
+    };
+    mockProvider = mock(Provider);
+    provider = instance(mockProvider);
+  });
+
+  beforeEach(async () => {
+    storeServiceA = firebaseServiceFactory.createStoreService(
+      process.env.FIREBASE_STORE_SERVER_KEY! + generateUUID()
+    );
+    nodeA = await Node.create(
+      messagingService,
+      storeServiceA,
+      EMPTY_NETWORK,
+      nodeConfig,
+      provider
+    );
+
+    storeServiceB = firebaseServiceFactory.createStoreService(
+      process.env.FIREBASE_STORE_SERVER_KEY! + generateUUID()
+    );
+    nodeB = await Node.create(
+      messagingService,
+      storeServiceB,
+      EMPTY_NETWORK,
+      nodeConfig,
+      provider
+    );
+  });
+
+  afterAll(() => {
+    firebaseServer.close();
+  });
+
+  describe(
+    "Node A gets app install proposal, sends to node B, B approves it, installs it," +
+      "sends acks back to A, A installs it, both nodes have the same app instance",
+    () => {
+      it("sends proposal with non-null initial state", async done => {
+        // A channel is first created between the two nodes
+        const multisigAddress = await getNewMultisig(nodeA, [
+          nodeA.address,
+          nodeB.address
+        ]);
+        expect(multisigAddress).toBeDefined();
+        expect(await getInstalledAppInstances(nodeA)).toEqual([]);
+        expect(await getInstalledAppInstances(nodeB)).toEqual([]);
+
+        let appInstanceId;
+
+        // second, an app instance must be proposed to be installed into that channel
+        const appInstanceInstallationProposalRequest = makeInstallProposalRequest(
+          nodeB.address
+        );
+
+        nodeA.on(
+          NODE_EVENTS.REJECT_INSTALL,
+          async (msg: RejectProposalMessage) => {
+            expect((await getProposedAppInstances(nodeA)).length).toEqual(0);
+            done();
+          }
+        );
+
+        // node B then decides to reject the proposal
+        nodeB.on(NODE_EVENTS.PROPOSE_INSTALL, async (msg: ProposeMessage) => {
+          confirmProposedAppInstanceOnNode(
+            appInstanceInstallationProposalRequest.params,
+            await getProposedAppInstanceInfo(nodeA, appInstanceId)
+          );
+
+          const rejectReq = makeRejectInstallRequest(msg.data.appInstanceId);
+
+          // Node A should have a proposal in place before Node B rejects it
+          expect((await getProposedAppInstances(nodeA)).length).toEqual(1);
+
+          await nodeB.call(rejectReq.type, rejectReq);
+
+          expect((await getProposedAppInstances(nodeB)).length).toEqual(0);
+        });
+
+        const response = await nodeA.call(
+          appInstanceInstallationProposalRequest.type,
+          appInstanceInstallationProposalRequest
+        );
+        appInstanceId = (response.result as NodeTypes.ProposeInstallResult)
+          .appInstanceId;
+      });
+    }
+  );
+});

--- a/packages/node/test/integration/utils.ts
+++ b/packages/node/test/integration/utils.ts
@@ -125,6 +125,18 @@ export function makeInstallRequest(
   };
 }
 
+export function makeRejectInstallRequest(
+  appInstanceId: string
+): NodeTypes.MethodRequest {
+  return {
+    requestId: generateUUID(),
+    type: NodeTypes.MethodName.REJECT_INSTALL,
+    params: {
+      appInstanceId
+    } as NodeTypes.RejectInstallParams
+  };
+}
+
 export function makeInstallProposalRequest(
   respondingAddress: Address,
   nullInitialState: boolean = false


### PR DESCRIPTION
### Description

This implements the [`rejectInstall`](https://github.com/counterfactual/monorepo/blob/master/packages/cf.js/API_REFERENCE.md#method-rejectInstall) public API method.

Note this is only for non-virtual AppInstances. Implementation for rejecting a Virtual AppInstance will follow this.

- [x] Deploy preview is functional
