### PR TITLE
[playground] [dapp-high-roller] [dapp-tic-tac-toe] Implements Matchmaking API call via postMessage()

### DIFF
--- a/packages/dapp-tic-tac-toe/src/Wager.jsx
+++ b/packages/dapp-tic-tac-toe/src/Wager.jsx
@@ -19,29 +19,9 @@ class Wager extends Component {
     this.props.cfProvider.on("installVirtual", this.onInstall.bind(this));
 
     console.log("user data", this.props.user);
-    const { token } = this.props.user;
-    const { matchmakeWith } = this.props;
 
     try {
-      const response = await fetch(
-        // TODO: This URL must come from an environment variable.
-        "https://server.playground-staging.counterfactual.com/api/matchmaking",
-        {
-          method: "POST",
-          ...(matchmakeWith
-            ? {
-                body: JSON.stringify({
-                  data: { attributes: { matchmakeWith } }
-                })
-              }
-            : {}),
-          headers: {
-            "Content-Type": "application/json",
-            Authorization: `Bearer ${token}`
-          }
-        }
-      );
-      const result = await response.json();
+      const result = await this.matchmake();
 
       const opponent = result.included.find(
         resource =>
@@ -60,6 +40,27 @@ class Wager extends Component {
         error
       });
     }
+  }
+
+  async matchmake() {
+    return new Promise(resolve => {
+      const onMatchmakeResponse = event => {
+        if (
+          !event.data.toString().startsWith("playground:response:matchmake")
+        ) {
+          return;
+        }
+
+        window.removeEventListener("message", onMatchmakeResponse);
+
+        const [, data] = event.data.split("|");
+        resolve(JSON.parse(data));
+      };
+
+      window.addEventListener("message", onMatchmakeResponse);
+
+      window.parent.postMessage("playground:request:matchmake", "*");
+    });
   }
 
   createAppFactory() {

--- a/packages/playground/src/components/dapp-container/dapp-container.tsx
+++ b/packages/playground/src/components/dapp-container/dapp-container.tsx
@@ -6,6 +6,7 @@ import { MatchResults, RouterHistory } from "@stencil/router";
 import AccountTunnel from "../../data/account";
 import AppRegistryTunnel from "../../data/app-registry";
 import CounterfactualNode from "../../data/counterfactual";
+import PlaygroundAPIClient from "../../data/playground-api-client";
 import { AppDefinition, UserSession } from "../../types";
 
 @Component({
@@ -100,31 +101,51 @@ export class DappContainer {
     this.iframe.remove();
   }
 
-  private handlePlaygroundMessage(event: MessageEvent): void {
+  private async handlePlaygroundMessage(event: MessageEvent): Promise<void> {
     if (!this.frameWindow) {
       return;
     }
 
     if (event.data === "playground:request:user") {
-      const matchmakeWith = window.localStorage.getItem(
-        "playground:matchmakeWith"
-      ) as string;
-
-      this.frameWindow.postMessage(
-        `playground:response:user|${JSON.stringify({
-          user: {
-            ...this.user,
-            token: window.localStorage.getItem(
-              "playground:user:token"
-            ) as string
-          },
-          balance: this.balance,
-          // This devtool flag allows to force a matchmake with a given username.
-          ...(matchmakeWith ? { matchmakeWith } : {})
-        })}`,
-        "*"
-      );
+      await this.sendResponseForRequestUser(this.frameWindow);
     }
+
+    if (event.data === "playground:request:matchmake") {
+      await this.sendResponseForMatchmakeRequest(this.frameWindow);
+    }
+  }
+
+  private get token(): string {
+    return window.localStorage.getItem("playground:user:token") as string;
+  }
+
+  private get matchmakeWith(): string | null {
+    return window.localStorage.getItem("playground:matchmakeWith");
+  }
+
+  private async sendResponseForRequestUser(frameWindow: Window) {
+    frameWindow.postMessage(
+      `playground:response:user|${JSON.stringify({
+        user: {
+          ...this.user,
+          token: this.token
+        },
+        balance: this.balance
+      })}`,
+      "*"
+    );
+  }
+
+  private async sendResponseForMatchmakeRequest(frameWindow: Window) {
+    const json = await PlaygroundAPIClient.matchmake(
+      this.token,
+      this.matchmakeWith
+    );
+
+    frameWindow.postMessage(
+      `playground:response:matchmake|${JSON.stringify(json)}`,
+      "*"
+    );
   }
 
   /**

--- a/packages/playground/src/data/playground-api-client.ts
+++ b/packages/playground/src/data/playground-api-client.ts
@@ -2,6 +2,7 @@ import {
   APIError,
   APIRequest,
   APIResource,
+  APIResourceAttributes,
   APIResourceCollection,
   APIResponse,
   AppAttributes,
@@ -30,7 +31,8 @@ function timeout(delay: number = API_TIMEOUT) {
 async function post(
   endpoint: string,
   data: APIResource,
-  signature?: string
+  token?: string,
+  authType: "Bearer" | "Signature" = "Signature"
 ): Promise<APIResponse> {
   const requestTimeout = timeout();
 
@@ -40,7 +42,7 @@ async function post(
     } as APIRequest),
     headers: {
       "Content-Type": "application/json; charset=utf-8",
-      ...(signature ? { Authorization: `Signature ${signature}` } : {})
+      ...(token ? { Authorization: `${authType} ${token}` } : {})
     },
     method: "POST"
   });
@@ -165,6 +167,21 @@ export default class PlaygroundAPIClient {
 
       return resources.map(resource =>
         fromAPIResource<AppDefinition, AppAttributes>(resource)
+      );
+    } catch (e) {
+      return Promise.reject(e);
+    }
+  }
+
+  public static async matchmake(token: string, matchmakeWith: string | null) {
+    try {
+      return await post(
+        "matchmaking",
+        matchmakeWith
+          ? { type: "matchmaking", attributes: { matchmakeWith } }
+          : ({} as APIResource<APIResourceAttributes>),
+        token,
+        "Bearer"
       );
     } catch (e) {
       return Promise.reject(e);


### PR DESCRIPTION
This PR features a new Playground message: `playground:request:matchmaking`. Simply put, dApps no longer need to know about the API, and instead of calling it directly, they ask the Playground for a matchmaking, the same way dApps request user data.