### PR TITLE
[apps] Make apps instance of CounterfactualApp

### DIFF
--- a/packages/apps/contracts/CountingApp.sol
+++ b/packages/apps/contracts/CountingApp.sol
@@ -5,7 +5,7 @@ import "@counterfactual/contracts/contracts/libs/Transfer.sol";
 import "@counterfactual/contracts/contracts/CounterfactualApp.sol";
 
 
-contract CountingApp {
+contract CountingApp is CounterfactualApp {
 
   enum ActionTypes { INCREMENT, DECREMENT}
 

--- a/packages/apps/contracts/HighRollerApp.sol
+++ b/packages/apps/contracts/HighRollerApp.sol
@@ -11,7 +11,7 @@ import "@counterfactual/contracts/contracts/CounterfactualApp.sol";
 ///         The winner is the player whose sum of dice outcomes is highest.
 /// @dev This contract is an example of a dApp built to run on
 ///      the CounterFactual framework
-contract HighRollerApp {
+contract HighRollerApp is CounterfactualApp {
 
   enum ActionType {
     START_GAME,

--- a/packages/apps/contracts/NimApp.sol
+++ b/packages/apps/contracts/NimApp.sol
@@ -9,7 +9,7 @@ import "@counterfactual/contracts/contracts/CounterfactualApp.sol";
 Normal-form Nim
 https://en.wikipedia.org/wiki/Nim
 */
-contract NimApp {
+contract NimApp is CounterfactualApp {
 
   struct Action {
     uint256 pileIdx;

--- a/packages/apps/contracts/TicTacToeApp.sol
+++ b/packages/apps/contracts/TicTacToeApp.sol
@@ -5,7 +5,7 @@ import "@counterfactual/contracts/contracts/libs/Transfer.sol";
 import "@counterfactual/contracts/contracts/CounterfactualApp.sol";
 
 
-contract TicTacToeApp {
+contract TicTacToeApp is CounterfactualApp {
 
   enum ActionType {
     PLAY,


### PR DESCRIPTION
### Description

In a recent PR #584 we added `encodedState` and `encodedAction` to our dapp contract code. This is because they should be an instance of CounterfactualApp contract.

This adds a few contracts that were missed.

One contract that I ran into issues with is `PaymentApp`. Adding the `is CounterfactualApp` caused tests for the contract to fail. @snario Could you help me look into this?

### Related issues

Related: #584 

- [ ] Deploy preview is functional
