### PR TITLE
[node] Implements rejectInstall for Virtual AppInstance

### DIFF
--- a/packages/node/src/api-router.ts
+++ b/packages/node/src/api-router.ts
@@ -7,6 +7,7 @@ import {
   proposeInstallEventController,
   proposeInstallVirtualEventController,
   rejectInstallEventController,
+  rejectInstallVirtualEventController,
   takeActionEventController
 } from "./events";
 import protocolMessageEventController from "./events/protocol-message/controller";
@@ -50,6 +51,7 @@ export const eventNameToImplementation = {
   [NODE_EVENTS.TAKE_ACTION]: takeActionEventController,
   [NODE_EVENTS.PROTOCOL_MESSAGE_EVENT]: protocolMessageEventController,
   [NODE_EVENTS.REJECT_INSTALL]: rejectInstallEventController,
+  [NODE_EVENTS.REJECT_INSTALL_VIRTUAL]: rejectInstallVirtualEventController,
   // TODO: implement the rest
   [NODE_EVENTS.PROPOSE_STATE]: () => {},
   [NODE_EVENTS.REJECT_STATE]: () => {},

--- a/packages/node/src/events/index.ts
+++ b/packages/node/src/events/index.ts
@@ -3,6 +3,7 @@ import installEventController from "./install/controller";
 import addMultisigController from "./multisig-created/controller";
 import proposeInstallVirtualEventController from "./propose-install-virtual/controller";
 import proposeInstallEventController from "./propose-install/controller";
+import rejectInstallVirtualEventController from "./reject-install-virtual/controller";
 import rejectInstallEventController from "./reject-install/controller";
 import takeActionEventController from "./take-action/controller";
 
@@ -13,5 +14,6 @@ export {
   proposeInstallEventController,
   proposeInstallVirtualEventController,
   takeActionEventController,
-  rejectInstallEventController
+  rejectInstallEventController,
+  rejectInstallVirtualEventController
 };

--- a/packages/node/src/events/reject-install-virtual/controller.ts
+++ b/packages/node/src/events/reject-install-virtual/controller.ts
@@ -1,0 +1,10 @@
+import { RequestHandler } from "../../request-handler";
+import { RejectProposalMessage } from "../../types";
+
+export default async function rejectInstallVirtualEventController(
+  requestHandler: RequestHandler,
+  msg: RejectProposalMessage
+) {
+  const { appInstanceId } = msg.data;
+  await requestHandler.store.removeAppInstanceProposal(appInstanceId);
+}

--- a/packages/node/src/methods/app-instance/reject-install-virtual/controller.ts
+++ b/packages/node/src/methods/app-instance/reject-install-virtual/controller.ts
@@ -1,0 +1,31 @@
+import { Node } from "@counterfactual/types";
+
+import { RequestHandler } from "../../../request-handler";
+import { NODE_EVENTS, RejectInstallVirtualMessage } from "../../../types";
+
+export default async function rejectInstallVirtualController(
+  requestHandler: RequestHandler,
+  params: Node.RejectInstallParams
+): Promise<Node.RejectInstallResult> {
+  const { appInstanceId } = params;
+  const appInstanceInfo = await requestHandler.store.getProposedAppInstanceInfo(
+    appInstanceId
+  );
+
+  await requestHandler.store.removeAppInstanceProposal(appInstanceId);
+
+  const rejectInstallVirtualMsg: RejectInstallVirtualMessage = {
+    from: requestHandler.address,
+    event: NODE_EVENTS.REJECT_INSTALL_VIRTUAL,
+    data: {
+      appInstanceId
+    }
+  };
+
+  await requestHandler.messagingService.send(
+    appInstanceInfo.initiatingAddress,
+    rejectInstallVirtualMsg
+  );
+
+  return {};
+}

--- a/packages/node/src/methods/app-instance/reject-install/controller.ts
+++ b/packages/node/src/methods/app-instance/reject-install/controller.ts
@@ -2,6 +2,7 @@ import { Node } from "@counterfactual/types";
 
 import { RequestHandler } from "../../../request-handler";
 import { NODE_EVENTS, RejectProposalMessage } from "../../../types";
+import rejectInstallVirtualController from "../reject-install-virtual/controller";
 
 export default async function rejectInstallController(
   requestHandler: RequestHandler,
@@ -11,6 +12,10 @@ export default async function rejectInstallController(
   const appInstanceInfo = await requestHandler.store.getProposedAppInstanceInfo(
     appInstanceId
   );
+
+  if (appInstanceInfo.intermediaries) {
+    return rejectInstallVirtualController(requestHandler, params);
+  }
 
   await requestHandler.store.removeAppInstanceProposal(appInstanceId);
 

--- a/packages/node/src/methods/index.ts
+++ b/packages/node/src/methods/index.ts
@@ -4,6 +4,7 @@ import installVirtualAppInstanceController from "./app-instance/install-virtual/
 import installAppInstanceController from "./app-instance/install/controller";
 import proposeInstallVirtualAppInstanceController from "./app-instance/propose-install-virtual/controller";
 import proposeInstallAppInstanceController from "./app-instance/propose-install/controller";
+import rejectInstallVirtualController from "./app-instance/reject-install-virtual/controller";
 import rejectInstallController from "./app-instance/reject-install/controller";
 import takeActionController from "./app-instance/take-action/controller";
 import getProposedAppInstancesController from "./proposed-app-instance/get-all/controller";
@@ -21,5 +22,6 @@ export {
   proposeInstallAppInstanceController,
   proposeInstallVirtualAppInstanceController,
   takeActionController,
-  rejectInstallController
+  rejectInstallController,
+  rejectInstallVirtualController
 };

--- a/packages/node/src/methods/index.ts
+++ b/packages/node/src/methods/index.ts
@@ -4,7 +4,6 @@ import installVirtualAppInstanceController from "./app-instance/install-virtual/
 import installAppInstanceController from "./app-instance/install/controller";
 import proposeInstallVirtualAppInstanceController from "./app-instance/propose-install-virtual/controller";
 import proposeInstallAppInstanceController from "./app-instance/propose-install/controller";
-import rejectInstallVirtualController from "./app-instance/reject-install-virtual/controller";
 import rejectInstallController from "./app-instance/reject-install/controller";
 import takeActionController from "./app-instance/take-action/controller";
 import getProposedAppInstancesController from "./proposed-app-instance/get-all/controller";
@@ -22,6 +21,5 @@ export {
   proposeInstallAppInstanceController,
   proposeInstallVirtualAppInstanceController,
   takeActionController,
-  rejectInstallController,
-  rejectInstallVirtualController
+  rejectInstallController
 };

--- a/packages/node/src/types.ts
+++ b/packages/node/src/types.ts
@@ -14,7 +14,8 @@ enum Events {
   PROPOSE_INSTALL_VIRTUAL = "proposeInstallVirtualEvent",
   TAKE_ACTION = "takeActionEvent",
   PROTOCOL_MESSAGE_EVENT = "protocolMessageEvent",
-  INSTALL_VIRTUAL = "installVirtualEvent"
+  INSTALL_VIRTUAL = "installVirtualEvent",
+  REJECT_INSTALL_VIRTUAL = "rejectInstallVirtualEvent"
 }
 
 // Because `extend`ing isn't a native enum feature
@@ -80,3 +81,5 @@ export interface RejectProposalMessage extends NodeMessage {
     appInstanceId: string;
   };
 }
+
+export interface RejectInstallVirtualMessage extends RejectProposalMessage {}

--- a/packages/node/test/integration/reject-install-virtual.spec.ts
+++ b/packages/node/test/integration/reject-install-virtual.spec.ts
@@ -1,0 +1,167 @@
+import { Node as NodeTypes } from "@counterfactual/types";
+import { Provider } from "ethers/providers";
+import FirebaseServer from "firebase-server";
+import { instance, mock } from "ts-mockito";
+import { v4 as generateUUID } from "uuid";
+
+import { IMessagingService, IStoreService, Node, NodeConfig } from "../../src";
+import {
+  NODE_EVENTS,
+  ProposeVirtualMessage,
+  RejectProposalMessage
+} from "../../src/types";
+
+import TestFirebaseServiceFactory from "./services/firebase-service";
+import {
+  confirmProposedVirtualAppInstanceOnNode,
+  EMPTY_NETWORK,
+  getNewMultisig,
+  getProposedAppInstances,
+  makeInstallVirtualProposalRequest,
+  makeRejectInstallRequest
+} from "./utils";
+
+describe("Node method follows spec - rejectInstallVirtual", () => {
+  let firebaseServiceFactory: TestFirebaseServiceFactory;
+  let firebaseServer: FirebaseServer;
+  let messagingService: IMessagingService;
+  let nodeA: Node;
+  let storeServiceA: IStoreService;
+  let nodeB: Node;
+  let storeServiceB: IStoreService;
+  let nodeC: Node;
+  let storeServiceC: IStoreService;
+  let nodeConfig: NodeConfig;
+  let mockProvider: Provider;
+  let provider;
+
+  beforeAll(async () => {
+    firebaseServiceFactory = new TestFirebaseServiceFactory(
+      process.env.FIREBASE_DEV_SERVER_HOST!,
+      process.env.FIREBASE_DEV_SERVER_PORT!
+    );
+    firebaseServer = firebaseServiceFactory.createServer();
+    messagingService = firebaseServiceFactory.createMessagingService(
+      process.env.FIREBASE_MESSAGING_SERVER_KEY!
+    );
+    nodeConfig = {
+      STORE_KEY_PREFIX: process.env.FIREBASE_STORE_PREFIX_KEY!
+    };
+    mockProvider = mock(Provider);
+    provider = instance(mockProvider);
+  });
+
+  beforeEach(async () => {
+    // Setting up a different store service to simulate different store services
+    // being used for each Node
+    storeServiceA = firebaseServiceFactory.createStoreService(
+      process.env.FIREBASE_STORE_SERVER_KEY! + generateUUID()
+    );
+    nodeA = await Node.create(
+      messagingService,
+      storeServiceA,
+      EMPTY_NETWORK,
+      nodeConfig,
+      provider
+    );
+
+    storeServiceB = firebaseServiceFactory.createStoreService(
+      process.env.FIREBASE_STORE_SERVER_KEY! + generateUUID()
+    );
+    nodeB = await Node.create(
+      messagingService,
+      storeServiceB,
+      EMPTY_NETWORK,
+      nodeConfig,
+      provider
+    );
+
+    storeServiceC = firebaseServiceFactory.createStoreService(
+      process.env.FIREBASE_STORE_SERVER_KEY! + generateUUID()
+    );
+    nodeC = await Node.create(
+      messagingService,
+      storeServiceC,
+      EMPTY_NETWORK,
+      nodeConfig,
+      provider
+    );
+  });
+
+  afterAll(() => {
+    firebaseServer.close();
+  });
+  describe(
+    "Node A makes a proposal through an intermediary Node B to install a " +
+      "Virtual AppInstance with Node C. Node C rejects proposal. Node A confirms rejection",
+    () => {
+      it("sends proposal with non-null initial state", async done => {
+        const multisigAddressAB = await getNewMultisig(nodeA, [
+          nodeA.address,
+          nodeB.address
+        ]);
+        expect(multisigAddressAB).toBeDefined();
+
+        const multisigAddressBC = await getNewMultisig(nodeB, [
+          nodeB.address,
+          nodeC.address
+        ]);
+        expect(multisigAddressBC).toBeDefined();
+
+        const intermediaries = [nodeB.address];
+        const installVirtualAppInstanceProposalRequest = makeInstallVirtualProposalRequest(
+          nodeC.address,
+          intermediaries
+        );
+
+        nodeA.on(
+          NODE_EVENTS.REJECT_INSTALL_VIRTUAL,
+          async (msg: RejectProposalMessage) => {
+            expect((await getProposedAppInstances(nodeA)).length).toEqual(0);
+            done();
+          }
+        );
+
+        nodeC.on(
+          NODE_EVENTS.PROPOSE_INSTALL_VIRTUAL,
+          async (msg: ProposeVirtualMessage) => {
+            const proposedAppInstanceA = (await getProposedAppInstances(
+              nodeA
+            ))[0];
+            const proposedAppInstanceC = (await getProposedAppInstances(
+              nodeC
+            ))[0];
+
+            confirmProposedVirtualAppInstanceOnNode(
+              installVirtualAppInstanceProposalRequest.params,
+              proposedAppInstanceA
+            );
+            confirmProposedVirtualAppInstanceOnNode(
+              installVirtualAppInstanceProposalRequest.params,
+              proposedAppInstanceC
+            );
+
+            expect(proposedAppInstanceC.initiatingAddress).toEqual(
+              nodeA.address
+            );
+            expect(proposedAppInstanceA.id).toEqual(proposedAppInstanceC.id);
+
+            const rejectReq = makeRejectInstallRequest(msg.data.appInstanceId);
+
+            await nodeC.call(rejectReq.type, rejectReq);
+
+            expect((await getProposedAppInstances(nodeC)).length).toEqual(0);
+          }
+        );
+
+        const response = await nodeA.call(
+          installVirtualAppInstanceProposalRequest.type,
+          installVirtualAppInstanceProposalRequest
+        );
+        const appInstanceId = (response.result as NodeTypes.ProposeInstallVirtualResult)
+          .appInstanceId;
+        expect(appInstanceId).toBeDefined();
+      });
+    }
+  );
+});

--- a/packages/node/test/integration/reject-install.spec.ts
+++ b/packages/node/test/integration/reject-install.spec.ts
@@ -23,7 +23,7 @@ import {
   makeRejectInstallRequest
 } from "./utils";
 
-describe("Node method follows spec - proposeInstall", () => {
+describe("Node method follows spec - rejectInstall", () => {
   let firebaseServiceFactory: TestFirebaseServiceFactory;
   let firebaseServer: FirebaseServer;
   let messagingService: IMessagingService;


### PR DESCRIPTION
### Description

This is the follow up to https://github.com/counterfactual/monorepo/pull/558. It implements support for making the [`rejectInstall`](https://github.com/counterfactual/monorepo/blob/master/packages/cf.js/API_REFERENCE.md#method-rejectInstall) call on proposed Virtual AppInstances.

- [x] Deploy preview is functional
