### PR TITLE
rename dispatchReceivedMessage to runProtocolWithMessage

### DIFF
--- a/packages/machine/src/instruction-executor.ts
+++ b/packages/machine/src/instruction-executor.ts
@@ -27,7 +27,10 @@ export class InstructionExecutor {
     this.middlewares.add(scope, method);
   }
 
-  public async dispatchReceivedMessage(
+  /// Starts executing a protocol in response to a message received. This
+  /// function should not be called with messages that are waited for by
+  /// `IO_SEND_AND_WAIT`
+  public async runProtocolWithMessage(
     msg: ProtocolMessage,
     sc: Map<string, StateChannel>
   ) {

--- a/packages/node/src/events/install/controller.ts
+++ b/packages/node/src/events/install/controller.ts
@@ -15,7 +15,7 @@ import { InstallMessage } from "../../types";
  *       methods/intall/operations.ts::install method with the exception
  *       of the lack of a runInstallProtocol call. This is because this is
  *       the counterparty end of the install protocol which runs _after_
- *       the _dispatchReceivedMessage_ call finishes and saves the result.
+ *       the _runProtocolWithMessage_ call finishes and saves the result.
  *
  *       Future iterations of this code will simply be a middleware hook on
  *       the _STATE TRANSITION COMMIT_ opcode.

--- a/packages/node/src/events/protocol-message/controller.ts
+++ b/packages/node/src/events/protocol-message/controller.ts
@@ -6,7 +6,7 @@ import { NodeMessageWrappedProtocolMessage } from "../../types";
 /**
  * Forwards all received NodeMessages that are for the machine's internal
  * protocol execution directly to the instructionExecutor's message handler:
- * `dispatchReceivedMessage`
+ * `runProtocolWithMessage`
  */
 export default async function protocolMessageEventController(
   requestHandler: RequestHandler,
@@ -19,13 +19,13 @@ export default async function protocolMessageEventController(
   //
   //        An alternative might be that IO_SEND_AND_WAIT is hooked onto toms event
   //        listeniner inside the instructionExecutor that emits noise
-  //        when dispatchReceivedMessage receives a message for an in-progress
+  //        when runProtocolWithMessage receives a message for an in-progress
   //        protocol execution.
   //
   //        Does NOT work for InstallVirtualApp
   if (nodeMsg.data.seq === 2) return;
 
-  const stateChannelsMap = await requestHandler.instructionExecutor.dispatchReceivedMessage(
+  const stateChannelsMap = await requestHandler.instructionExecutor.runProtocolWithMessage(
     nodeMsg.data,
     new Map<string, StateChannel>(
       Object.entries(await requestHandler.store.getAllChannels())


### PR DESCRIPTION
The previous name `dispatchReceivedMessage` is potentially ambiguous