### PR TITLE
[node, machine] Deep machine integration into the Node (including IO_SEND, IO_WAIT)

### DIFF
--- a/packages/apps/tslint.json
+++ b/packages/apps/tslint.json
@@ -1,6 +1,6 @@
 {
   "extends": ["../../tslint.json"],
   "linterOptions": {
-    "exclude": ["build/*.json"]
+    "exclude": ["**/*.json"]
   }
 }

--- a/packages/machine/src/models/state-channel.ts
+++ b/packages/machine/src/models/state-channel.ts
@@ -43,8 +43,9 @@ const ERRORS = {
     "multisigOwners parameter of StateChannel must be sorted"
 };
 
-const sortAddresses = (addrs: string[]) =>
-  addrs.sort((a, b) => (parseInt(a, 16) < parseInt(b, 16) ? -1 : 1));
+function sortAddresses(addrs: string[]) {
+  return addrs.sort((a, b) => (parseInt(a, 16) < parseInt(b, 16) ? -1 : 1));
+}
 
 export type StateChannelJSON = {
   readonly multisigAddress: string;

--- a/packages/machine/src/models/state-channel.ts
+++ b/packages/machine/src/models/state-channel.ts
@@ -43,6 +43,9 @@ const ERRORS = {
     "multisigOwners parameter of StateChannel must be sorted"
 };
 
+const sortAddresses = (addrs: string[]) =>
+  addrs.sort((a, b) => (parseInt(a, 16) < parseInt(b, 16) ? -1 : 1));
+
 export type StateChannelJSON = {
   readonly multisigAddress: string;
   readonly multisigOwners: string[];
@@ -104,9 +107,7 @@ export class StateChannel {
     private readonly monotonicNumInstalledApps: number = 0,
     public readonly rootNonceValue: number = 0
   ) {
-    const sortedMultisigOwners = multisigOwners.sort((a, b) =>
-      parseInt(a, 16) < parseInt(b, 16) ? -1 : 1
-    );
+    const sortedMultisigOwners = sortAddresses(multisigOwners);
     multisigOwners.forEach((owner, idx) => {
       if (owner !== sortedMultisigOwners[idx]) {
         throw new Error(ERRORS.MULTISIG_OWNERS_NOT_SORTED);
@@ -182,9 +183,11 @@ export class StateChannel {
     multisigAddress: string,
     multisigOwners: string[]
   ) {
+    const sortedMultisigOwners = sortAddresses(multisigOwners);
+
     const fb = createETHFreeBalance(
       multisigAddress,
-      multisigOwners,
+      sortedMultisigOwners,
       network.ETHBucket
     );
 
@@ -196,7 +199,7 @@ export class StateChannel {
 
     return new StateChannel(
       multisigAddress,
-      multisigOwners,
+      sortedMultisigOwners,
       appInstances,
       new Map<string, ETHVirtualAppAgreementInstance>(),
       freeBalanceAppIndexes,

--- a/packages/machine/src/models/state-channel.ts
+++ b/packages/machine/src/models/state-channel.ts
@@ -180,7 +180,7 @@ export class StateChannel {
   }
 
   public static setupChannel(
-    network: NetworkContext,
+    ethBucketAddress: string,
     multisigAddress: string,
     multisigOwners: string[]
   ) {
@@ -189,7 +189,7 @@ export class StateChannel {
     const fb = createETHFreeBalance(
       multisigAddress,
       sortedMultisigOwners,
-      network.ETHBucket
+      ethBucketAddress
     );
 
     const appInstances = new Map<string, AppInstance>();

--- a/packages/machine/src/models/state-channel.ts
+++ b/packages/machine/src/models/state-channel.ts
@@ -1,9 +1,4 @@
-import {
-  AppState,
-  AssetType,
-  ETHBucketAppState,
-  NetworkContext
-} from "@counterfactual/types";
+import { AppState, AssetType, ETHBucketAppState } from "@counterfactual/types";
 import { Zero } from "ethers/constants";
 import { INSUFFICIENT_FUNDS } from "ethers/errors";
 import { BigNumber, bigNumberify } from "ethers/utils";

--- a/packages/machine/src/protocol/install.ts
+++ b/packages/machine/src/protocol/install.ts
@@ -114,13 +114,14 @@ function proposeStateTransition(message: ProtocolMessage, context: Context) {
   const newStateChannel = context.stateChannelsMap
     .get(multisigAddress)!
     .installApp(appInstance, aliceBalanceDecrement, bobBalanceDecrement);
+
   context.stateChannelsMap.set(multisigAddress, newStateChannel);
 
   const appIdentityHash = appInstance.identityHash;
 
   context.commitment = constructInstallOp(
     context.network,
-    context.stateChannelsMap.get(multisigAddress)!,
+    newStateChannel,
     appIdentityHash
   );
 

--- a/packages/machine/src/protocol/setup.ts
+++ b/packages/machine/src/protocol/setup.ts
@@ -86,8 +86,19 @@ function proposeStateTransition(message: ProtocolMessage, context: Context) {
     respondingAddress
   } = message.params as SetupParams;
 
-  if (context.stateChannelsMap.has(multisigAddress)) {
-    throw Error(`Found an already-setup channel at ${multisigAddress}`);
+  if (!context.stateChannelsMap.has(multisigAddress)) {
+    context.stateChannelsMap.set(
+      multisigAddress,
+      new StateChannel(
+        multisigAddress,
+        [initiatingAddress, respondingAddress].sort((a, b) =>
+          parseInt(a, 16) < parseInt(b, 16) ? -1 : 1
+        )
+      )
+    );
+  } else {
+    // TODO: Probably should happen inside InstructionExecutor class
+    throw Error("Cannot run SetupProtocol twice on the same StateChannel");
   }
 
   const newStateChannel = StateChannel.setupChannel(

--- a/packages/machine/src/protocol/setup.ts
+++ b/packages/machine/src/protocol/setup.ts
@@ -86,19 +86,8 @@ function proposeStateTransition(message: ProtocolMessage, context: Context) {
     respondingAddress
   } = message.params as SetupParams;
 
-  if (!context.stateChannelsMap.has(multisigAddress)) {
-    context.stateChannelsMap.set(
-      multisigAddress,
-      new StateChannel(
-        multisigAddress,
-        [initiatingAddress, respondingAddress].sort((a, b) =>
-          parseInt(a, 16) < parseInt(b, 16) ? -1 : 1
-        )
-      )
-    );
-  } else {
-    // TODO: Probably should happen inside InstructionExecutor class
-    throw Error("Cannot run SetupProtocol twice on the same StateChannel");
+  if (context.stateChannelsMap.has(multisigAddress)) {
+    throw Error(`Found an already-setup channel at ${multisigAddress}`);
   }
 
   const newStateChannel = StateChannel.setupChannel(

--- a/packages/machine/src/protocol/setup.ts
+++ b/packages/machine/src/protocol/setup.ts
@@ -91,7 +91,7 @@ function proposeStateTransition(message: ProtocolMessage, context: Context) {
   }
 
   const newStateChannel = StateChannel.setupChannel(
-    context.network,
+    context.network.ETHBucket,
     multisigAddress,
     [initiatingAddress, respondingAddress]
   );

--- a/packages/machine/src/protocol/setup.ts
+++ b/packages/machine/src/protocol/setup.ts
@@ -93,9 +93,7 @@ function proposeStateTransition(message: ProtocolMessage, context: Context) {
   const newStateChannel = StateChannel.setupChannel(
     context.network,
     multisigAddress,
-    [initiatingAddress, respondingAddress].sort((a, b) =>
-      parseInt(a, 16) < parseInt(b, 16) ? -1 : 1
-    )
+    [initiatingAddress, respondingAddress]
   );
 
   context.stateChannelsMap.set(multisigAddress, newStateChannel);

--- a/packages/machine/src/protocol/utils/signature-forwarder.ts
+++ b/packages/machine/src/protocol/utils/signature-forwarder.ts
@@ -29,6 +29,10 @@ export function addSignedCommitmentToOutboxForSeq1(
  * seq 2 for these kinds of protocols, so this is an alias for "use this
  * protocol message to finish up your callback on the IO_WAIT opcode"
  *
+ * Additionally, it swaps the `from` and `to` addresses since in the case
+ * where this helper is used, the `message` is one received initially from
+ * the initiator of the protocol (so `from` is the other guy to start)
+ *
  * @param message the message B initiated his machine protocol execution
  * @param context B's context at this point in the protocol execution
  */
@@ -38,6 +42,8 @@ export function addSignedCommitmentInResponseWithSeq2(
 ) {
   context.outbox.push({
     ...message,
+    fromAddress: message.toAddress,
+    toAddress: message.fromAddress,
     signature: context.signature,
     seq: 2
   });

--- a/packages/machine/src/protocol/utils/signature-validator.ts
+++ b/packages/machine/src/protocol/utils/signature-validator.ts
@@ -11,14 +11,6 @@ export function validateSignature(
     throw Error("validateSignature received an undefined commitment");
   }
 
-  // FIXME: This is a temporary hack to allow me to make progress
-  //        on upgrading the Node to use machine protocols to generate
-  //        state transitions. I want to entire protocol execution to run
-  //        through the machine (including OP_SIGN and validateSignature)
-  //        but haven't hooked up messaging yet, so its hard for me to generate
-  //        the correct signatures.
-  if (signature !== undefined && signature.v === -1) return;
-
   if (signature === undefined) {
     throw Error("validateSignature received an undefined signature");
   }

--- a/packages/machine/src/protocol/utils/signature-validator.ts
+++ b/packages/machine/src/protocol/utils/signature-validator.ts
@@ -1,4 +1,4 @@
-import { recoverAddress, Signature } from "ethers/utils";
+import { getAddress, recoverAddress, Signature } from "ethers/utils";
 
 import { EthereumCommitment } from "../../ethereum/types";
 
@@ -15,7 +15,11 @@ export function validateSignature(
     throw Error("validateSignature received an undefined signature");
   }
 
-  if (expectedSigner !== recoverAddress(commitment.hashToSign(), signature)) {
-    throw Error("Received invalid signature on validateSignature");
+  const signer = recoverAddress(commitment.hashToSign(), signature);
+
+  if (getAddress(expectedSigner) !== signer) {
+    throw Error(
+      `Validating a signature with expected signer ${expectedSigner} but recovered ${signer} for commitment hash ${commitment.hashToSign()}`
+    );
   }
 }

--- a/packages/machine/test/integration/install-then-set-state.spec.ts
+++ b/packages/machine/test/integration/install-then-set-state.spec.ts
@@ -96,7 +96,11 @@ describe("Scenario: install AppInstance, set state, put on-chain", () => {
     );
 
     proxyFactory.on("ProxyCreation", async proxy => {
-      let stateChannel = StateChannel.setupChannel(network, proxy, users);
+      let stateChannel = StateChannel.setupChannel(
+        network.ETHBucket,
+        proxy,
+        users
+      );
       let freeBalanceETH = stateChannel.getFreeBalanceFor(AssetType.ETH);
 
       const state = {

--- a/packages/machine/test/integration/setup-then-set-state.spec.ts
+++ b/packages/machine/test/integration/setup-then-set-state.spec.ts
@@ -89,7 +89,11 @@ describe("Scenario: Setup, set state on free balance, go on chain", () => {
     );
 
     proxyFactory.on("ProxyCreation", async proxy => {
-      let stateChannel = StateChannel.setupChannel(network, proxy, users);
+      let stateChannel = StateChannel.setupChannel(
+        network.ETHBucket,
+        proxy,
+        users
+      );
       let freeBalanceETH = stateChannel.getFreeBalanceFor(AssetType.ETH);
 
       const state = {

--- a/packages/machine/test/unit/ethereum/install-commitment.spec.ts
+++ b/packages/machine/test/unit/ethereum/install-commitment.spec.ts
@@ -38,7 +38,7 @@ describe("InstallCommitment", () => {
 
   // State channel testing values
   let stateChannel = StateChannel.setupChannel(
-    networkContext,
+    networkContext.ETHBucket,
     getAddress(hexlify(randomBytes(20))),
     [interaction.sender, interaction.receiver].sort((a, b) =>
       parseInt(a, 16) < parseInt(b, 16) ? -1 : 1

--- a/packages/machine/test/unit/ethereum/setup-commitment.spec.ts
+++ b/packages/machine/test/unit/ethereum/setup-commitment.spec.ts
@@ -38,7 +38,7 @@ describe("SetupCommitment", () => {
 
   // State channel testing values
   const stateChannel = StateChannel.setupChannel(
-    networkContext,
+    networkContext.ETHBucket,
     getAddress(hexlify(randomBytes(20))),
     [interaction.sender, interaction.receiver].sort((a, b) =>
       parseInt(a, 16) < parseInt(b, 16) ? -1 : 1

--- a/packages/machine/test/unit/ethereum/uninstall-commitment.spec.ts
+++ b/packages/machine/test/unit/ethereum/uninstall-commitment.spec.ts
@@ -39,7 +39,7 @@ describe("Uninstall Commitment", () => {
 
   // State channel testing values
   let stateChannel = StateChannel.setupChannel(
-    networkContext,
+    networkContext.ETHBucket,
     getAddress(hexlify(randomBytes(20))),
     [interaction.sender, interaction.receiver].sort((a, b) =>
       parseInt(a, 16) < parseInt(b, 16) ? -1 : 1

--- a/packages/machine/test/unit/models/state-channel/install.spec.ts
+++ b/packages/machine/test/unit/models/state-channel/install.spec.ts
@@ -21,7 +21,7 @@ describe("StateChannel::uninstallApp", () => {
     ];
 
     sc1 = StateChannel.setupChannel(
-      networkContext,
+      networkContext.ETHBucket,
       multisigAddress,
       multisigOwners
     );

--- a/packages/machine/test/unit/models/state-channel/set-state.spec.ts
+++ b/packages/machine/test/unit/models/state-channel/set-state.spec.ts
@@ -45,7 +45,7 @@ describe("StateChannel::setState", () => {
     );
 
     sc1 = StateChannel.setupChannel(
-      networkContext,
+      networkContext.ETHBucket,
       multisigAddress,
       multisigOwners
     ).installApp(testApp, Zero, Zero);

--- a/packages/machine/test/unit/models/state-channel/setup-channel.spec.ts
+++ b/packages/machine/test/unit/models/state-channel/setup-channel.spec.ts
@@ -18,7 +18,7 @@ describe("StateChannel::setupChannel", () => {
 
   beforeAll(() => {
     sc = StateChannel.setupChannel(
-      networkContext,
+      networkContext.ETHBucket,
       multisigAddress,
       multisigOwners
     );

--- a/packages/machine/test/unit/models/state-channel/uninstall-app.spec.ts
+++ b/packages/machine/test/unit/models/state-channel/uninstall-app.spec.ts
@@ -45,7 +45,7 @@ describe("StateChannel::uninstallApp", () => {
     );
 
     sc1 = StateChannel.setupChannel(
-      networkContext,
+      networkContext.ETHBucket,
       multisigAddress,
       multisigOwners
     ).installApp(testApp, Zero, Zero);

--- a/packages/machine/test/unit/protocol/signature-validator.spec.ts
+++ b/packages/machine/test/unit/protocol/signature-validator.spec.ts
@@ -44,6 +44,6 @@ describe("Signature Validator Helper", () => {
         commitment,
         signer.signDigest(HashZero.replace("00", "11")) // 0x111111...
       )
-    ).toThrow("Received invalid signature on validateSignature");
+    ).toThrow();
   });
 });

--- a/packages/node/src/deferred.ts
+++ b/packages/node/src/deferred.ts
@@ -1,0 +1,24 @@
+export class Deferred<T> {
+  private internalPromise: Promise<T>;
+  private internalResolve!: (value?: T | PromiseLike<T>) => void;
+  private internalReject!: (reason?: any) => void;
+
+  constructor() {
+    this.internalPromise = new Promise<T>((resolve, reject) => {
+      this.internalResolve = resolve;
+      this.internalReject = reject;
+    });
+  }
+
+  get promise(): Promise<T> {
+    return this.internalPromise;
+  }
+
+  resolve = (value?: T | PromiseLike<T>): void => {
+    this.internalResolve(value);
+  };
+
+  reject = (reason?: any): void => {
+    this.internalReject(reason);
+  };
+}

--- a/packages/node/src/events/install/controller.ts
+++ b/packages/node/src/events/install/controller.ts
@@ -30,7 +30,7 @@ export default async function installEventController(
   const { appInstanceId } = params;
 
   if (!appInstanceId || !appInstanceId.trim()) {
-    return Promise.reject(ERRORS.NO_APP_INSTANCE_ID_TO_INSTALL);
+    throw new Error(ERRORS.NO_APP_INSTANCE_ID_TO_INSTALL);
   }
 
   const appInstanceInfo = await store.getProposedAppInstanceInfo(appInstanceId);

--- a/packages/node/src/events/install/controller.ts
+++ b/packages/node/src/events/install/controller.ts
@@ -1,20 +1,86 @@
-import { install } from "../../methods/app-instance/install/operation";
+import { AppInstance, StateChannel } from "@counterfactual/machine";
+import { AppInterface, Terms } from "@counterfactual/types";
+import { AddressZero } from "ethers/constants";
+
+import { ERRORS } from "../../methods/errors";
+import { ProposedAppInstanceInfo } from "../../models";
 import { RequestHandler } from "../../request-handler";
 import { InstallMessage } from "../../types";
 
 /**
  * This function responds to a installation proposal approval from a peer Node
  * by counter installing the AppInstance this Node proposed earlier.
+ *
+ * NOTE: The following code is mostly just a copy of the code from the
+ *       methods/intall/operations.ts::install method with the exception
+ *       of the lack of a runInstallProtocol call. This is because this is
+ *       the counterparty end of the install protocol which runs _after_
+ *       the _dispatchReceivedMessage_ call finishes and saves the result.
+ *
+ *       Future iterations of this code will simply be a middleware hook on
+ *       the _STATE TRANSITION COMMIT_ opcode.
  */
 export default async function installEventController(
   requestHandler: RequestHandler,
   nodeMsg: InstallMessage
 ) {
-  await install(
-    requestHandler.store,
-    requestHandler.instructionExecutor,
-    requestHandler.address,
-    nodeMsg.from,
-    nodeMsg.data.params
+  const store = requestHandler.store;
+  const params = nodeMsg.data.params;
+
+  const { appInstanceId } = params;
+  if (
+    !appInstanceId ||
+    (typeof appInstanceId === "string" && appInstanceId.trim() === "")
+  ) {
+    return Promise.reject(ERRORS.NO_APP_INSTANCE_ID_TO_INSTALL);
+  }
+
+  const appInstanceInfo = await store.getProposedAppInstanceInfo(appInstanceId);
+
+  const stateChannel = await store.getChannelFromAppInstanceID(appInstanceId);
+
+  await store.updateChannelWithAppInstanceInstallation(
+    stateChannel,
+    createAppInstanceFromAppInstanceInfo(appInstanceInfo, stateChannel)
+      .identityHash,
+    appInstanceInfo
+  );
+
+  return appInstanceInfo;
+}
+
+function createAppInstanceFromAppInstanceInfo(
+  proposedAppInstanceInfo: ProposedAppInstanceInfo,
+  channel: StateChannel
+): AppInstance {
+  const appInterface: AppInterface = {
+    ...proposedAppInstanceInfo.abiEncodings,
+    addr: proposedAppInstanceInfo.appId
+  };
+
+  // TODO: throw if asset type is ETH and token is also set
+  const terms: Terms = {
+    assetType: proposedAppInstanceInfo.asset.assetType,
+    limit: proposedAppInstanceInfo.myDeposit.add(
+      proposedAppInstanceInfo.peerDeposit
+    ),
+    token: proposedAppInstanceInfo.asset.token || AddressZero
+  };
+
+  return new AppInstance(
+    channel.multisigAddress,
+    // TODO: generate ephemeral app-specific keys
+    channel.multisigOwners,
+    proposedAppInstanceInfo.timeout.toNumber(),
+    appInterface,
+    terms,
+    // TODO: pass correct value when virtual app support gets added
+    false,
+    // TODO: this should be thread-safe
+    channel.numInstalledApps + 1,
+    channel.rootNonceValue,
+    proposedAppInstanceInfo.initialState,
+    0,
+    proposedAppInstanceInfo.timeout.toNumber()
   );
 }

--- a/packages/node/src/events/install/controller.ts
+++ b/packages/node/src/events/install/controller.ts
@@ -28,10 +28,8 @@ export default async function installEventController(
   const params = nodeMsg.data.params;
 
   const { appInstanceId } = params;
-  if (
-    !appInstanceId ||
-    (typeof appInstanceId === "string" && appInstanceId.trim() === "")
-  ) {
+
+  if (!appInstanceId || !appInstanceId.trim()) {
     return Promise.reject(ERRORS.NO_APP_INSTANCE_ID_TO_INSTALL);
   }
 

--- a/packages/node/src/events/multisig-created/controller.ts
+++ b/packages/node/src/events/multisig-created/controller.ts
@@ -15,7 +15,7 @@ export default async function addMultisigController(
   const multisigOwners = nodeMsg.data.params.owners;
   await requestHandler.store.saveStateChannel(
     StateChannel.setupChannel(
-      requestHandler.networkContext,
+      requestHandler.networkContext.ETHBucket,
       multisigAddress,
       multisigOwners
     )

--- a/packages/node/src/events/multisig-created/controller.ts
+++ b/packages/node/src/events/multisig-created/controller.ts
@@ -1,6 +1,4 @@
 import { StateChannel } from "@counterfactual/machine";
-import { AssetType } from "@counterfactual/types";
-import { bigNumberify } from "ethers/utils";
 
 import { RequestHandler } from "../../request-handler";
 import { CreateMultisigMessage } from "../../types";
@@ -20,11 +18,6 @@ export default async function addMultisigController(
       requestHandler.networkContext,
       multisigAddress,
       multisigOwners
-    ).setFreeBalanceFor(AssetType.ETH, {
-      alice: multisigOwners[0],
-      bob: multisigOwners[1],
-      aliceBalance: bigNumberify(0),
-      bobBalance: bigNumberify(0)
-    })
+    )
   );
 }

--- a/packages/node/src/events/protocol-message/controller.ts
+++ b/packages/node/src/events/protocol-message/controller.ts
@@ -21,12 +21,19 @@ export default async function protocolMessageEventController(
   //        listeniner inside the instructionExecutor that emits noise
   //        when dispatchReceivedMessage receives a message for an in-progress
   //        protocol execution.
+  //
+  //        Does NOT work for InstallVirtualApp
   if (nodeMsg.data.seq === 2) return;
 
-  await requestHandler.instructionExecutor.dispatchReceivedMessage(
+  const stateChannelsMap = await requestHandler.instructionExecutor.dispatchReceivedMessage(
     nodeMsg.data,
     new Map<string, StateChannel>(
       Object.entries(await requestHandler.store.getAllChannels())
     )
+  );
+
+  stateChannelsMap.forEach(
+    async stateChannel =>
+      await requestHandler.store.saveStateChannel(stateChannel)
   );
 }

--- a/packages/node/src/methods/app-instance/install/operation.ts
+++ b/packages/node/src/methods/app-instance/install/operation.ts
@@ -62,12 +62,12 @@ export async function install(
     }
   );
 
-  delete appInstanceInfo.initialState;
-
   await store.updateChannelWithAppInstanceInstallation(
     stateChannelsMap.get(stateChannel.multisigAddress)!,
-    createAppInstanceFromAppInstanceInfo(appInstanceInfo, stateChannel)
-      .identityHash,
+    createAppInstanceFromAppInstanceInfo(
+      appInstanceInfo,
+      stateChannelsMap.get(stateChannel.multisigAddress)!
+    ).identityHash,
     appInstanceInfo
   );
 

--- a/packages/node/src/methods/app-instance/take-action/controller.ts
+++ b/packages/node/src/methods/app-instance/take-action/controller.ts
@@ -19,6 +19,7 @@ export default async function takeActionController(
   const appInstance = await requestHandler.store.getAppInstanceFromAppInstanceID(
     appInstanceId
   );
+
   try {
     await actionIsEncondable(appInstance, action);
   } catch (e) {

--- a/packages/node/src/node.ts
+++ b/packages/node/src/node.ts
@@ -152,13 +152,10 @@ export class Node {
     instructionExecutor.register(
       Opcode.IO_WAIT,
       async (message: ProtocolMessage, next: Function, context: Context) => {
-        await new Promise(async (resolve, reject) => {
-          const checksumAddress = getAddress(message.toAddress);
-          const msg = await this.ioSendDeferrals[checksumAddress].promise;
-          context.inbox.push(msg.data);
-          resolve();
-          next();
-        });
+        const checksumAddress = getAddress(message.toAddress);
+        const msg = await this.ioSendDeferrals[checksumAddress].promise;
+        context.inbox.push(msg.data);
+        next();
       }
     );
 

--- a/packages/node/src/node.ts
+++ b/packages/node/src/node.ts
@@ -123,9 +123,9 @@ export class Node {
     instructionExecutor.register(
       Opcode.IO_SEND,
       async (message: ProtocolMessage, next: Function, context: Context) => {
+        const [data] = context.outbox;
         const from = getAddress(this.address);
-        const to = getAddress(context.outbox[0].toAddress);
-        const data = context.outbox[0];
+        const to = getAddress(data.toAddress);
 
         // FIXME: When seq === 1 it means that, for a round trip protocol like
         //        Update, Setup, Install, etc this is the first message A sends

--- a/packages/node/src/node.ts
+++ b/packages/node/src/node.ts
@@ -226,18 +226,18 @@ export class Node {
    *     solely to the deffered promise's resolve callback.
    */
   private async handleReceivedMessage(msg: NodeMessage) {
+    if (!NODE_EVENTS[msg.event]) {
+      console.error(`Received message with unknown event type`);
+    }
+
     const isIoSendDeferral = (msg: NodeMessage) =>
       msg.event === NODE_EVENTS.PROTOCOL_MESSAGE_EVENT &&
       this.ioSendDeferrals[msg.from] !== undefined;
 
-    if (Object.values(NODE_EVENTS).includes(msg.event)) {
-      if (isIoSendDeferral(msg)) {
-        this.handleIoSendDeferral(msg as NodeMessageWrappedProtocolMessage);
-      } else {
-        await this.requestHandler.callEvent(msg.event, msg);
-      }
+    if (isIoSendDeferral(msg)) {
+      this.handleIoSendDeferral(msg as NodeMessageWrappedProtocolMessage);
     } else {
-      console.error(`Received message with unknown event type: "${msg.event}"`);
+      await this.requestHandler.callEvent(msg.event, msg);
     }
   }
 

--- a/packages/node/src/node.ts
+++ b/packages/node/src/node.ts
@@ -14,7 +14,11 @@ import EventEmitter from "eventemitter3";
 import { RequestHandler } from "./request-handler";
 import { IMessagingService, IStoreService } from "./services";
 import { getSigner } from "./signer";
-import { NODE_EVENTS, NodeMessage } from "./types";
+import {
+  NODE_EVENTS,
+  NodeMessage,
+  NodeMessageWrappedProtocolMessage
+} from "./types";
 
 export interface NodeConfig {
   // The prefix for any keys used in the store by this Node depends on the
@@ -119,11 +123,15 @@ export class Node {
     this.instructionExecutor.register(
       Opcode.IO_SEND,
       async (message: ProtocolMessage, next: Function, context: Context) => {
-        await this.messagingService.send(context.outbox[0].toAddress, {
+        const protocolMsg: NodeMessageWrappedProtocolMessage = {
           from: this.address,
           event: NODE_EVENTS.PROTOCOL_MESSAGE_EVENT,
           data: context.outbox[0]
-        });
+        };
+        await this.messagingService.send(
+          context.outbox[0].toAddress,
+          protocolMsg
+        );
         next();
       }
     );

--- a/packages/node/src/node.ts
+++ b/packages/node/src/node.ts
@@ -127,6 +127,12 @@ export class Node {
         const to = getAddress(context.outbox[0].toAddress);
         const data = context.outbox[0];
 
+        // FIXME: When seq === 1 it means that, for a round trip protocol like
+        //        Update, Setup, Install, etc this is the first message A sends
+        //        to B, indicating B should start at step 1 of the flow. Thus,
+        //        we create a deferral for future resolution by the message
+        //        handler on the receiving side which is expecting B to reply
+        //        later with seq === 2.
         if (context.outbox[0].seq === 1) {
           this.ioSendDeferrals[to] = new Deferred<
             NodeMessageWrappedProtocolMessage

--- a/packages/node/src/node.ts
+++ b/packages/node/src/node.ts
@@ -153,15 +153,11 @@ export class Node {
       Opcode.IO_WAIT,
       async (message: ProtocolMessage, next: Function, context: Context) => {
         await new Promise(async (resolve, reject) => {
-          try {
-            const checksumAddress = getAddress(message.toAddress);
-            const msg = await this.ioSendDeferrals[checksumAddress].promise;
-            context.inbox.push(msg.data);
-            resolve();
-            next();
-          } catch (e) {
-            reject(e);
-          }
+          const checksumAddress = getAddress(message.toAddress);
+          const msg = await this.ioSendDeferrals[checksumAddress].promise;
+          context.inbox.push(msg.data);
+          resolve();
+          next();
         });
       }
     );

--- a/packages/node/src/node.ts
+++ b/packages/node/src/node.ts
@@ -193,7 +193,7 @@ export class Node {
    * usually external subscribed (i.e. consumers of the Node).
    */
   private registerMessagingConnection() {
-    this.messagingService.receive(this.address, async (msg: NodeMessage) => {
+    this.messagingService.onReceive(this.address, async (msg: NodeMessage) => {
       if (Object.values(NODE_EVENTS).includes(msg.event)) {
         await this.requestHandler.callEvent(msg.event, msg);
       } else {

--- a/packages/node/src/node.ts
+++ b/packages/node/src/node.ts
@@ -2,15 +2,14 @@ import {
   Context,
   InstructionExecutor,
   Opcode,
-  Protocol,
   ProtocolMessage
 } from "@counterfactual/machine";
 import { NetworkContext, Node as NodeTypes } from "@counterfactual/types";
-import { AddressZero, HashZero } from "ethers/constants";
 import { Provider } from "ethers/providers";
 import { SigningKey } from "ethers/utils";
 import EventEmitter from "eventemitter3";
 
+import { Deferred } from "./deferred";
 import { RequestHandler } from "./request-handler";
 import { IMessagingService, IStoreService } from "./services";
 import { getSigner } from "./signer";
@@ -36,6 +35,9 @@ export class Node {
   private readonly outgoing: EventEmitter;
 
   private readonly instructionExecutor: InstructionExecutor;
+  private ioSendDeferrals: {
+    [address: string]: Deferred<NodeMessageWrappedProtocolMessage>;
+  } = {};
 
   // These properties don't have initializers in the constructor and get
   // initialized in the `init` function
@@ -69,9 +71,7 @@ export class Node {
   ) {
     this.incoming = new EventEmitter();
     this.outgoing = new EventEmitter();
-    this.instructionExecutor = new InstructionExecutor(networkContext);
-    this.registerOpSignMiddleware();
-    this.registerIoMiddleware();
+    this.instructionExecutor = this.buildInstructionExecutor();
   }
 
   private async asyncronouslySetupUsingRemoteServices(): Promise<Node> {
@@ -95,8 +95,14 @@ export class Node {
     return this.signer.address;
   }
 
-  private registerOpSignMiddleware() {
-    this.instructionExecutor.register(
+  /**
+   * Instantiates a new _InstructionExecutor_ object and attaches middleware
+   * for the OP_SIGN, IO_SEND, and IO_WAIT opcodes.
+   */
+  private buildInstructionExecutor(): InstructionExecutor {
+    const instructionExecutor = new InstructionExecutor(this.networkContext);
+
+    instructionExecutor.register(
       Opcode.OP_SIGN,
       async (message: ProtocolMessage, next: Function, context: Context) => {
         if (!context.commitment) {
@@ -105,62 +111,55 @@ export class Node {
             "Reached OP_SIGN middleware without generated commitment."
           );
         }
-        context.signature = {
-          v: -1,
-          r: HashZero,
-          s: HashZero
-        };
-        // TODO: Replace the above hack with the below
-        // context.signature = this.signer.signDigest(
-        //   context.commitment.hashToSign()
-        // );
+
+        context.signature = this.signer.signDigest(
+          context.commitment.hashToSign()
+        );
+
         next();
       }
     );
-  }
 
-  private registerIoMiddleware() {
-    this.instructionExecutor.register(
+    instructionExecutor.register(
       Opcode.IO_SEND,
       async (message: ProtocolMessage, next: Function, context: Context) => {
-        const protocolMsg: NodeMessageWrappedProtocolMessage = {
-          from: this.address,
-          event: NODE_EVENTS.PROTOCOL_MESSAGE_EVENT,
-          data: context.outbox[0]
-        };
-        await this.messagingService.send(
-          context.outbox[0].toAddress,
-          protocolMsg
-        );
+        const from = this.address;
+        const to = context.outbox[0].toAddress;
+        const data = context.outbox[0];
+
+        if (context.outbox[0].seq === 1) {
+          this.ioSendDeferrals[to] = new Deferred<
+            NodeMessageWrappedProtocolMessage
+          >();
+        }
+
+        await this.messagingService.send(to, {
+          from,
+          data,
+          event: NODE_EVENTS.PROTOCOL_MESSAGE_EVENT
+        } as NodeMessageWrappedProtocolMessage);
+
         next();
       }
     );
 
-    // TODO: Currently this mocks the response for all protocols as the below
-    //       mocked ProtocolMessage object. Next task is to listen for a real
-    //       message from a counterparty.
-    this.instructionExecutor.register(
+    instructionExecutor.register(
       Opcode.IO_WAIT,
-      (message: ProtocolMessage, next: Function, context: Context) => {
-        // FIXME: This is a temporary hack to get IO_WAIT to progress
-        context.inbox.push({
-          protocol: Protocol.Setup,
-          fromAddress: AddressZero,
-          toAddress: AddressZero,
-          seq: 2,
-          params: {
-            initiatingAddress: AddressZero,
-            respondingAddress: AddressZero,
-            multisigAddress: AddressZero
-          },
-          signature: {
-            v: -1,
-            r: HashZero,
-            s: HashZero
+      async (message: ProtocolMessage, next: Function, context: Context) => {
+        await new Promise(async (resolve, reject) => {
+          try {
+            const msg = await this.ioSendDeferrals[message.toAddress].promise;
+            context.inbox.push(msg.data);
+            resolve();
+            next();
+          } catch (e) {
+            reject(e);
           }
         });
       }
     );
+
+    return instructionExecutor;
   }
 
   /**
@@ -196,20 +195,59 @@ export class Node {
 
   /**
    * When a Node is first instantiated, it establishes a connection
-   * with the messaging service.
-   * When it receives a message, it emits the message to its registered subscribers,
-   * usually external subscribed (i.e. consumers of the Node).
+   * with the messaging service. When it receives a message, it emits
+   * the message to its registered subscribers, usually external
+   * subscribed (i.e. consumers of the Node).
    */
   private registerMessagingConnection() {
     this.messagingService.onReceive(this.address, async (msg: NodeMessage) => {
-      if (Object.values(NODE_EVENTS).includes(msg.event)) {
-        await this.requestHandler.callEvent(msg.event, msg);
-      } else {
-        console.error(
-          `Received message with unknown event type: "${msg.event}"`
-        );
-      }
+      await this.handleReceivedMessage(msg);
       this.outgoing.emit(msg.event, msg);
     });
+  }
+
+  /**
+   * Messages received by the Node fit into one of three categories:
+   *
+   * (a) A NodeMessage which is _not_ a NodeMessageWrappedProtocolMessage;
+   *     this is a standard received message which is handled by a named
+   *     controller in the _events_ folder.
+   *
+   * (b) A NodeMessage which is a NodeMessageWrappedProtocolMessage _and_
+   *     has no registered _ioSendDeferral_ callback. In this case, it means
+   *     it will be sent to the protocol message event controller to dispatch
+   *     the received message to the instruction executor.
+   *
+   * (c) A NodeMessage which is a NodeMessageWrappedProtocolMessage _and_
+   *     _does have_ an _ioSendDeferral_, in which case the message is dispatched
+   *     solely to the deffered promise's resolve callback.
+   */
+  private async handleReceivedMessage(msg: NodeMessage) {
+    const isIoSendDeferral = (msg: NodeMessage) =>
+      msg.event === NODE_EVENTS.PROTOCOL_MESSAGE_EVENT &&
+      this.ioSendDeferrals[msg.from] !== undefined;
+
+    if (Object.values(NODE_EVENTS).includes(msg.event)) {
+      if (isIoSendDeferral(msg)) {
+        this.handleIoSendDeferral(msg as NodeMessageWrappedProtocolMessage);
+      } else {
+        await this.requestHandler.callEvent(msg.event, msg);
+      }
+    } else {
+      console.error(`Received message with unknown event type: "${msg.event}"`);
+    }
+  }
+
+  private async handleIoSendDeferral(msg: NodeMessageWrappedProtocolMessage) {
+    try {
+      this.ioSendDeferrals[msg.from].resolve(msg);
+    } catch (error) {
+      console.error(
+        `Error while executing callback registered by IO_WAIT middleware hook`,
+        { error, msg }
+      );
+    }
+
+    delete this.ioSendDeferrals[msg.from];
   }
 }

--- a/packages/node/src/services.ts
+++ b/packages/node/src/services.ts
@@ -2,9 +2,11 @@ import { Address } from "@counterfactual/types";
 import * as firebase from "firebase/app";
 import "firebase/database";
 
+import { NodeMessage } from "./types";
+
 export interface IMessagingService {
-  send(respondingAddress: Address, msg: any);
-  onReceive(address: Address, callback: (msg: any) => void);
+  send(respondingAddress: Address, msg: NodeMessage): Promise<void>;
+  onReceive(address: Address, callback: (msg: NodeMessage) => void);
 }
 
 export interface IStoreService {
@@ -62,7 +64,7 @@ class FirebaseMessagingService implements IMessagingService {
       .set(JSON.parse(JSON.stringify(msg)));
   }
 
-  onReceive(address: Address, callback: (msg: object) => void) {
+  onReceive(address: Address, callback: (msg: NodeMessage) => void) {
     if (!this.firebase.app) {
       console.error(
         "Cannot register a connection with an uninitialized firebase handle"

--- a/packages/node/src/services.ts
+++ b/packages/node/src/services.ts
@@ -65,34 +65,34 @@ class FirebaseMessagingService implements IMessagingService {
   }
 
   onReceive(address: Address, callback: (msg: NodeMessage) => void) {
-    if (!this.firebase.app) {
+    if (this.firebase.app) {
+      this.firebase
+        .ref(`${this.messagingServerKey}/${address}`)
+        .on("value", (snapshot: firebase.database.DataSnapshot | null) => {
+          if (snapshot === null) {
+            console.error(
+              `Node with address ${address} received a "null" snapshot`
+            );
+          } else {
+            const msg = snapshot.val();
+            // TODO: Figure out why sometimes the message is null?
+            // Answer: https://stackoverflow.com/a/37310606/2680092
+            if (msg !== null) {
+              const stringifiedMsg = JSON.stringify(msg);
+              if (stringifiedMsg in this.servedMessages) {
+                delete this.servedMessages[stringifiedMsg];
+              } else {
+                this.servedMessages[stringifiedMsg] = true;
+                callback(msg);
+              }
+            }
+          }
+        });
+    } else {
       console.error(
         "Cannot register a connection with an uninitialized firebase handle"
       );
-      return;
     }
-
-    this.firebase
-      .ref(`${this.messagingServerKey}/${address}`)
-      .on("value", (snapshot: firebase.database.DataSnapshot | null) => {
-        if (snapshot === null) {
-          console.debug(
-            `Node with address ${address} received a "null" snapshot`
-          );
-          return;
-        }
-        const msg = snapshot.val();
-        const msgKey = JSON.stringify(msg);
-        if (msg === null) {
-          return;
-        }
-        if (msgKey in this.servedMessages) {
-          delete this.servedMessages[msgKey];
-          return;
-        }
-        this.servedMessages[msgKey] = true;
-        callback(msg);
-      });
   }
 }
 

--- a/packages/node/src/services.ts
+++ b/packages/node/src/services.ts
@@ -51,7 +51,7 @@ export class FirebaseServiceFactory {
 class FirebaseMessagingService implements IMessagingService {
   // naive caching - firebase fires observers twice upon initial callback
   // registration and invocation
-  private servedMessages = new Map();
+  private servedMessages = new Set();
 
   constructor(
     private readonly firebase: firebase.database.Database,
@@ -92,11 +92,10 @@ class FirebaseMessagingService implements IMessagingService {
           return;
         }
 
-        const stringifiedMsg = JSON.stringify(msg);
-        if (stringifiedMsg in this.servedMessages) {
-          delete this.servedMessages[stringifiedMsg];
+        if (this.servedMessages.has(msg)) {
+          this.servedMessages.delete(msg);
         } else {
-          this.servedMessages[stringifiedMsg] = true;
+          this.servedMessages.add(msg);
           callback(msg);
         }
       });

--- a/packages/node/src/services.ts
+++ b/packages/node/src/services.ts
@@ -75,8 +75,10 @@ class FirebaseMessagingService implements IMessagingService {
             );
           } else {
             const msg = snapshot.val();
-            // TODO: Figure out why sometimes the message is null?
-            // Answer: https://stackoverflow.com/a/37310606/2680092
+            // We check for `msg` being not null because when the Firebase listener
+            // connects, the snapshot starts with a `null` value, and on the second
+            // the call it receives a value.
+            // See: https://stackoverflow.com/a/37310606/2680092
             if (msg !== null) {
               const stringifiedMsg = JSON.stringify(msg);
               if (stringifiedMsg in this.servedMessages) {

--- a/packages/node/src/services.ts
+++ b/packages/node/src/services.ts
@@ -4,7 +4,7 @@ import "firebase/database";
 
 export interface IMessagingService {
   send(respondingAddress: Address, msg: any);
-  receive(address: Address, callback: (msg: any) => void);
+  onReceive(address: Address, callback: (msg: any) => void);
 }
 
 export interface IStoreService {
@@ -62,7 +62,7 @@ class FirebaseMessagingService implements IMessagingService {
       .set(JSON.parse(JSON.stringify(msg)));
   }
 
-  receive(address: Address, callback: (msg: object) => void) {
+  onReceive(address: Address, callback: (msg: object) => void) {
     if (!this.firebase.app) {
       console.error(
         "Cannot register a connection with an uninitialized firebase handle"

--- a/packages/node/src/store.ts
+++ b/packages/node/src/store.ts
@@ -45,13 +45,10 @@ export class Store {
       `${this.storeKeyPrefix}/${DB_NAMESPACE_CHANNEL}`
     )) as { [multisigAddress: string]: StateChannelJSON };
 
-    if (!channelsJSON) {
-      console.log("No channels exist yet");
-    } else {
-      for (const entry of Object.entries(channelsJSON)) {
-        channels[entry[0]] = StateChannel.fromJson(entry[1]);
-      }
+    for (const entry of Object.entries(channelsJSON || {})) {
+      channels[entry[0]] = StateChannel.fromJson(entry[1]);
     }
+
     return channels;
   }
 

--- a/packages/node/src/store.ts
+++ b/packages/node/src/store.ts
@@ -41,12 +41,12 @@ export class Store {
     [multisigAddress: string]: StateChannel;
   }> {
     const channels = {};
-    const channelsJSON = (await this.storeService.get(
+    const channelsJSON = ((await this.storeService.get(
       `${this.storeKeyPrefix}/${DB_NAMESPACE_CHANNEL}`
-    )) as { [multisigAddress: string]: StateChannelJSON };
+    )) || {}) as { [multisigAddress: string]: StateChannelJSON };
 
-    for (const entry of Object.entries(channelsJSON || {})) {
-      channels[entry[0]] = StateChannel.fromJson(entry[1]);
+    for (const [key, value] of Object.entries(channelsJSON)) {
+      channels[key] = StateChannel.fromJson(value);
     }
 
     return channels;

--- a/packages/node/test/integration/cant-take-action.spec.ts
+++ b/packages/node/test/integration/cant-take-action.spec.ts
@@ -1,3 +1,4 @@
+import TicTacToeApp from "@counterfactual/apps/build/TicTacToeApp.json";
 import {
   Address,
   AppABIEncodings,
@@ -13,7 +14,6 @@ import FirebaseServer from "firebase-server";
 import ganache from "ganache-core";
 import { v4 as generateUUID } from "uuid";
 
-import TicTacToeApp from "../../../apps/build/TicTacToeApp.json";
 import {
   IMessagingService,
   InstallMessage,

--- a/packages/node/test/integration/node-communication.spec.ts
+++ b/packages/node/test/integration/node-communication.spec.ts
@@ -32,11 +32,13 @@ describe("Two nodes can communicate with each other", () => {
         some: "data"
       }
     };
-    messagingService.onReceive(address, msg => {
+
+    messagingService.onReceive(address, (msg: any) => {
       expect(msg.event).toEqual(testMsg.event);
       expect(msg.data).toEqual(testMsg.data);
       done();
     });
+
     messagingService.send(address, testMsg as any);
   });
 });

--- a/packages/node/test/integration/node-communication.spec.ts
+++ b/packages/node/test/integration/node-communication.spec.ts
@@ -32,7 +32,7 @@ describe("Two nodes can communicate with each other", () => {
         some: "data"
       }
     };
-    messagingService.receive(address, msg => {
+    messagingService.onReceive(address, msg => {
       expect(msg.event).toEqual(testMsg.event);
       expect(msg.data).toEqual(testMsg.data);
       done();

--- a/packages/node/test/integration/take-action.spec.ts
+++ b/packages/node/test/integration/take-action.spec.ts
@@ -1,3 +1,4 @@
+import TicTacToeApp from "@counterfactual/apps/build/TicTacToeApp.json";
 import {
   Address,
   AppABIEncodings,
@@ -13,7 +14,6 @@ import FirebaseServer from "firebase-server";
 import ganache from "ganache-core";
 import { v4 as generateUUID } from "uuid";
 
-import TicTacToeApp from "../../../apps/build/TicTacToeApp.json";
 import {
   IMessagingService,
   InstallMessage,

--- a/packages/node/test/services/mock-messaging-service.ts
+++ b/packages/node/test/services/mock-messaging-service.ts
@@ -1,10 +1,11 @@
 import { Address } from "@counterfactual/types";
 
 import { IMessagingService } from "../../src/services";
+import { NodeMessage } from "../../src/types";
 
 class MockMessagingService implements IMessagingService {
-  send(respondingAddress: Address, msg: object) {}
-  onReceive(address: Address, callback: (msg: object) => void) {}
+  async send(respondingAddress: Address, msg: NodeMessage) {}
+  onReceive(address: Address, callback: (msg: NodeMessage) => void) {}
 }
 
 const mockMessagingService = new MockMessagingService();

--- a/packages/node/test/services/mock-messaging-service.ts
+++ b/packages/node/test/services/mock-messaging-service.ts
@@ -4,7 +4,7 @@ import { IMessagingService } from "../../src/services";
 
 class MockMessagingService implements IMessagingService {
   send(respondingAddress: Address, msg: object) {}
-  receive(address: Address, callback: (msg: object) => void) {}
+  onReceive(address: Address, callback: (msg: object) => void) {}
 }
 
 const mockMessagingService = new MockMessagingService();

--- a/packages/node/test/unit/install.spec.ts
+++ b/packages/node/test/unit/install.spec.ts
@@ -1,7 +1,6 @@
 import { InstructionExecutor, StateChannel } from "@counterfactual/machine";
-import { AssetType } from "@counterfactual/types";
 import { Wallet } from "ethers";
-import { AddressZero, Zero } from "ethers/constants";
+import { AddressZero } from "ethers/constants";
 import { anything, instance, mock, when } from "ts-mockito";
 import { v4 as generateUUID } from "uuid";
 
@@ -84,14 +83,11 @@ describe("Can handle correct & incorrect installs", () => {
     const multisigAddress = Wallet.createRandom().address;
     const owners = [Wallet.createRandom().address, AddressZero];
 
-    const stateChannel = StateChannel
-      .setupChannel(EMPTY_NETWORK, multisigAddress, owners)
-      .setFreeBalanceFor(AssetType.ETH, {
-        alice: owners[0],
-        bob: owners[1],
-        aliceBalance: Zero,
-        bobBalance: Zero
-      });
+    const stateChannel = StateChannel.setupChannel(
+      EMPTY_NETWORK,
+      multisigAddress,
+      owners
+    );
 
     await store.saveStateChannel(stateChannel);
 

--- a/packages/node/test/unit/install.spec.ts
+++ b/packages/node/test/unit/install.spec.ts
@@ -84,7 +84,7 @@ describe("Can handle correct & incorrect installs", () => {
     const owners = [Wallet.createRandom().address, AddressZero];
 
     const stateChannel = StateChannel.setupChannel(
-      EMPTY_NETWORK,
+      EMPTY_NETWORK.ETHBucket,
       multisigAddress,
       owners
     );

--- a/packages/node/tsconfig.json
+++ b/packages/node/tsconfig.json
@@ -3,5 +3,5 @@
   "compilerOptions": {
     "declarationDir": "dist/"
   },
-  "include": ["src"]
+  "include": ["src", "test"]
 }

--- a/packages/playground-server/src/controllers/decorators/validate-signature.ts
+++ b/packages/playground-server/src/controllers/decorators/validate-signature.ts
@@ -46,11 +46,13 @@ function validateSignatureMiddleware(
     }
 
     const expectedMessage = await expectedSignatureMessage(resource);
+
     const ethAddress = getAddress(
       (((json as unknown) as APIRequest<SessionAttributes>).data as APIResource<
         SessionAttributes
       >).attributes.ethAddress
     );
+
     const [, signedMessage] = signedHeader.split(" ");
 
     const expectedAddress = verifyMessage(

--- a/packages/playground-server/src/node.ts
+++ b/packages/playground-server/src/node.ts
@@ -67,7 +67,9 @@ export function getNodeAddress(): string {
 export async function createMultisigFor(
   userAddress: string
 ): Promise<NodeTypes.CreateMultisigResult> {
-  if (!node) node = await createNodeSingleton();
+  if (!node) {
+    node = await createNodeSingleton();
+  }
 
   const multisigResponse = await node.call(
     NodeTypes.MethodName.CREATE_MULTISIG,

--- a/packages/playground-server/test/api.spec.ts
+++ b/packages/playground-server/test/api.spec.ts
@@ -6,7 +6,7 @@ import { resolve } from "path";
 
 import mountApi from "../src/api";
 import { getDatabase } from "../src/db";
-import { createNodeSingleton, getNodeAddress } from "../src/node";
+import { createNode, createNodeSingleton, getNodeAddress } from "../src/node";
 import {
   APIResource,
   APIResourceCollection,
@@ -19,6 +19,9 @@ import {
 } from "../src/types";
 
 import {
+  PK_ALICE,
+  PK_BOB,
+  PK_CHARLIE,
   POST_SESSION_ALICE,
   POST_SESSION_ALICE_SIGNATURE_HEADER,
   POST_SESSION_CHARLIE,
@@ -53,6 +56,10 @@ Log.setOutputLevel(LogLevel.ERROR);
 describe("playground-server", () => {
   beforeAll(async () => {
     await createNodeSingleton();
+
+    await createNode(PK_ALICE);
+    await createNode(PK_BOB);
+    await createNode(PK_CHARLIE);
 
     await db.schema.dropTableIfExists("users");
     await db.schema.createTable("users", table => {
@@ -284,9 +291,9 @@ describe("playground-server", () => {
               {
                 attributes: {
                   email: "bob@wonderland.com",
-                  ethAddress: "0x0f693cc956df59dec24bb1c605ac94cadce6014d",
+                  ethAddress: "0x0f693CC956DF59deC24BB1C605ac94CadCe6014d",
                   multisigAddress: "0xc5F6047a22A5582f62dBcD278f1A2275ab39001A",
-                  nodeAddress: "0xFE0460D00c589F55Fa60be61050419B008d56e15",
+                  nodeAddress: "0x0f693CC956DF59deC24BB1C605ac94CadCe6014d",
                   username: "bob_account1"
                 },
                 id: "e5a48217-5d83-4fdd-bf1d-b9e35934f0f2",

--- a/packages/playground-server/test/mock-data.ts
+++ b/packages/playground-server/test/mock-data.ts
@@ -1,22 +1,34 @@
+export const PK_ALICE =
+  "0xe74ad40ac33d783e5775666ebbd28d0b395dbb4287bee0e88e1803df6eaa7ab4";
+
+export const PK_ALICE_DUPE =
+  "0x114ed1e994780a9d6decfc0915f43668f61b97fe8c37611152fc8b5e942b2dd5";
+
+export const PK_BOB =
+  "0x114ed1e994780a9d6decfc0915f43668f61b97fe8c37611152fc8b5e942b2dd5";
+
+export const PK_CHARLIE =
+  "0x4a138819ac516411432e76db794333eecd66e88926a528e621e31a97f5280c33";
+
 export const USR_ALICE = {
   username: "alice_account3",
   email: "alice@wonderland.com",
-  ethAddress: "0x5faddca4889ddc5791cf65446371151f29653285",
-  nodeAddress: "0xFE0460D00c589F55Fa60be61050419B008d56e15"
+  ethAddress: "0x5fAddCa4889DdC5791cf65446371151f29653285",
+  nodeAddress: "0x5fAddCa4889DdC5791cf65446371151f29653285"
 };
 
 export const USR_ALICE_DUPLICATE_USERNAME = {
   username: "alice_account3",
   email: "alice@wonderland.com",
-  ethAddress: "0x0f693cc956df59dec24bb1c605ac94cadce6014d",
-  nodeAddress: "0xdd270e32c1eC7D7Ac90AA02e7E03FBACFa53b34b"
+  ethAddress: "0x0f693CC956DF59deC24BB1C605ac94CadCe6014d",
+  nodeAddress: "0x0f693CC956DF59deC24BB1C605ac94CadCe6014d"
 };
 
 export const USR_BOB = {
   email: "bob@wonderland.com",
-  ethAddress: "0x0f693cc956df59dec24bb1c605ac94cadce6014d",
+  ethAddress: "0x0f693CC956DF59deC24BB1C605ac94CadCe6014d",
   multisigAddress: "0xc5F6047a22A5582f62dBcD278f1A2275ab39001A",
-  nodeAddress: "0xFE0460D00c589F55Fa60be61050419B008d56e15",
+  nodeAddress: "0x0f693CC956DF59deC24BB1C605ac94CadCe6014d",
   username: "bob_account1"
 };
 
@@ -25,8 +37,8 @@ export const USR_BOB_ID = "e5a48217-5d83-4fdd-bf1d-b9e35934f0f2";
 export const USR_CHARLIE = {
   username: "charlie_account2",
   email: "charlie@wonderland.com",
-  ethAddress: "0x93678a4828d07708ad34272d61404dd06ae2ca64",
-  nodeAddress: "0xFE0460D00c589F55Fa60be61050419B008d56e15"
+  ethAddress: "0x93678a4828D07708aD34272D61404dD06aE2CA64",
+  nodeAddress: "0x93678a4828D07708aD34272D61404dD06aE2CA64"
 };
 
 export const POST_USERS_ALICE = {
@@ -37,7 +49,7 @@ export const POST_USERS_ALICE = {
 
 export const POST_USERS_ALICE_SIGNATURE_HEADER = {
   authorization:
-    "Signature 0x75d3f99deabc40c2745955ed7c8301a128c2262b45a0d1c7fa9c6d786c93ce4116c57b6c2bbee0304ccc12ada554f063c90a3d87176b854c175cc9e887cbda7b1c"
+    "Signature 0xb62fe274751aedfc9ab0a11009d100e798dc17d806e787b699eea72b899ebe9d52a7bd9b66552a41a2359872cae6b56fac1593cc7ac3fbf2cc5d2782563545761b"
 };
 
 export const POST_USERS_ALICE_NO_SIGNATURE = {
@@ -63,7 +75,7 @@ export const POST_USERS_ALICE_DUPLICATE_USERNAME = {
 
 export const POST_USERS_ALICE_DUPLICATE_USERNAME_SIGNATURE_HEADER = {
   authorization:
-    "Signature 0x865aa97aa1765903e100648169fb2bdb7259123ba112d81043a14039400a980a3f4bbc4505d8d140a37f6c53add5474e76e11fda44ffbf6842cdbc6c7a3f02f21b"
+    "Signature 0x5a129cec41a5ffe092c9b020ee945543d340131605fa5a9b5e6aefea4db619616ca730062155fd0b4922325eb93c75fab673ce35457083bb5d2b81285f3a76f41c"
 };
 
 export const POST_USERS_CHARLIE = {
@@ -74,47 +86,47 @@ export const POST_USERS_CHARLIE = {
 
 export const POST_USERS_CHARLIE_SIGNATURE_HEADER = {
   authorization:
-    "Signature 0xc4365196ccad8af8daa75f02c3b38282de3faafe19e255e271cdbc80f8aea8960fdf8be1356693a1846b7d0e1ff290d313f5064e887ee30935e2f14fba4e76691b"
+    "Signature 0x1cf892974e79fc38f7eadd231fb0f27ab11f2888f519bba1b87d5408637ba81a49f290343c179745d6070efa5c9cf9bf060ea704bd9ec9c13de4c8c3baa5f78b1c"
 };
 
 export const POST_SESSION_CHARLIE = {
   data: {
     type: "session",
     id: "",
-    attributes: { ethAddress: "0x93678a4828d07708ad34272d61404dd06ae2ca64" }
+    attributes: { ethAddress: "0x93678a4828D07708aD34272D61404dD06aE2CA64" }
   }
 };
 
 export const POST_SESSION_CHARLIE_SIGNATURE_HEADER = {
   authorization:
-    "Signature 0x3978ffd558c3e142b1e7f622b74efed5889e4452c978abd4babcb81cdbda59f345fb5e2b089854cd67c463eb6245931077a34b8404d089003ddcb7aa5ba5a8dd1c"
+    "Signature 0x9aaf0833ed78cc9d29c9d2965156ad57a45e0d74cd9ded50910812806f13f8b86dc4c0f0bf802061f3e8e1ff91442adf9652443864a213bbded0e1a12d6bd3fa1b"
 };
 
 export const POST_SESSION_BOB = {
   data: {
     type: "session",
     id: "",
-    attributes: { ethAddress: "0x0f693cc956df59dec24bb1c605ac94cadce6014d" }
+    attributes: { ethAddress: "0x0f693CC956DF59deC24BB1C605ac94CadCe6014d" }
   }
 };
 
 export const POST_SESSION_BOB_SIGNATURE_HEADER = {
   authorization:
-    "Signature 0x0d89ad46772a1ae1e3ae7202da31a32de00d8c8993fa448cc2e6265608c8bd1e493a75ab3e3bc67aa28cce29691a0b013c9c96c06fdf35834b82ad27e46e9d2b1c"
+    "Signature 0xe627ce2761d0f411a985472e3f08edd57915f08743be9bcf9f6b620a2b3b33b90481e2fc8ba195ae9eaa8fb6cdee7ee490561e1792dddc9f86bcb14919fe23591b"
 };
 
 export const POST_SESSION_ALICE = {
   data: {
     type: "session",
     id: "",
-    attributes: { ethAddress: "0x5faddca4889ddc5791cf65446371151f29653285" }
+    attributes: { ethAddress: "0x5fAddCa4889DdC5791cf65446371151f29653285" }
   }
 };
 
 export const POST_SESSION_ALICE_SIGNATURE_HEADER = {
   authorization:
-    "Signature 0xf8d4518ce9c41875e5e9bf87201d5b68ebbdf62726fbe9a573ff39bcc3d150d960c8d7e92bbee9d72212eaba58be0205807bf959fe021c1a2f0992ebbc44df601c"
+    "Signature 0x49adc42b169295b67d8efa9d4da8ad079b5d7ed2475cd8a948de411ba284e3fc4c4039f893bd7d7cc5a44c330e20ae8b7c6d79fc32083fae7bb7f4522903f6bf1c"
 };
 
 export const TOKEN_BOB =
-  "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6ImU1YTQ4MjE3LTVkODMtNGZkZC1iZjFkLWI5ZTM1OTM0ZjBmMiIsInR5cGUiOiJ1c2VycyIsImF0dHJpYnV0ZXMiOnsidXNlcm5hbWUiOiJib2JfYWNjb3VudDEiLCJlbWFpbCI6ImJvYkB3b25kZXJsYW5kLmNvbSIsImV0aEFkZHJlc3MiOiIweDBmNjkzY2M5NTZkZjU5ZGVjMjRiYjFjNjA1YWM5NGNhZGNlNjAxNGQiLCJub2RlQWRkcmVzcyI6IjB4RkUwNDYwRDAwYzU4OUY1NUZhNjBiZTYxMDUwNDE5QjAwOGQ1NmUxNSIsIm11bHRpc2lnQWRkcmVzcyI6IjB4YzVGNjA0N2EyMkE1NTgyZjYyZEJjRDI3OGYxQTIyNzVhYjM5MDAxQSJ9LCJpYXQiOjE1NDc3NjQxOTgsImV4cCI6MTU3OTMyMTc5OH0.gjryLLyW1JumqMK__pLFjnMPwTCXCSw4eI9lCkTrEIs";
+  "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJhdHRyaWJ1dGVzIjp7ImVtYWlsIjoiYm9iQHdvbmRlcmxhbmQuY29tIiwiZXRoQWRkcmVzcyI6IjB4MGY2OTNDQzk1NkRGNTlkZUMyNEJCMUM2MDVhYzk0Q2FkQ2U2MDE0ZCIsIm11bHRpc2lnQWRkcmVzcyI6IjB4YzVGNjA0N2EyMkE1NTgyZjYyZEJjRDI3OGYxQTIyNzVhYjM5MDAxQSIsIm5vZGVBZGRyZXNzIjoiMHgwZjY5M0NDOTU2REY1OWRlQzI0QkIxQzYwNWFjOTRDYWRDZTYwMTRkIiwidXNlcm5hbWUiOiJib2JfYWNjb3VudDEifSwiaWQiOiJlNWE0ODIxNy01ZDgzLTRmZGQtYmYxZC1iOWUzNTkzNGYwZjIiLCJpYXQiOjE1NDgyMDA1NjcsImV4cCI6MTU3OTc1ODE2N30.EMeP0Glq0ARFZpgXLkVuIILDOUxtY9n3qQJol7m29Uk";

--- a/packages/playground/src/data/firebase.ts
+++ b/packages/playground/src/data/firebase.ts
@@ -52,7 +52,7 @@ export default class FirebaseServiceFactory {
 class FirebaseMessagingService implements IMessagingService {
   // naive caching - firebase fires observers twice upon initial callback
   // registration and invocation
-  private servedMessages = new Map();
+  private servedMessages = new Set();
 
   constructor(
     private readonly firebase: firebase.database.Database,
@@ -93,11 +93,10 @@ class FirebaseMessagingService implements IMessagingService {
           return;
         }
 
-        const stringifiedMsg = JSON.stringify(msg);
-        if (stringifiedMsg in this.servedMessages) {
-          delete this.servedMessages[stringifiedMsg];
+        if (this.servedMessages.has(msg)) {
+          this.servedMessages.delete(msg);
         } else {
-          this.servedMessages[stringifiedMsg] = true;
+          this.servedMessages.add(msg);
           callback(msg);
         }
       });

--- a/packages/playground/src/data/firebase.ts
+++ b/packages/playground/src/data/firebase.ts
@@ -66,34 +66,34 @@ class FirebaseMessagingService implements IMessagingService {
   }
 
   onReceive(address: Address, callback: (msg: object) => void) {
-    if (!this.firebase.app) {
+    if (this.firebase.app) {
+      this.firebase
+        .ref(`${this.messagingServerKey}/${address}`)
+        .on("value", (snapshot: firebase.database.DataSnapshot | null) => {
+          if (snapshot === null) {
+            console.error(
+              `Node with address ${address} received a "null" snapshot`
+            );
+          } else {
+            const msg = snapshot.val();
+            // TODO: Figure out why sometimes the message is null?
+            // Answer: https://stackoverflow.com/a/37310606/2680092
+            if (msg !== null) {
+              const stringifiedMsg = JSON.stringify(msg);
+              if (stringifiedMsg in this.servedMessages) {
+                delete this.servedMessages[stringifiedMsg];
+              } else {
+                this.servedMessages[stringifiedMsg] = true;
+                callback(msg);
+              }
+            }
+          }
+        });
+    } else {
       console.error(
         "Cannot register a connection with an uninitialized firebase handle"
       );
-      return;
     }
-
-    this.firebase
-      .ref(`${this.messagingServerKey}/${address}`)
-      .on("value", (snapshot: firebase.database.DataSnapshot | null) => {
-        if (snapshot === null) {
-          console.debug(
-            `Node with address ${address} received a "null" snapshot`
-          );
-          return;
-        }
-        const msg = snapshot.val();
-        const msgKey = JSON.stringify(msg);
-        if (msg === null) {
-          return;
-        }
-        if (msgKey in this.servedMessages) {
-          delete this.servedMessages[msgKey];
-          return;
-        }
-        this.servedMessages[msgKey] = true;
-        callback(msg);
-      });
   }
 }
 

--- a/packages/playground/src/data/firebase.ts
+++ b/packages/playground/src/data/firebase.ts
@@ -6,7 +6,7 @@ import firebase from "firebase/app";
 import "firebase/database";
 
 export interface IMessagingService {
-  send(respondingAddress: Address, msg: any);
+  send(respondingAddress: Address, msg: any): Promise<void>;
   onReceive(address: Address, callback: (msg: any) => void);
 }
 

--- a/packages/playground/src/data/firebase.ts
+++ b/packages/playground/src/data/firebase.ts
@@ -76,8 +76,10 @@ class FirebaseMessagingService implements IMessagingService {
             );
           } else {
             const msg = snapshot.val();
-            // TODO: Figure out why sometimes the message is null?
-            // Answer: https://stackoverflow.com/a/37310606/2680092
+            // We check for `msg` being not null because when the Firebase listener
+            // connects, the snapshot starts with a `null` value, and on the second
+            // the call it receives a value.
+            // See: https://stackoverflow.com/a/37310606/2680092
             if (msg !== null) {
               const stringifiedMsg = JSON.stringify(msg);
               if (stringifiedMsg in this.servedMessages) {

--- a/packages/playground/src/data/firebase.ts
+++ b/packages/playground/src/data/firebase.ts
@@ -66,36 +66,41 @@ class FirebaseMessagingService implements IMessagingService {
   }
 
   onReceive(address: Address, callback: (msg: object) => void) {
-    if (this.firebase.app) {
-      this.firebase
-        .ref(`${this.messagingServerKey}/${address}`)
-        .on("value", (snapshot: firebase.database.DataSnapshot | null) => {
-          if (snapshot === null) {
-            console.error(
-              `Node with address ${address} received a "null" snapshot`
-            );
-          } else {
-            const msg = snapshot.val();
-            // We check for `msg` being not null because when the Firebase listener
-            // connects, the snapshot starts with a `null` value, and on the second
-            // the call it receives a value.
-            // See: https://stackoverflow.com/a/37310606/2680092
-            if (msg !== null) {
-              const stringifiedMsg = JSON.stringify(msg);
-              if (stringifiedMsg in this.servedMessages) {
-                delete this.servedMessages[stringifiedMsg];
-              } else {
-                this.servedMessages[stringifiedMsg] = true;
-                callback(msg);
-              }
-            }
-          }
-        });
-    } else {
+    if (!this.firebase.app) {
       console.error(
         "Cannot register a connection with an uninitialized firebase handle"
       );
+      return;
     }
+
+    this.firebase
+      .ref(`${this.messagingServerKey}/${address}`)
+      .on("value", (snapshot: firebase.database.DataSnapshot | null) => {
+        if (!snapshot) {
+          console.error(
+            `Node with address ${address} received a "null" snapshot`
+          );
+          return;
+        }
+
+        const msg = snapshot.val();
+
+        if (msg === null) {
+          // We check for `msg` being not null because when the Firebase listener
+          // connects, the snapshot starts with a `null` value, and on the second
+          // the call it receives a value.
+          // See: https://stackoverflow.com/a/37310606/2680092
+          return;
+        }
+
+        const stringifiedMsg = JSON.stringify(msg);
+        if (stringifiedMsg in this.servedMessages) {
+          delete this.servedMessages[stringifiedMsg];
+        } else {
+          this.servedMessages[stringifiedMsg] = true;
+          callback(msg);
+        }
+      });
   }
 }
 

--- a/packages/playground/src/data/firebase.ts
+++ b/packages/playground/src/data/firebase.ts
@@ -7,7 +7,7 @@ import "firebase/database";
 
 export interface IMessagingService {
   send(respondingAddress: Address, msg: any);
-  receive(address: Address, callback: (msg: any) => void);
+  onReceive(address: Address, callback: (msg: any) => void);
 }
 
 export interface IStoreService {
@@ -65,7 +65,7 @@ class FirebaseMessagingService implements IMessagingService {
       .set(JSON.parse(JSON.stringify(msg)));
   }
 
-  receive(address: Address, callback: (msg: object) => void) {
+  onReceive(address: Address, callback: (msg: object) => void) {
     if (!this.firebase.app) {
       console.error(
         "Cannot register a connection with an uninitialized firebase handle"

--- a/yarn.lock
+++ b/yarn.lock
@@ -866,6 +866,17 @@
     lodash "^4.17.10"
     to-fast-properties "^2.0.0"
 
+"@counterfactual/cf.js@0.0.1":
+  version "0.0.1"
+  resolved "https://registry.yarnpkg.com/@counterfactual/cf.js/-/cf.js-0.0.1.tgz#9c30e2433366852430f1dd4b6b92ce5a27511ae4"
+  integrity sha512-Rnxy5sZm/cDaa36zUkOjyH5RAxFPGGUTZGBJ2oHb2yC5DqWbvpcLlnspiS4JgUNxW5+IN9jIiWSXHomgEhI6JQ==
+  dependencies:
+    "@counterfactual/contracts" "0.0.3"
+    "@counterfactual/types" "0.0.1"
+    cuid "^2.1.4"
+    ethers "4.0.21"
+    eventemitter3 "^3.1.0"
+
 "@csstools/convert-colors@^1.4.0":
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/@csstools/convert-colors/-/convert-colors-1.4.0.tgz#ad495dc41b12e75d588c6db8b9834f08fa131eb7"
@@ -5255,6 +5266,11 @@ cssstyle@^1.0.0, cssstyle@^1.1.1:
   integrity sha512-364AI1l/M5TYcFH83JnOH/pSqgaNnKmYgKrm0didZMGKWjQB60dymwWy1rKUgL3J1ffdq9xVi2yGLHdSjjSNog==
   dependencies:
     cssom "0.3.x"
+
+cuid@^2.1.4:
+  version "2.1.4"
+  resolved "https://registry.yarnpkg.com/cuid/-/cuid-2.1.4.tgz#e1178eb92a05ef9364b29a9942feed36d3604cdd"
+  integrity sha512-l1vrCiWOwBpu85bfm939Hg3MQh2alxAMoGZnjcJOYkgN7wzy9yi3vQhRzwcTr9mdIlfTp8DP9G5ZgIIPyaQEvg==
 
 currently-unhandled@^0.4.1:
   version "0.4.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -866,16 +866,16 @@
     lodash "^4.17.10"
     to-fast-properties "^2.0.0"
 
-"@counterfactual/cf.js@0.0.1":
-  version "0.0.1"
-  resolved "https://registry.yarnpkg.com/@counterfactual/cf.js/-/cf.js-0.0.1.tgz#9c30e2433366852430f1dd4b6b92ce5a27511ae4"
-  integrity sha512-Rnxy5sZm/cDaa36zUkOjyH5RAxFPGGUTZGBJ2oHb2yC5DqWbvpcLlnspiS4JgUNxW5+IN9jIiWSXHomgEhI6JQ==
+"@counterfactual/cf.js@0.0.2":
+  version "0.0.2"
+  resolved "https://registry.yarnpkg.com/@counterfactual/cf.js/-/cf.js-0.0.2.tgz#fcddda4c1f224df95ee9e2caa39442907514017d"
+  integrity sha512-dMBHRyZAB5/mNQkGyB4JNBOm58mNWM6ZURQJixEkdXBIBbdJpZath8w//k/EfxIsQC6sgnvYOqy4PkcpKcNLlQ==
   dependencies:
     "@counterfactual/contracts" "0.0.3"
     "@counterfactual/types" "0.0.1"
-    cuid "^2.1.4"
     ethers "4.0.21"
     eventemitter3 "^3.1.0"
+    uuid "3.3.2"
 
 "@csstools/convert-colors@^1.4.0":
   version "1.4.0"
@@ -5267,11 +5267,6 @@ cssstyle@^1.0.0, cssstyle@^1.1.1:
   dependencies:
     cssom "0.3.x"
 
-cuid@^2.1.4:
-  version "2.1.4"
-  resolved "https://registry.yarnpkg.com/cuid/-/cuid-2.1.4.tgz#e1178eb92a05ef9364b29a9942feed36d3604cdd"
-  integrity sha512-l1vrCiWOwBpu85bfm939Hg3MQh2alxAMoGZnjcJOYkgN7wzy9yi3vQhRzwcTr9mdIlfTp8DP9G5ZgIIPyaQEvg==
-
 currently-unhandled@^0.4.1:
   version "0.4.1"
   resolved "https://registry.yarnpkg.com/currently-unhandled/-/currently-unhandled-0.4.1.tgz#988df33feab191ef799a61369dd76c17adf957ea"
@@ -6545,7 +6540,7 @@ ethereum-common@^0.0.18:
 
 ethereum-waffle@2.0.1:
   version "2.0.1"
-  resolved "https://registry.npmjs.org/ethereum-waffle/-/ethereum-waffle-2.0.1.tgz#4d8228db3c16fc10a9201ad77a8e92087cb06f26"
+  resolved "https://registry.yarnpkg.com/ethereum-waffle/-/ethereum-waffle-2.0.1.tgz#4d8228db3c16fc10a9201ad77a8e92087cb06f26"
   integrity sha512-r90mH2y0Jb6DgE1gfhkflmedTLiloe8VeNvtXAVlzHH3PYbCJ1TvwMFC5fOiqBp2PaqD9tPo8BNGmREOiTuNqg==
   dependencies:
     ethers "^4.0.0"
@@ -16606,10 +16601,10 @@ tslint-eslint-rules@^5.4.0:
     tslib "1.9.0"
     tsutils "^3.0.0"
 
-tslint-microsoft-contrib@~5.2.1:
-  version "5.2.1"
-  resolved "https://registry.npmjs.org/tslint-microsoft-contrib/-/tslint-microsoft-contrib-5.2.1.tgz#a6286839f800e2591d041ea2800c77487844ad81"
-  integrity sha512-PDYjvpo0gN9IfMULwKk0KpVOPMhU6cNoT9VwCOLeDl/QS8v8W2yspRpFFuUS7/c5EIH/n8ApMi8TxJAz1tfFUA==
+tslint-microsoft-contrib@^6.0.0, tslint-microsoft-contrib@~5.2.1:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/tslint-microsoft-contrib/-/tslint-microsoft-contrib-6.0.0.tgz#7bff73c9ad7a0b7eb5cdb04906de58f42a2bf7a2"
+  integrity sha512-R//efwn+34IUjTJeYgNDAJdzG0jyLWIehygPt/PHuZAieTolFVS56FgeFW7DOLap9ghXzMiFPTmDgm54qaL7QA==
   dependencies:
     tsutils "^2.27.2 <2.29.0"
 


### PR DESCRIPTION
This pull request incorporates changes initially spiked out in #529.

1. Updates the protocols to correctly and safely do signature validation based on the initial message that kicked off the machine's execution and the commitment generated and stored inside context.

2. Attaches the `messagingService` to the `IO_SEND` opcode as middleware hook.

3. Attached the `IO_WAIT` opcode to a middleware which checks for a promise of a received value from the counterparty. Due the nature of the middleware architecture and wanting to only have a single "messaging listener" attached on the Node (to avoid duplication and opt instead for filtering) I introduced a `Deferred` type which extracts the `resolve` callback inside a `Promise` to an external method. Thus, the messaging receiver _resolves_ the `Deferred` and the `IO_WAIT` middleware hook listens for the resolution before resolving itself and the `IO_SEND` registers the `Deferred` itself _before_ sending the message to ensure it won't get caught in a race condition (where the message is received before the hook is set). 

4. Introduces a new event type, `protocolMessageEventController` which dispatches a new message type `NodeWrappedProtocolMessage` to the `InstructionExecutor`'s `receiveDispatchedMessage` handler.

5. Updates to the `playground-server` to support the requirements of messaging (namely: signing by the correct address which is the public facing address of the Node and correct checksummed addresses as the network addresses & signed message data addresses)