### PR TITLE
[monorepo] Make unused local variables a lint error not a build error

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,7 +4,8 @@
     "emitDecoratorMetadata": true,
     "experimentalDecorators": true,
     "noImplicitAny": false,
-    "noUnusedLocals": true,
+    // Turned on as no-unused-variable in tslint.json instead
+    "noUnusedLocals": false,
     "noImplicitReturns": true,
     "noLib": false,
     "removeComments": true,

--- a/tslint.json
+++ b/tslint.json
@@ -9,6 +9,7 @@
     // NOTE: Added by Liam. I just prefer this rule to be on. Looks clean.
     "ordered-imports": [true, {"grouped-imports": true}],
     // See https://github.com/counterfactual/monorepo/pull/231#discussion_r233860710
-    "import-name": false
+    "import-name": false,
+    "no-unused-variable": true
   }
 }


### PR DESCRIPTION
As suggested by @IIIIllllIIIIllllIIIIllllIIIIllllIIIIll 