### PR TITLE
[dapp-high-roller] Assert that numbers passed in by players in HighRoller are not 0

### DIFF
--- a/packages/apps/contracts/HighRollerApp.sol
+++ b/packages/apps/contracts/HighRollerApp.sol
@@ -177,6 +177,10 @@ contract HighRollerApp {
     pure
     returns (bytes32)
   {
+    require(
+      num1 != 0 && num2 != 0,
+      "Numbers passed in cannot equal 0"
+      );
     return keccak256(abi.encodePacked(num1 * num2));
   }
 


### PR DESCRIPTION
### Description

In the High Roller Contract we calculate the `randomSalt` to be used as a random bytes32 seed for generating 4 dice rolls.
This salt is created by doing: `keccak256(abi.encodePacked(num1 * num2));`

If one of the numbers is 0, the output is always the same no matter what the other player chooses.

This adds an assertion that neither of the player numbers is 0.


- [ ] Deploy preview is functional
