### PR TITLE
[monorepo] remove some uses of setFreeBalanceFor

### DIFF
--- a/packages/node/src/events/multisig-created/controller.ts
+++ b/packages/node/src/events/multisig-created/controller.ts
@@ -1,6 +1,4 @@
 import { StateChannel } from "@counterfactual/machine";
-import { AssetType } from "@counterfactual/types";
-import { bigNumberify } from "ethers/utils";
 
 import { RequestHandler } from "../../request-handler";
 import { CreateMultisigMessage } from "../../types";
@@ -20,11 +18,6 @@ export default async function addMultisigController(
       requestHandler.networkContext,
       multisigAddress,
       multisigOwners
-    ).setFreeBalanceFor(AssetType.ETH, {
-      alice: multisigOwners[0],
-      bob: multisigOwners[1],
-      aliceBalance: bigNumberify(0),
-      bobBalance: bigNumberify(0)
-    })
+    )
   );
 }

--- a/packages/node/test/unit/install.spec.ts
+++ b/packages/node/test/unit/install.spec.ts
@@ -85,13 +85,14 @@ describe("Can handle correct & incorrect installs", () => {
     const owners = [Wallet.createRandom().address, AddressZero];
 
     const stateChannel = StateChannel
-      .setupChannel(EMPTY_NETWORK, multisigAddress, owners)
-      .setFreeBalanceFor(AssetType.ETH, {
-        alice: owners[0],
-        bob: owners[1],
-        aliceBalance: Zero,
-        bobBalance: Zero
-      });
+      .setupChannel(EMPTY_NETWORK, multisigAddress, owners);
+
+    const fbState = stateChannel.getFreeBalanceFor(AssetType.ETH).state;
+
+    expect(fbState.alice === owners[1]);
+    expect(fbState.bob === owners[0]);
+    expect(fbState.aliceBalance).toEqual(Zero);
+    expect(fbState.bobBalance).toEqual(Zero);
 
     await store.saveStateChannel(stateChannel);
 

--- a/packages/node/test/unit/install.spec.ts
+++ b/packages/node/test/unit/install.spec.ts
@@ -1,6 +1,7 @@
 import { InstructionExecutor, StateChannel } from "@counterfactual/machine";
+import { AssetType } from "@counterfactual/types";
 import { Wallet } from "ethers";
-import { AddressZero } from "ethers/constants";
+import { AddressZero, Zero } from "ethers/constants";
 import { anything, instance, mock, when } from "ts-mockito";
 import { v4 as generateUUID } from "uuid";
 
@@ -83,8 +84,11 @@ describe("Can handle correct & incorrect installs", () => {
     const multisigAddress = Wallet.createRandom().address;
     const owners = [Wallet.createRandom().address, AddressZero];
 
-    const stateChannel = StateChannel
-      .setupChannel(EMPTY_NETWORK.ETHBucket, multisigAddress, owners);
+    const stateChannel = StateChannel.setupChannel(
+      EMPTY_NETWORK.ETHBucket,
+      multisigAddress,
+      owners
+    );
 
     const fbState = stateChannel.getFreeBalanceFor(AssetType.ETH).state;
 


### PR DESCRIPTION
since `setupChannel` already populates an empty ETH free balance, these calls are unnecessary