### PR TITLE
[dapp-high-roller] Revert back original order in getTurnTaker ternary

### DIFF
--- a/packages/apps/contracts/HighRollerApp.sol
+++ b/packages/apps/contracts/HighRollerApp.sol
@@ -63,8 +63,8 @@ contract HighRollerApp {
     AppState memory state = abi.decode(encodedState, (AppState));
 
     return state.stage == Stage.COMMITTING_NUM ?
-      signingKeys[uint8(Player.FIRST)] :
-      signingKeys[uint8(Player.SECOND)];
+      signingKeys[uint8(Player.SECOND)] :
+      signingKeys[uint8(Player.FIRST)];
   }
 
   function applyAction(bytes memory encodedState, bytes memory encodedAction)


### PR DESCRIPTION
### Description

Ternary expression in getTurnTaker of HighRollerApp contract was flipped in a recent PR. This reverts that

### Related issues

Caused by: #584 

- [ ] Deploy preview is functional
