### PR TITLE
[playground] Fixes misalignment for logo in widget-screen

### DIFF
--- a/packages/playground/src/components/widgets/widget-screen/widget-screen.scss
+++ b/packages/playground/src/components/widgets/widget-screen/widget-screen.scss
@@ -45,7 +45,6 @@
 
 .logo {
   width: 33%;
-  min-width: 140px;
   margin: auto;
 }
 


### PR DESCRIPTION
Before:

![image](https://user-images.githubusercontent.com/118913/52070638-0acff600-2560-11e9-9d19-81c0bcb22506.png)

After:

![image](https://user-images.githubusercontent.com/118913/52070661-16bbb800-2560-11e9-8153-51c0243374c3.png)
