### PR TITLE
[nodeProvider] Update dependencies & rollup

### DIFF
--- a/packages/node-provider/package.json
+++ b/packages/node-provider/package.json
@@ -16,8 +16,6 @@
     "lint": "tslint -c tslint.json -p ."
   },
   "devDependencies": {
-    "@counterfactual/cf.js": "0.0.2",
-    "@counterfactual/types": "0.0.1",
     "@types/jest": "^23.3.11",
     "@types/node": "^10.9.3",
     "jest": "23.6.0",
@@ -28,6 +26,10 @@
     "ts-jest": "23.10.5",
     "tslint": "^5.11.0",
     "typescript": "^3.1.2"
+  },
+  "dependencies": {
+    "@counterfactual/types": "0.0.1",
+    "eventemitter3": "^3.1.0"
   },
   "jest": {
     "verbose": false,
@@ -51,8 +53,5 @@
       "json"
     ],
     "testURL": "http://localhost/"
-  },
-  "dependencies": {
-    "eventemitter3": "^3.1.0"
   }
 }

--- a/packages/node-provider/rollup.config.js
+++ b/packages/node-provider/rollup.config.js
@@ -1,5 +1,13 @@
+import commonjs from "rollup-plugin-commonjs";
+import nodeResolve from "rollup-plugin-node-resolve";
 import typescript from "rollup-plugin-typescript2";
+
 import pkg from "./package.json";
+
+const bundledDependencies = new Set([
+  "@counterfactual/types",
+  "eventemitter3",
+]);
 
 export default [
   {
@@ -17,6 +25,12 @@ export default [
       }
     ],
     plugins: [
+      nodeResolve({
+        only: [...bundledDependencies]
+      }),
+      commonjs({
+        include: 'node_modules/eventemitter3/index.js',
+      }),
       typescript()
     ]
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -866,12 +866,11 @@
     lodash "^4.17.10"
     to-fast-properties "^2.0.0"
 
-"@counterfactual/cf.js@0.0.2":
-  version "0.0.2"
-  resolved "https://registry.yarnpkg.com/@counterfactual/cf.js/-/cf.js-0.0.2.tgz#fcddda4c1f224df95ee9e2caa39442907514017d"
-  integrity sha512-dMBHRyZAB5/mNQkGyB4JNBOm58mNWM6ZURQJixEkdXBIBbdJpZath8w//k/EfxIsQC6sgnvYOqy4PkcpKcNLlQ==
+"@counterfactual/cf.js@0.0.3":
+  version "0.0.3"
+  resolved "https://registry.npmjs.org/@counterfactual/cf.js/-/cf.js-0.0.3.tgz#806b3903af3150b4881aafadbe3b79715e1634b1"
+  integrity sha512-RwbavZVFBYa+x0x3Y9oqG7L7cd9B1Fk0mF188O5O35d3HAJXO5YCImbzP3WoGaHIDDfiOtIDmwkZtDNstfO5HQ==
   dependencies:
-    "@counterfactual/contracts" "0.0.3"
     "@counterfactual/types" "0.0.1"
     ethers "4.0.21"
     eventemitter3 "^3.1.0"
@@ -6789,6 +6788,22 @@ ethers@4.0.21:
   version "4.0.21"
   resolved "https://registry.yarnpkg.com/ethers/-/ethers-4.0.21.tgz#b3d88fa5f5832383de515769841fe6ad8545a71a"
   integrity sha512-wKW0tG15n91qtnt6e1YUXOeRRiHc03U6qenmLQbjiPLX9KVhNnBKe1kFpRtiiuPp0dyHsWWmtML9pz44pmAO1g==
+  dependencies:
+    "@types/node" "^10.3.2"
+    aes-js "3.0.0"
+    bn.js "^4.4.0"
+    elliptic "6.3.3"
+    hash.js "1.1.3"
+    js-sha3 "0.5.7"
+    scrypt-js "2.0.4"
+    setimmediate "1.0.4"
+    uuid "2.0.1"
+    xmlhttprequest "1.8.0"
+
+ethers@4.0.22:
+  version "4.0.22"
+  resolved "https://registry.npmjs.org/ethers/-/ethers-4.0.22.tgz#decaa08b3ca6378f28d0bb591b8d89bbbd25cd15"
+  integrity sha512-Mf9gDANLYbpk+8l//SSgyKA63PKWjUaxCnXbiwUNWLzp/4aikRK8fPTzoGpUB3SHz/EA5Ku87FpGmx/ILGMZvg==
   dependencies:
     "@types/node" "^10.3.2"
     aes-js "3.0.0"


### PR DESCRIPTION
This updates the dist to bundle eventemitter with it and removes the unused cf.js package dependency.