### PR TITLE
[playground] Implements event-driven balance updates + unconfirmed balance UI

### DIFF
--- a/packages/playground/src/components/account/account-deposit/account-deposit.tsx
+++ b/packages/playground/src/components/account/account-deposit/account-deposit.tsx
@@ -15,36 +15,30 @@ export class AccountDeposit {
   @Prop() user: UserSession = {} as UserSession;
   @Prop() updateAccount: (e) => void = e => {};
   @Prop() history: RouterHistory = {} as RouterHistory;
+  @Prop() signer: Signer = {} as Signer;
 
   @State() error: string = "";
   @State() amountDeposited;
 
   async componentWillLoad() {
-    const provider = new ethers.providers.Web3Provider(web3.currentProvider);
-    const signer = provider.getSigner();
-
-    try {
-      const balance = await signer.getBalance();
-      this.balance = parseFloat(ethers.utils.formatEther(balance.toString()));
-    } catch {
-      console.warn("Unable to get account balance");
-    }
+    this.balance = parseFloat(
+      ethers.utils.formatEther((await this.signer.getBalance()).toString())
+    );
   }
 
   async formSubmitionHandler(e) {
     this.amountDeposited = ethers.utils.parseEther(e.target.value);
 
-    const provider = new ethers.providers.Web3Provider(web3.currentProvider);
-    const signer = provider.getSigner();
-
     try {
-      await signer.sendTransaction({
+      await this.signer.sendTransaction({
         to: this.user.multisigAddress,
         value: this.amountDeposited
       });
 
       this.updateAccount({
-        balance: ethers.utils.formatEther(this.amountDeposited)
+        unconfirmedBalance: parseFloat(
+          ethers.utils.formatEther(this.amountDeposited)
+        )
       });
 
       this.history.push("/");
@@ -74,4 +68,9 @@ export class AccountDeposit {
   }
 }
 
-AccountTunnel.injectProps(AccountDeposit, ["balance", "updateAccount", "user"]);
+AccountTunnel.injectProps(AccountDeposit, [
+  "balance",
+  "updateAccount",
+  "user",
+  "signer"
+]);

--- a/packages/playground/src/components/app-root/app-root.tsx
+++ b/packages/playground/src/components/app-root/app-root.tsx
@@ -31,6 +31,8 @@ export class AppRoot {
   }
 
   async updateMultisigBalance(ethBalance: any) {
+    // TODO: This comparison might need changes if the user's doing
+    // deposits beyond the registration flow.
     if (ethBalance._hex === "0x0" && this.accountState.unconfirmedBalance) {
       return;
     }

--- a/packages/playground/src/components/layout/layout-header/header-account-info/header-account-info.tsx
+++ b/packages/playground/src/components/layout/layout-header/header-account-info/header-account-info.tsx
@@ -9,6 +9,7 @@ export class HeaderAccountInfo {
   @Prop() src: string = "";
   @Prop() header: string = "";
   @Prop() content: string = "";
+  @Prop() spinner: boolean = false;
 
   render() {
     return (
@@ -16,7 +17,10 @@ export class HeaderAccountInfo {
         <img class="info-img" src={this.src} />
         <div class="info-text">
           <div class="header">{this.header}</div>
-          <div class="content">{this.content}</div>
+          <div class="content">
+            {this.content}
+            <widget-spinner visible={this.spinner} />
+          </div>
         </div>
       </div>
     );

--- a/packages/playground/src/components/layout/layout-header/header-account/header-account.tsx
+++ b/packages/playground/src/components/layout/layout-header/header-account/header-account.tsx
@@ -25,10 +25,13 @@ function buildSignaturePayload(address: string) {
 export class HeaderAccount {
   @Element() el!: HTMLStencilElement;
   @Prop() balance: number = 0;
-  @Prop() user: UserSession = {} as UserSession;
+  @Prop() unconfirmedBalance?: number;
+  @Prop({ mutable: true }) user: UserSession = {} as UserSession;
   @Prop({ mutable: true }) authenticated: boolean = false;
   @Prop() fakeConnect: boolean = false;
   @Prop() updateAccount: (e) => void = e => {};
+  @Prop() provider: Web3Provider = {} as Web3Provider;
+  @Prop() signer: Signer = {} as Signer;
   @Event() authenticationChanged: EventEmitter = {} as EventEmitter;
 
   @Watch("authenticated")
@@ -53,9 +56,13 @@ export class HeaderAccount {
       return;
     }
 
-    const user = await PlaygroundAPIClient.getUser(token);
+    if (!this.user || !this.user.username) {
+      this.updateAccount({ user: await PlaygroundAPIClient.getUser(token) });
+    }
 
-    this.getBalances(user);
+    await this.getBalances();
+
+    this.authenticated = true;
   }
 
   async login(error: Error, signedData: string) {
@@ -72,13 +79,14 @@ export class HeaderAccount {
         signedData
       );
 
-      this.getBalances(user).then(() => {
-        // TODO: Define schema for DB in localStorage.
-        window.localStorage.setItem(
-          "playground:user:token",
-          user.token as string
-        );
-      });
+      await this.getBalances();
+
+      window.localStorage.setItem(
+        "playground:user:token",
+        user.token as string
+      );
+
+      this.updateAccount({ user });
 
       this.removeError();
     } catch (error) {
@@ -86,46 +94,27 @@ export class HeaderAccount {
     }
   }
 
-  getBalances(user) {
-    return Promise.all([
-      new Promise(resolve => {
-        web3.eth.getBalance(
-          user.multisigAddress,
-          web3.eth.defaultBlock,
-          (err, result) => {
-            const balance = parseFloat(
-              ethers.utils.formatEther(result.toString())
-            );
+  async getBalances() {
+    if (!this.user.multisigAddress || !this.user.ethAddress) {
+      return;
+    }
 
-            this.updateAccount({
-              user,
-              balance
-            });
+    const multisigBalance = parseFloat(
+      ethers.utils.formatEther(
+        (await this.provider.getBalance(this.user.multisigAddress)).toString()
+      )
+    );
 
-            this.authenticated = true;
+    const walletBalance = parseFloat(
+      ethers.utils.formatEther(
+        (await this.provider.getBalance(this.user.ethAddress)).toString()
+      )
+    );
 
-            resolve();
-          }
-        );
-      }),
-      new Promise(resolve => {
-        web3.eth.getBalance(
-          this.user.ethAddress,
-          web3.eth.defaultBlock,
-          (err, result) => {
-            const accountBalance = parseFloat(
-              ethers.utils.formatEther(result.toString())
-            );
-
-            this.updateAccount({
-              accountBalance
-            });
-
-            resolve();
-          }
-        );
-      })
-    ]);
+    this.updateAccount({
+      balance: multisigBalance,
+      accountBalance: walletBalance
+    });
   }
 
   displayLoginError() {
@@ -144,31 +133,17 @@ export class HeaderAccount {
   }
 
   get ethBalance() {
-    return `${this.balance.toFixed(4)} ETH`;
+    return `${(this.unconfirmedBalance || this.balance).toFixed(4)} ETH`;
+  }
+
+  get hasUnconfirmedBalance() {
+    return !isNaN(this.unconfirmedBalance as number);
   }
 
   render() {
-    return (
-      <div class="account-container">
-        <widget-error-message />
-        {this.user.username ? (
-          <div class="info-container">
-            <stencil-route-link url="/exchange">
-              <header-account-info
-                src="/assets/icon/cf.png"
-                header="Balance"
-                content={this.ethBalance}
-              />
-            </stencil-route-link>
-            <stencil-route-link url="/account">
-              <header-account-info
-                src="/assets/icon/account.png"
-                header="Account"
-                content={this.user.username}
-              />
-            </stencil-route-link>
-          </div>
-        ) : (
+    if (!this.user || !this.user.username) {
+      return (
+        <div class="account-container">
           <div class="btn-container">
             <button onClick={this.onLoginClicked.bind(this)} class="btn">
               Login
@@ -177,10 +152,39 @@ export class HeaderAccount {
               <button class="btn btn-outline">Register</button>
             </stencil-route-link>
           </div>
-        )}
+        </div>
+      );
+    }
+
+    return (
+      <div class="account-container">
+        <widget-error-message />
+        <div class="info-container">
+          <stencil-route-link url="/exchange">
+            <header-account-info
+              src="/assets/icon/cf.png"
+              header="Balance"
+              content={this.ethBalance}
+              spinner={this.hasUnconfirmedBalance}
+            />
+          </stencil-route-link>
+          <stencil-route-link url="/account">
+            <header-account-info
+              src="/assets/icon/account.png"
+              header="Account"
+              content={this.user.username}
+            />
+          </stencil-route-link>
+        </div>
       </div>
     );
   }
 }
 
-AccountTunnel.injectProps(HeaderAccount, ["balance", "user", "updateAccount"]);
+AccountTunnel.injectProps(HeaderAccount, [
+  "balance",
+  "user",
+  "updateAccount",
+  "provider",
+  "unconfirmedBalance"
+]);

--- a/packages/playground/src/components/web3-connector/web3-connector.tsx
+++ b/packages/playground/src/components/web3-connector/web3-connector.tsx
@@ -17,16 +17,25 @@ export class Web3Connector {
     } catch {}
 
     if (web3.currentProvider) {
+      const provider = new ethers.providers.Web3Provider(web3.currentProvider);
+      const signer = provider.getSigner();
+      const ethAddress = web3.currentProvider.selectedAddress;
+
       this.accountState.updateAccount!({
+        provider,
+        signer,
         user: {
+          ethAddress,
           username: "",
           multisigAddress: "",
           id: "",
           email: "",
-          nodeAddress: "",
-          ethAddress: web3.currentProvider.selectedAddress
-        }
+          nodeAddress: ""
+        },
+        balance: 0,
+        accountBalance: 0
       });
+
       this.networkState.updateNetwork!({
         network: web3.version.network,
         connected: true

--- a/packages/playground/src/components/widgets/widget-spinner/widget-spinner.scss
+++ b/packages/playground/src/components/widgets/widget-spinner/widget-spinner.scss
@@ -1,0 +1,31 @@
+.spinner {
+  display: inline-block;
+  width: 14px;
+  height: 14px;
+  padding-left: 5px;
+
+  &.spinner--hidden {
+    visibility: hidden;
+  }
+}
+
+.spinner:after {
+  content: " ";
+  display: block;
+  width: 14px;
+  height: 14px;
+  margin: 1px;
+  border-radius: 50%;
+  border: 2px solid #000;
+  border-color: #000 transparent #000 transparent;
+  animation: spinner 1.2s linear infinite;
+}
+
+@keyframes spinner {
+  0% {
+    transform: rotate(0deg);
+  }
+  100% {
+    transform: rotate(360deg);
+  }
+}

--- a/packages/playground/src/components/widgets/widget-spinner/widget-spinner.tsx
+++ b/packages/playground/src/components/widgets/widget-spinner/widget-spinner.tsx
@@ -1,0 +1,13 @@
+import { Component, Prop } from "@stencil/core";
+
+@Component({
+  tag: "widget-spinner",
+  styleUrl: "widget-spinner.scss"
+})
+export class WidgetSpinner {
+  @Prop() visible: boolean = false;
+
+  render() {
+    return <div class={`spinner ${!this.visible ? "spinner--hidden" : ""}`} />;
+  }
+}

--- a/packages/playground/src/data/account.tsx
+++ b/packages/playground/src/data/account.tsx
@@ -7,7 +7,10 @@ export type AccountState = {
   error?: ErrorMessage;
   accountBalance?: number;
   balance?: number;
+  unconfirmedBalance?: number;
   updateAccount?(data: AccountState): Promise<void>;
+  provider: Web3Provider;
+  signer: Signer;
 };
 
 export default createProviderConsumer<AccountState>(

--- a/packages/typescript-typings/types/ethers/index.d.ts
+++ b/packages/typescript-typings/types/ethers/index.d.ts
@@ -10,6 +10,9 @@ type Signer = {
 declare class Web3Provider {
   constructor(provider);
   getSigner(): Signer;
+  getBalance(address: string): Promise<BigNumber>;
+  on(event: string, callback: (...args) => void): void;
+  removeAllListeners(event: string): void;
 }
 
 declare var ethers = {


### PR DESCRIPTION
This PR refactors the way deposits are made and account balances are read, introducing the concept of _unconfirmed balances_. 

Since a transaction takes time to be confirmed by the blockchain, the account state stores an _unconfirmed balance_ which is the amount the user has deposited upon registration. While the value of `unconfirmedBalance` exists, a spinner will show next to the account balance on the UI. 

The provider listens to an address-type event to get the updated balance. When the listener is triggered, it removes the `unconfirmedBalance` value and sets the true balance, hiding the spinner.

**Preview:**
![deepin-screen-recorder_select area_20190201181235](https://user-images.githubusercontent.com/118913/52150136-ca4ea600-264d-11e9-8350-2f61ac53f1a0.gif)
