### PR TITLE
[playground] Fixes unintended no-eth multisig funding

### DIFF
--- a/packages/playground/src/components/account/account-register/account-register.tsx
+++ b/packages/playground/src/components/account/account-register/account-register.tsx
@@ -83,10 +83,7 @@ export class AccountRegister {
         signedMessage
       );
 
-      this.updateAccount({
-        ...this.changeset,
-        multisigAddress: newAccount.multisigAddress
-      });
+      this.updateAccount({ user: newAccount });
 
       window.localStorage.setItem(
         "playground:user:token",

--- a/packages/typescript-typings/types/ethers/index.d.ts
+++ b/packages/typescript-typings/types/ethers/index.d.ts
@@ -1,8 +1,24 @@
 // This file should be removed in favour of the real "ethers" package typings.
 
+type Signer = {
+  getAddress(): Promise<string>;
+  signMessage(message): Promise<string>;
+  sendTransaction(tx): Promise<any>;
+  getBalance(): Promise<any>;
+};
+
+declare class Web3Provider {
+  constructor(provider);
+  getSigner(): Signer;
+}
+
 declare var ethers = {
   utils: {
     formatEther: (value: string) => string,
-    parseEther: (value: string) => BigNumber
+    parseEther: (value: string) => BigNumber,
+    bigNumberify: (value: any) => BigNumber
+  },
+  providers: {
+    Web3Provider: Web3Provider
   }
 };

--- a/packages/typescript-typings/types/web3/index.d.ts
+++ b/packages/typescript-typings/types/web3/index.d.ts
@@ -1,11 +1,5 @@
 // API matches version 0.20.3 of Web3
 
-declare class BigNumber {
-  constructor(num: string);
-  toNumber(): number;
-  toString(): string;
-}
-
 declare var web3: {
   BigNumber: (num: string) => void;
   eth: {


### PR DESCRIPTION
Due to a state tunnel update error, the deposit flow wasn't aware of the multisig address, hence it was dealing with the deposit as if it were a contract deployment.

This PR fixes the way the state is saved, using the full API response from account creation and refactors the deposit action to use Ethers.js instead of web3.