### PR TITLE
[cf.js] Bundle dependencies for distribution

### DIFF
--- a/packages/cf.js/package.json
+++ b/packages/cf.js/package.json
@@ -21,6 +21,7 @@
   "devDependencies": {
     "jest": "23.6.0",
     "rollup": "^1.0.1",
+    "rollup-plugin-node-resolve": "^4.0.0",
     "rollup-plugin-typescript2": "^0.19.0",
     "tslint": "^5.11.0",
     "typedoc": "^0.14.0",
@@ -28,9 +29,9 @@
   },
   "dependencies": {
     "@counterfactual/types": "0.0.1",
-    "uuid": "3.3.2",
     "ethers": "4.0.21",
-    "eventemitter3": "^3.1.0"
+    "eventemitter3": "^3.1.0",
+    "uuid": "3.3.2"
   },
   "jest": {
     "verbose": false,

--- a/packages/cf.js/package.json
+++ b/packages/cf.js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@counterfactual/cf.js",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "description": "The bridge between web applications and Counterfactual wallets.",
   "types": "dist/src/index.d.ts",
   "main": "dist/index.js",

--- a/packages/cf.js/rollup.config.js
+++ b/packages/cf.js/rollup.config.js
@@ -1,7 +1,11 @@
 import typescript from "rollup-plugin-typescript2";
-import json from "rollup-plugin-json";
+import nodeResolve from "rollup-plugin-node-resolve";
 
 import pkg from "./package.json";
+
+const bundledDependencies = new Set([
+  "@counterfactual/types",
+]);
 
 export default {
   input: "src/index.ts",
@@ -23,6 +27,9 @@ export default {
     }
   ],
   plugins: [
+    nodeResolve({
+      only: [...bundledDependencies]
+    }),
     typescript(),
   ]
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -6527,10 +6527,10 @@ ethereum-common@^0.0.18:
   resolved "https://registry.yarnpkg.com/ethereum-common/-/ethereum-common-0.0.18.tgz#2fdc3576f232903358976eb39da783213ff9523f"
   integrity sha1-L9w1dvIykDNYl26znaeDIT/5Uj8=
 
-ethereum-waffle@2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/ethereum-waffle/-/ethereum-waffle-2.0.0.tgz#4a6cf66569d4b90d6894b04a70f7c577bce986e9"
-  integrity sha512-sbqMOyID+0eyDJpDXcSiwBjuFo05Li7vL9xYBhJO1NzoaKRMtAJY0tsM3DtPRDTxNethtqqukqcLehA9KLBZNg==
+ethereum-waffle@2.0.1:
+  version "2.0.1"
+  resolved "https://registry.npmjs.org/ethereum-waffle/-/ethereum-waffle-2.0.1.tgz#4d8228db3c16fc10a9201ad77a8e92087cb06f26"
+  integrity sha512-r90mH2y0Jb6DgE1gfhkflmedTLiloe8VeNvtXAVlzHH3PYbCJ1TvwMFC5fOiqBp2PaqD9tPo8BNGmREOiTuNqg==
   dependencies:
     ethers "^4.0.0"
     ganache-core "2.2.1"
@@ -14585,7 +14585,7 @@ rollup-plugin-json@^3.1.0:
 
 rollup-plugin-node-resolve@^4.0.0:
   version "4.0.0"
-  resolved "https://registry.yarnpkg.com/rollup-plugin-node-resolve/-/rollup-plugin-node-resolve-4.0.0.tgz#9bc6b8205e9936cc0e26bba2415f1ecf1e64d9b2"
+  resolved "https://registry.npmjs.org/rollup-plugin-node-resolve/-/rollup-plugin-node-resolve-4.0.0.tgz#9bc6b8205e9936cc0e26bba2415f1ecf1e64d9b2"
   integrity sha512-7Ni+/M5RPSUBfUaP9alwYQiIKnKeXCOHiqBpKUl9kwp3jX5ZJtgXAait1cne6pGEVUUztPD6skIKH9Kq9sNtfw==
   dependencies:
     builtin-modules "^3.0.0"
@@ -16590,10 +16590,10 @@ tslint-eslint-rules@^5.4.0:
     tslib "1.9.0"
     tsutils "^3.0.0"
 
-tslint-microsoft-contrib@^6.0.0, tslint-microsoft-contrib@~5.2.1:
-  version "6.0.0"
-  resolved "https://registry.yarnpkg.com/tslint-microsoft-contrib/-/tslint-microsoft-contrib-6.0.0.tgz#7bff73c9ad7a0b7eb5cdb04906de58f42a2bf7a2"
-  integrity sha512-R//efwn+34IUjTJeYgNDAJdzG0jyLWIehygPt/PHuZAieTolFVS56FgeFW7DOLap9ghXzMiFPTmDgm54qaL7QA==
+tslint-microsoft-contrib@~5.2.1:
+  version "5.2.1"
+  resolved "https://registry.npmjs.org/tslint-microsoft-contrib/-/tslint-microsoft-contrib-5.2.1.tgz#a6286839f800e2591d041ea2800c77487844ad81"
+  integrity sha512-PDYjvpo0gN9IfMULwKk0KpVOPMhU6cNoT9VwCOLeDl/QS8v8W2yspRpFFuUS7/c5EIH/n8ApMi8TxJAz1tfFUA==
   dependencies:
     tsutils "^2.27.2 <2.29.0"
 


### PR DESCRIPTION
This bundles some of the dependencies for the @countrefactual/cf.js package in its dist, but notably leaves out:
- `ethers`
- `eventemitter3`
- `uuid`

These can reliably be fetched from CDNs.
