### PR TITLE
[dapp-tic-tac-toe] Replaces cuid with uuid

### DIFF
--- a/packages/dapp-tic-tac-toe/public/index.html
+++ b/packages/dapp-tic-tac-toe/public/index.html
@@ -23,14 +23,17 @@
       Learn how to configure a non-root public URL by running `npm run build`.
     -->
     <title>Tic Tac Toe</title>
-    <link href="https://fonts.googleapis.com/css?family=Dosis:500,700,800" rel="stylesheet">
+    <link
+      href="https://fonts.googleapis.com/css?family=Dosis:500,700,800"
+      rel="stylesheet"
+    />
 
     <!--
       TODO: These builds are symlinked from node_modules and local packages.
       THIS MUST NOT BE LIKE THIS! We must solve how Rollup is building
       all of this.
     -->
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/cuid/1.3.8/browser-cuid.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/node-uuid/1.4.8/uuid.js"></script>
     <script src="/eventemitter3.js"></script>
     <script src="/ethers.js"></script>
     <script src="/types.js"></script>


### PR DESCRIPTION
Since #564 got merged, TTT must inject a different dependency for a browser version of `uuid`.