### PR TITLE
[dapp-tic-tac-toe] Fix calling connect function with a redundant param

### DIFF
--- a/packages/dapp-tic-tac-toe/src/App.js
+++ b/packages/dapp-tic-tac-toe/src/App.js
@@ -28,7 +28,7 @@ export default class App extends Component {
       gameInfo
     };
 
-    this.connect(nodeProvider);
+    this.connect();
     this.requestUserData();
   }
 


### PR DESCRIPTION
### Description

Fix calling connect function with a redundant param. 
The `connect` function expects 0 arguments and it is called with `nodeProvider` redundantly.

- [ ] Deploy preview is functional
