### PR TITLE
[playground] [playground-server] [dapp-high-roller] [dapp-tic-tac-toe] Adds support for "playground:matchmakeWith" flag

### DIFF
--- a/packages/dapp-high-roller/src/components/app-wager/app-wager.tsx
+++ b/packages/dapp-high-roller/src/components/app-wager/app-wager.tsx
@@ -162,12 +162,20 @@ export class AppWager {
     }
 
     const { token } = this.account.user;
+    const { matchmakeWith } = this.account;
+
     const response = await fetch(
       // TODO: This URL must come from an environment variable.
       "https://server.playground-staging.counterfactual.com/api/matchmaking",
       {
         method: "POST",
+        ...(matchmakeWith
+          ? {
+              body: JSON.stringify({ data: { attributes: { matchmakeWith } } })
+            }
+          : {}),
         headers: {
+          "Content-Type": "application/json",
           Authorization: `Bearer ${token}`
         }
       }

--- a/packages/dapp-tic-tac-toe/src/App.js
+++ b/packages/dapp-tic-tac-toe/src/App.js
@@ -55,6 +55,7 @@ export default class App extends Component {
         const playgroundState = JSON.parse(data);
         this.setState({
           user: playgroundState.user,
+          matchmakeWith: playgroundState.matchmakeWith,
           connected: true
         });
       }
@@ -102,6 +103,7 @@ export default class App extends Component {
                 gameInfo={this.state.gameInfo}
                 cfProvider={this.state.cfProvider}
                 user={this.state.user}
+                matchmakeWith={this.state.matchmakeWith}
                 onChangeAppInstance={this.appInstanceChanged.bind(this)}
               />
             )}

--- a/packages/dapp-tic-tac-toe/src/Wager.jsx
+++ b/packages/dapp-tic-tac-toe/src/Wager.jsx
@@ -20,6 +20,7 @@ class Wager extends Component {
 
     console.log("user data", this.props.user);
     const { token } = this.props.user;
+    const { matchmakeWith } = this.props;
 
     try {
       const response = await fetch(
@@ -27,7 +28,15 @@ class Wager extends Component {
         "https://server.playground-staging.counterfactual.com/api/matchmaking",
         {
           method: "POST",
+          ...(matchmakeWith
+            ? {
+                body: JSON.stringify({
+                  data: { attributes: { matchmakeWith } }
+                })
+              }
+            : {}),
           headers: {
+            "Content-Type": "application/json",
             Authorization: `Bearer ${token}`
           }
         }

--- a/packages/playground-server/src/db.ts
+++ b/packages/playground-server/src/db.ts
@@ -143,6 +143,53 @@ export async function getUser(
   } as APIResource<UserAttributes>;
 }
 
+export async function getUserByName(
+  username: string
+): Promise<APIResource<UserAttributes>> {
+  const db = getDatabase();
+
+  const query = db("users")
+    .columns({
+      id: "id",
+      username: "username",
+      email: "email",
+      ethAddress: "eth_address",
+      multisigAddress: "multisig_address",
+      nodeAddress: "node_address"
+    })
+    .select()
+    .where("username", "=", username);
+
+  const users: (UserAttributes & { id: string })[] = await query;
+
+  Log.debug("Executed getUser query", {
+    tags: { query: query.toSQL().sql }
+  });
+
+  await db.destroy();
+
+  if (users.length === 0) {
+    Log.info("No user found with provided username", {
+      tags: { user: username }
+    });
+    throw ErrorCode.UserNotFound;
+  }
+
+  const [user] = users;
+
+  return {
+    type: "users",
+    id: user.id,
+    attributes: {
+      username: user.username,
+      email: user.email,
+      ethAddress: user.ethAddress,
+      multisigAddress: user.multisigAddress,
+      nodeAddress: user.nodeAddress
+    }
+  } as APIResource<UserAttributes>;
+}
+
 export async function userExists(user: UserAttributes): Promise<boolean> {
   const db = getDatabase();
 

--- a/packages/playground-server/src/types.ts
+++ b/packages/playground-server/src/types.ts
@@ -123,6 +123,7 @@ export type MatchedUserAttributes = {
 
 export type MatchmakingAttributes = {
   intermediary: string;
+  matchmakeWith?: string;
 };
 
 export type AppsControllerOptions = {

--- a/packages/playground/src/components/dapp-container/dapp-container.tsx
+++ b/packages/playground/src/components/dapp-container/dapp-container.tsx
@@ -106,6 +106,10 @@ export class DappContainer {
     }
 
     if (event.data === "playground:request:user") {
+      const matchmakeWith = window.localStorage.getItem(
+        "playground:matchmakeWith"
+      ) as string;
+
       this.frameWindow.postMessage(
         `playground:response:user|${JSON.stringify({
           user: {
@@ -114,7 +118,9 @@ export class DappContainer {
               "playground:user:token"
             ) as string
           },
-          balance: this.balance
+          balance: this.balance,
+          // This devtool flag allows to force a matchmake with a given username.
+          ...(matchmakeWith ? { matchmakeWith } : {})
         })}`,
         "*"
       );


### PR DESCRIPTION
This PR introduces a new flag called `playground:matchmakeWith`, useful for dev/testing purposes.

In order to be used, this flag must be set in the Playground's `localStorage`, like this:

![image](https://user-images.githubusercontent.com/118913/52079830-36a9a680-2575-11e9-982b-e54767d743d6.png)

This flag will be passed to the dApp as part of the `playground:request:user` message response. If the flag is set, it'll be then passed as part of the request to the Matchmaking API:

```json
{ "data": { "attributes": { "matchmakeWith": "c" } } }
```

When the Playground Server parses this request, it'll return the specified user's data, instead of running the matchmaking algorithm.

if the flag is not set, matchmaking will work as usual.