### PR TITLE
[dapp-high-roller] Add opponent name to waiting screen

### DIFF
--- a/packages/dapp-high-roller/src/components/app-game/app-game.tsx
+++ b/packages/dapp-high-roller/src/components/app-game/app-game.tsx
@@ -113,8 +113,8 @@ export class AppGame {
   @Prop() cfProvider: cf.Provider = {} as cf.Provider;
   @Prop({ mutable: true }) appInstance: AppInstance = {} as AppInstance;
 
-  @Prop() user: any = { username: "Facundo" };
-  @Prop() opponent: any = { username: "John" };
+  @Prop() account: any = { user: { username: "Facundo" } };
+  @Prop() opponent: any = { attributes: { username: "John" } };
 
   defaultHighRollerState: HighRollerAppState = {
     playerAddrs: [AddressZero, AddressZero],
@@ -243,7 +243,7 @@ export class AppGame {
       <div class="wrapper">
         <div class="game">
           <app-game-player
-            playerName={this.opponent.username}
+            playerName={this.opponent.attributes.username}
             playerScore={this.opponentScore}
             playerType={PlayerType.Black}
             playerRoll={this.opponentRoll}
@@ -253,7 +253,7 @@ export class AppGame {
             betAmount={this.betAmount}
           />
           <app-game-player
-            playerName={this.user.username}
+            playerName={this.account.user.username}
             playerScore={this.myScore}
             playerType={PlayerType.White}
             playerRoll={this.myRoll}
@@ -293,4 +293,4 @@ export class AppGame {
   }
 }
 
-CounterfactualTunnel.injectProps(AppGame, ["user", "opponent"]);
+CounterfactualTunnel.injectProps(AppGame, ["account", "opponent"]);

--- a/packages/dapp-high-roller/src/components/app-root/app-root.tsx
+++ b/packages/dapp-high-roller/src/components/app-root/app-root.tsx
@@ -23,14 +23,14 @@ export class AppRoot {
   constructor() {
     const params = new URLSearchParams(window.location.search);
     this.state = {
-      user: {},
+      account: {},
       opponent: {},
       standalone: params.get("standalone") === "true" || false,
       appInstance: null,
       appFactory: null,
       updateAppInstance: this.updateAppInstance.bind(this),
       updateAppFactory: this.updateAppFactory.bind(this),
-      updateUser: this.updateUser.bind(this),
+      updateUser: this.updateAccount.bind(this),
       updateOpponent: this.updateOpponent.bind(this)
     };
   }
@@ -43,25 +43,27 @@ export class AppRoot {
       ) {
         const [, data] = event.data.split("|");
         const account = JSON.parse(data);
-        this.updateUser(account);
+        this.updateAccount(account);
         console.log(this.state);
       }
     });
 
     window.parent.postMessage("playground:request:user", "*");
     if (this.state.standalone) {
-      const mockUser = {
-        address: "0xc60b9023bb8dc153b4046977328ce79af12a77e0",
-        email: "alon2@example.com",
-        id: "687297bc-8014-4c82-8cee-3b7ca7db09d4",
-        multisigAddress: "0x9499ac5A66c36447e535d252c049304D80961CED",
-        username: "MyName"
+      const mockAccount = {
+        user: {
+          address: "0xc60b9023bb8dc153b4046977328ce79af12a77e0",
+          email: "alon2@example.com",
+          id: "687297bc-8014-4c82-8cee-3b7ca7db09d4",
+          username: "MyName"
+        },
+        multisigAddress: "0x9499ac5A66c36447e535d252c049304D80961CED"
       };
-      this.updateUser(mockUser);
+      this.updateAccount(mockAccount);
     }
   }
 
-  updateUser(account: any) {
+  updateAccount(account: any) {
     this.state = { ...this.state, account };
   }
 

--- a/packages/dapp-high-roller/src/components/app-wager/app-wager.tsx
+++ b/packages/dapp-high-roller/src/components/app-wager/app-wager.tsx
@@ -132,7 +132,7 @@ export class AppWager {
                 id: this.account.user.id
               }
             },
-            matchedUsers: {
+            matchedUser: {
               data: {
                 type: "matchedUsers",
                 id: "3d54b508-b355-4323-8738-4cdf7290a2fd"

--- a/packages/dapp-high-roller/src/components/app-waiting/app-waiting.tsx
+++ b/packages/dapp-high-roller/src/components/app-waiting/app-waiting.tsx
@@ -106,6 +106,7 @@ export class AppWaiting {
                 <p class="countdown">{this.seconds}</p>
                 <p>
                   Player: {this.myName} <br />
+                  Opponent: {this.opponentName} <br />
                   Bet Amount: {this.betAmount} ETH
                 </p>
               </div>

--- a/packages/dapp-high-roller/src/data/mock-node-provider.ts
+++ b/packages/dapp-high-roller/src/data/mock-node-provider.ts
@@ -52,7 +52,7 @@ export default class NodeProvider implements INodeProvider {
             type: Node.EventName.INSTALL,
             data: { appInstanceId }
           },
-          200
+          5000
         );
         break;
       case Node.MethodName.GET_APP_INSTANCE_DETAILS:


### PR DESCRIPTION
### Description

Add opponent name to waiting screen

In addition this fixes some issues and errors that were being thrown when running in standalone.
Another issue is that the API for getting a user was updated, but the usage of that user, (renamed to account) wasn't updated.

- [ ] Deploy preview is functional
