### PR TITLE
[node] [node-provider] Fixes CF.js version

### DIFF
--- a/packages/node-provider/package.json
+++ b/packages/node-provider/package.json
@@ -16,7 +16,7 @@
     "lint": "tslint -c tslint.json -p ."
   },
   "devDependencies": {
-    "@counterfactual/cf.js": "0.0.1",
+    "@counterfactual/cf.js": "0.0.2",
     "@counterfactual/types": "0.0.1",
     "@types/jest": "^23.3.11",
     "@types/node": "^10.9.3",

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -29,7 +29,7 @@
     "typescript": "^3.1.2"
   },
   "dependencies": {
-    "@counterfactual/cf.js": "0.0.1",
+    "@counterfactual/cf.js": "0.0.2",
     "@counterfactual/machine": "0.0.1",
     "@counterfactual/types": "0.0.1",
     "ethers": "4.0.21",


### PR DESCRIPTION
When `0.0.2` of `@counterfactual/cf.js` was published, we left both the `Node` and `NodeProvider` packages pointing to the old version, making the monorepo to use an incorrect version.