### PR TITLE
[dapp-high-roller] Implements REVEAL stage, improves die animation triggers

### DIFF
--- a/packages/dapp-high-roller/src/components/app-game-coins/app-game-coins.tsx
+++ b/packages/dapp-high-roller/src/components/app-game-coins/app-game-coins.tsx
@@ -11,9 +11,9 @@ import { Component } from "@stencil/core";
 export class AppGameCoins {
   coinsAudio!: HTMLAudioElement;
 
-  componentDidLoad() {
+  async componentDidLoad() {
     this.coinsAudio.loop = true;
-    this.coinsAudio.play();
+    await this.coinsAudio.play();
   }
 
   render() {

--- a/packages/dapp-high-roller/src/components/app-game-die/app-game-die.scss
+++ b/packages/dapp-high-roller/src/components/app-game-die/app-game-die.scss
@@ -1,17 +1,17 @@
 // inspired by https://davidwalsh.name/css-cube
 
 .die__wrapper {
-	perspective: 800px;
-	perspective-origin: 50% 45px;
+  perspective: 800px;
+  perspective-origin: 50% 45px;
 }
 
 .die__faces {
-	position: relative;
-	height: 90px;
-	width: 90px;
+  position: relative;
+  height: 90px;
+  width: 90px;
   transform-style: preserve-3d;
-  transition: transform 600ms ease-out;
-  
+  transition: transform 300ms ease-out;
+
   img {
     position: absolute;
     height: 90px;
@@ -23,7 +23,7 @@
     }
 
     &.black {
-      background-color:#323233;
+      background-color: #323233;
     }
   }
 
@@ -53,24 +53,24 @@
 }
 
 .die__1 {
-	transform: rotateX(-90deg) translateY(-45px);
-	transform-origin: top center;
+  transform: rotateX(-90deg) translateY(-45px);
+  transform-origin: top center;
 }
 .die__2 {
-	transform: rotateY(180deg) translateZ(45px);
+  transform: rotateY(180deg) translateZ(45px);
 }
 .die__3 {
-	transform: rotateY(-90deg) translateX(-45px);
-	transform-origin: center left;
+  transform: rotateY(-90deg) translateX(-45px);
+  transform-origin: center left;
 }
 .die__4 {
-	transform: rotateY(90deg) translateX(45px);
-	transform-origin: top right;
+  transform: rotateY(90deg) translateX(45px);
+  transform-origin: top right;
 }
 .die__5 {
-	transform: translateZ(45px);
+  transform: translateZ(45px);
 }
 .die__6 {
-	transform: rotateX(90deg) translateY(45px);
-	transform-origin: bottom center;
+  transform: rotateX(90deg) translateY(45px);
+  transform-origin: bottom center;
 }

--- a/packages/dapp-high-roller/src/components/app-game-status/app-game-status.tsx
+++ b/packages/dapp-high-roller/src/components/app-game-status/app-game-status.tsx
@@ -1,7 +1,7 @@
 import { Component, Element, Prop } from "@stencil/core";
 
 import CounterfactualTunnel from "../../data/counterfactual";
-import { GameState } from "../../data/game-types";
+import { GameState, HighRollerStage } from "../../data/game-types";
 
 @Component({
   tag: "app-game-status",
@@ -11,16 +11,38 @@ import { GameState } from "../../data/game-types";
 export class AppGameStatus {
   @Element() el: HTMLStencilElement = {} as HTMLStencilElement;
   @Prop() gameState: GameState = GameState.Play;
+  @Prop() highRollerStage: HighRollerStage = HighRollerStage.PRE_GAME;
   @Prop() isProposing: boolean = true;
   @Prop() betAmount: string = "3 ETH";
   @Prop() account: any = { user: { username: "Facundo" } };
   @Prop() opponent: any = { attributes: { username: "John" } };
+  @Prop() label: string = "";
+
+  get gameStatusLabelForTurn() {
+    if (this.label) {
+      return this.label;
+    }
+
+    const isTurnForFirstPlayer =
+      this.highRollerStage === HighRollerStage.PRE_GAME;
+    const isTurnForSecondPlayer =
+      !this.isProposing &&
+      this.highRollerStage === HighRollerStage.COMMITTING_NUM;
+
+    if (isTurnForFirstPlayer || isTurnForSecondPlayer) {
+      return "Your turn";
+    }
+
+    return `${this.opponent.attributes.username}'s turn`;
+  }
 
   render() {
     return (
       <div class="divider">
         {this.gameState === GameState.Play ? (
-          <div class="divider__status divider__status--turn">Your turn</div>
+          <div class="divider__status divider__status--turn">
+            {this.gameStatusLabelForTurn}
+          </div>
         ) : this.gameState === GameState.Won ? (
           <div class="divider__status divider__status--won">
             <span class="result">You Won!</span>

--- a/packages/dapp-high-roller/src/components/app-game/app-game.tsx
+++ b/packages/dapp-high-roller/src/components/app-game/app-game.tsx
@@ -1,6 +1,6 @@
 declare var ethers;
 
-import { Component, Element, Prop, Watch } from "@stencil/core";
+import { Component, Element, Prop, State, Watch } from "@stencil/core";
 import { RouterHistory } from "@stencil/router";
 
 import CounterfactualTunnel from "../../data/counterfactual";
@@ -45,6 +45,8 @@ export class AppGame {
 
   @Prop() generateRandomRoll: () => number[] = () => [];
 
+  @State() gameStatusLabel: string = "";
+
   defaultHighRollerState: HighRollerAppState = {
     playerAddrs: [AddressZero, AddressZero],
     stage: HighRollerStage.PRE_GAME,
@@ -84,7 +86,7 @@ export class AppGame {
   @Watch("highRollerState")
   async onHighRollerStateChanged() {
     if (
-      this.highRollerState.stage > HighRollerStage.PRE_GAME &&
+      this.highRollerState.stage === HighRollerStage.COMMITTING_NUM &&
       !this.rolling.opponentRoll
     ) {
       await this.beginRolling("opponentRoll");
@@ -184,6 +186,8 @@ export class AppGame {
       this.highRollerState = await this.appInstance.takeAction(
         commitHashAction
       );
+
+      this.gameStatusLabel = "Who will win?";
     }
   }
 
@@ -217,6 +221,8 @@ export class AppGame {
             gameState={this.gameState}
             isProposing={this.isProposing}
             betAmount={this.betAmount}
+            highRollerStage={this.highRollerState.stage}
+            label={this.gameStatusLabel}
           />
           <app-game-player
             playerName="You"

--- a/packages/dapp-high-roller/src/components/app-game/app-game.tsx
+++ b/packages/dapp-high-roller/src/components/app-game/app-game.tsx
@@ -15,20 +15,14 @@ import {
 import HighRollerUITunnel from "../../data/high-roller";
 import { AppInstance } from "../../data/mock-app-instance";
 import { cf, HighRollerUIMutableState } from "../../data/types";
-import { getProp } from "../../utils/utils";
+import { computeCommitHash, getProp } from "../../utils/utils";
 
 const { AddressZero, HashZero } = ethers.constants;
-const { solidityKeccak256, bigNumberify } = ethers.utils;
+const { bigNumberify } = ethers.utils;
 
 // dice sound effect attributions:
 // http://soundbible.com/182-Shake-And-Roll-Dice.html
 // http://soundbible.com/181-Roll-Dice-2.html
-
-/// Returns the commit hash that can be used to commit to chosenNumber
-/// using appSalt
-function computeCommitHash(appSalt: string, chosenNumber: number) {
-  return solidityKeccak256(["bytes32", "uint256"], [appSalt, chosenNumber]);
-}
 
 @Component({
   tag: "app-game",

--- a/packages/dapp-high-roller/src/components/app-game/app-game.tsx
+++ b/packages/dapp-high-roller/src/components/app-game/app-game.tsx
@@ -99,23 +99,6 @@ export class AppGame {
     }
   }
 
-  // async animateRoll(roller): Promise<void> {
-  //   this.shakeAudio.loop = true;
-  //   this.shakeAudio.play();
-
-  //   this.rollingAnimationInterval = setTimeout(async () => {
-  //     this[roller] = this.generateRandomRoll();
-
-  //     if (this.rolling) {
-  //       await new Promise(resolve =>
-  //         setTimeout(resolve, 100 + Math.floor(Math.random() * Math.floor(150)))
-  //     );
-  //   }, 100);
-
-  //   this.shakeAudio.pause();
-  //   this.rollAudio.play();
-  // }
-
   async beginRolling(roller: "myRoll" | "opponentRoll") {
     this.shakeAudio.loop = true;
     await this.shakeAudio.play();

--- a/packages/dapp-high-roller/src/components/app-logo/app-logo.tsx
+++ b/packages/dapp-high-roller/src/components/app-logo/app-logo.tsx
@@ -18,10 +18,14 @@ import { cf } from "../../data/types";
 export class AppLogo {
   @Element() el: HTMLStencilElement = {} as HTMLStencilElement;
 
-  @Prop() goToWaitingRoom: (history: RouterHistory) => void = () => {};
+  @Prop() goToWaitingRoom: (
+    history: RouterHistory,
+    initialState: any
+  ) => void = () => {};
   @Prop() appInstance: any;
   @Prop() history: RouterHistory = {} as RouterHistory;
   @Prop() cfProvider: cf.Provider = {} as cf.Provider;
+  @Prop() opponent: any;
   @Prop() updateAppInstance: (appInstance: AppInstance) => void = () => {};
 
   @Watch("cfProvider")
@@ -32,7 +36,7 @@ export class AppLogo {
         this.appInstance
       );
       this.updateAppInstance(appInstance);
-      this.goToWaitingRoom(this.history);
+      this.goToWaitingRoom(this.history, this.opponent);
     }
   }
 
@@ -52,4 +56,4 @@ export class AppLogo {
   }
 }
 
-CounterfactualTunnel.injectProps(AppLogo, ["cfProvider"]);
+CounterfactualTunnel.injectProps(AppLogo, ["cfProvider", "opponent"]);

--- a/packages/dapp-high-roller/src/components/app-provider/app-provider.tsx
+++ b/packages/dapp-high-roller/src/components/app-provider/app-provider.tsx
@@ -2,11 +2,17 @@ import { Component, Element, Prop } from "@stencil/core";
 import { RouterHistory } from "@stencil/router";
 
 import CounterfactualTunnel from "../../data/counterfactual";
-import { GameState, HighRollerAppState } from "../../data/game-types";
+import {
+  ActionType,
+  GameState,
+  HighRollerAppState,
+  HighRollerStage
+} from "../../data/game-types";
 import HighRollerUITunnel from "../../data/high-roller";
 import { AppInstance } from "../../data/mock-app-instance";
 import MockNodeProvider from "../../data/mock-node-provider";
 import { cf, HighRollerUIMutableState, Node } from "../../data/types";
+import { computeCommitHash } from "../../utils/utils";
 
 declare var NodeProvider;
 declare var cf;
@@ -156,7 +162,18 @@ export class AppProvider {
     this.updateUIState(newUIState);
 
     debugger;
-    await this.appInstance.uninstall();
+
+    if (state.stage === HighRollerStage.REVEALING) {
+      const numberSalt =
+        "0xdfdaa4d168f0be935a1e1d12b555995bc5ea67bd33fce1bc5be0a1e0a381fc90";
+      const hash = computeCommitHash(numberSalt, state.playerFirstNumber);
+
+      await this.appInstance.takeAction({
+        actionType: ActionType.REVEAL,
+        actionHash: hash,
+        number: state.playerFirstNumber.toString()
+      });
+    }
   }
 
   onInstall(data) {

--- a/packages/dapp-high-roller/src/components/app-provider/app-provider.tsx
+++ b/packages/dapp-high-roller/src/components/app-provider/app-provider.tsx
@@ -122,19 +122,22 @@ export class AppProvider {
       return;
     }
 
+    let myScore = this.myScore;
+    let opponentScore = this.opponentScore;
+    let gameState;
+
     const rolls = await this.highRoller(
       state.playerFirstNumber,
       state.playerSecondNumber
     );
 
-    const myRoll = rolls.myRoll;
-    const opponentRoll = rolls.opponentRoll;
+    const myRoll =
+      state.stage < HighRollerStage.DONE ? rolls.myRoll : rolls.opponentRoll;
+    const opponentRoll =
+      state.stage < HighRollerStage.DONE ? rolls.opponentRoll : rolls.myRoll;
+
     const totalMyRoll = myRoll[0] + myRoll[1];
     const totalOpponentRoll = opponentRoll[0] + opponentRoll[1];
-
-    let myScore = this.myScore;
-    let opponentScore = this.opponentScore;
-    let gameState;
 
     if (totalMyRoll > totalOpponentRoll) {
       myScore = this.myScore + 1;

--- a/packages/dapp-high-roller/src/components/app-provider/app-provider.tsx
+++ b/packages/dapp-high-roller/src/components/app-provider/app-provider.tsx
@@ -76,7 +76,7 @@ export class AppProvider {
 
     this.appFactory = new cf.AppFactory(
       // TODO: This probably should be in a configuration, somewhere.
-      "0x6296F3ACf03b6D787BD1068B4DB8093c54d5d915",
+      "0x903217387B06a84F4dD0bEA565Ad8765Fc7cAA58",
       {
         actionEncoding:
           "tuple(uint8 actionType, uint256 number, bytes32 actionHash)",
@@ -105,9 +105,8 @@ export class AppProvider {
       stage: newStateArray[1],
       salt: newStateArray[2],
       commitHash: newStateArray[3],
-      playerFirstNumber: this.highRollerState.playerFirstNumber || {
-        _hex: "0x00"
-      },
+      playerFirstNumber:
+        this.highRollerState.playerFirstNumber || newStateArray[4],
       playerSecondNumber: newStateArray[5]
     } as HighRollerAppState;
 
@@ -159,8 +158,6 @@ export class AppProvider {
 
     this.updateUIState(newUIState);
 
-    debugger;
-
     if (state.stage === HighRollerStage.REVEALING) {
       const numberSalt =
         "0xdfdaa4d168f0be935a1e1d12b555995bc5ea67bd33fce1bc5be0a1e0a381fc90";
@@ -179,10 +176,7 @@ export class AppProvider {
     this.goToGame(this.history);
   }
 
-  onUninstall(data: Node.EventData) {
-    const uninstallData = data as Node.UninstallEventData;
-    debugger;
-  }
+  onUninstall(data: Node.EventData) {}
 
   render() {
     return <div />;

--- a/packages/dapp-high-roller/src/components/app-root/app-root.tsx
+++ b/packages/dapp-high-roller/src/components/app-root/app-root.tsx
@@ -182,20 +182,21 @@ export class AppRoot {
     };
   }
 
-  getDieNumber() {
-    return 1 + Math.floor(Math.random() * 6);
-  }
-
   getDieNumbers(totalSum: number): [number, number] {
     // Choose result for each die.
-    let firstDie = 0;
-    let secondDie = 0;
-
-    while (firstDie + secondDie !== totalSum) {
-      [firstDie, secondDie] = [this.getDieNumber(), this.getDieNumber()];
+    if (totalSum === 12) {
+      return [6, 6];
     }
 
-    return [firstDie, secondDie];
+    if (totalSum > 2 && totalSum < 12) {
+      return [Math.floor(totalSum / 2), Math.ceil(totalSum / 2)];
+    }
+
+    if (totalSum > 2 && totalSum % 2 === 0) {
+      return [Math.floor(totalSum / 2) - 1, Math.ceil(totalSum / 2) + 1];
+    }
+
+    return [totalSum / 2, totalSum / 2];
   }
 
   goToGame(history: RouterHistory, isProposing: boolean = true) {

--- a/packages/dapp-high-roller/src/components/app-root/app-root.tsx
+++ b/packages/dapp-high-roller/src/components/app-root/app-root.tsx
@@ -165,8 +165,6 @@ export class AppRoot {
       "function highRoller(bytes32 randomness) public pure returns(uint8 playerFirstTotal, uint8 playerSecondTotal)"
     ];
 
-    debugger;
-
     // Connect to the network
     const provider = new ethers.providers.Web3Provider(web3.currentProvider);
 
@@ -177,8 +175,6 @@ export class AppRoot {
     const contract = new ethers.Contract(contractAddress, abi, provider);
 
     const result = await contract.highRoller(randomness);
-
-    console.log(result);
 
     return {
       myRoll: result[0],

--- a/packages/dapp-high-roller/src/components/app-root/app-root.tsx
+++ b/packages/dapp-high-roller/src/components/app-root/app-root.tsx
@@ -212,7 +212,13 @@ export class AppRoot {
   }
 
   goToWaitingRoom(history: RouterHistory) {
-    history.push({ pathname: "/waiting" });
+    history.push({
+      pathname: "/waiting",
+      state: {
+        isProposing: false,
+        betAmount: "0.1"
+      }
+    });
   }
 
   render() {

--- a/packages/dapp-high-roller/src/components/app-root/app-root.tsx
+++ b/packages/dapp-high-roller/src/components/app-root/app-root.tsx
@@ -177,9 +177,25 @@ export class AppRoot {
     const result = await contract.highRoller(randomness);
 
     return {
-      myRoll: result[0],
-      opponentRoll: result[1]
+      myRoll: this.getDieNumbers(result[0]),
+      opponentRoll: this.getDieNumbers(result[1])
     };
+  }
+
+  getDieNumber() {
+    return 1 + Math.floor(Math.random() * 6);
+  }
+
+  getDieNumbers(totalSum: number): [number, number] {
+    // Choose result for each die.
+    let firstDie = 0;
+    let secondDie = 0;
+
+    while (firstDie + secondDie !== totalSum) {
+      [firstDie, secondDie] = [this.getDieNumber(), this.getDieNumber()];
+    }
+
+    return [firstDie, secondDie];
   }
 
   goToGame(history: RouterHistory, isProposing: boolean = true) {

--- a/packages/dapp-high-roller/src/components/app-waiting/app-waiting.tsx
+++ b/packages/dapp-high-roller/src/components/app-waiting/app-waiting.tsx
@@ -2,6 +2,7 @@ import { Component, Element, Prop, State } from "@stencil/core";
 import { RouterHistory } from "@stencil/router";
 
 import CounterfactualTunnel from "../../data/counterfactual";
+import { getProp } from "../../utils/utils";
 
 /**
  * User Story
@@ -23,6 +24,11 @@ export class AppWaiting {
   @Prop({ mutable: true }) isProposing: boolean = false;
   @State() seconds: number = 5;
   @State() isCountdownStarted: boolean = false;
+
+  componentWillLoad() {
+    this.betAmount = getProp("betAmount", this);
+    this.isProposing = getProp("isProposing", this);
+  }
 
   countDown() {
     if (this.seconds === 1) {
@@ -61,11 +67,11 @@ export class AppWaiting {
     this.countDown();
   }
 
-  setupWaiting(cfProvider?, appInstance?) {
+  setupWaiting(cfProvider?, appInstance?, account?, opponent?) {
     if (this.isProposing) {
       this.setupWaitingProposing();
     } else {
-      this.setupWaitingAccepting(cfProvider, appInstance);
+      this.setupWaitingAccepting(cfProvider, appInstance, account, opponent);
     }
   }
 
@@ -77,17 +83,21 @@ export class AppWaiting {
     this.startCountdown();
   }
 
-  setupWaitingAccepting(cfProvider, appInstance) {
+  setupWaitingAccepting(cfProvider, appInstance, account, opponent) {
     cfProvider.once("updateState", () => {
       this.goToGame(this.opponentName, appInstance.id);
     });
+    this.myName = account.user.username;
+    this.opponentName = opponent.attributes.username;
   }
 
   render() {
     return (
       <CounterfactualTunnel.Consumer>
-        {({ cfProvider, appInstance }) => [
-          <div>{this.setupWaiting(cfProvider, appInstance)}</div>,
+        {({ cfProvider, appInstance, account, opponent }) => [
+          <div>
+            {this.setupWaiting(cfProvider, appInstance, account, opponent)}
+          </div>,
           <div class="wrapper">
             <div class="waiting">
               <div class="message">

--- a/packages/dapp-high-roller/src/utils/utils.ts
+++ b/packages/dapp-high-roller/src/utils/utils.ts
@@ -1,7 +1,18 @@
+declare var ethers;
+
 function getProp(propertyName: string, context: { [key: string]: any }) {
   const state = context.history.location.state || {};
   const query = context.history.location.query || {};
   return state[propertyName] || query[propertyName] || context[propertyName];
 }
 
-export { getProp };
+/// Returns the commit hash that can be used to commit to chosenNumber
+/// using appSalt
+function computeCommitHash(appSalt: string, chosenNumber: number) {
+  return ethers.utils.solidityKeccak256(
+    ["bytes32", "uint256"],
+    [appSalt, chosenNumber]
+  );
+}
+
+export { getProp, computeCommitHash };

--- a/packages/playground-server/registry.json
+++ b/packages/playground-server/registry.json
@@ -1,7 +1,7 @@
 {
   "apps": [
     {
-      "id": "0x6296F3ACf03b6D787BD1068B4DB8093c54d5d915",
+      "id": "0x903217387B06a84F4dD0bEA565Ad8765Fc7cAA58",
       "name": "High Roller",
       "url": "https://high-roller-staging.counterfactual.com",
       "slug": "high-roller",

--- a/packages/playground-server/registry.local.json
+++ b/packages/playground-server/registry.local.json
@@ -1,7 +1,7 @@
 {
   "apps": [
     {
-      "id": "0x6296F3ACf03b6D787BD1068B4DB8093c54d5d915",
+      "id": "0x903217387B06a84F4dD0bEA565Ad8765Fc7cAA58",
       "name": "High Roller",
       "url": "http://localhost:3333",
       "slug": "high-roller",

--- a/packages/typescript-typings/types/ethers/index.d.ts
+++ b/packages/typescript-typings/types/ethers/index.d.ts
@@ -16,7 +16,8 @@ declare var ethers = {
   utils: {
     formatEther: (value: string) => string,
     parseEther: (value: string) => BigNumber,
-    bigNumberify: (value: any) => BigNumber
+    bigNumberify: (value: any) => BigNumber,
+    solidityKeccak256: (type: string[], data: any[]) => string
   },
   providers: {
     Web3Provider: Web3Provider


### PR DESCRIPTION
This PR features:

- Winning detection logic with the REVEAL stage
- Better animation UI triggers to reflect what's actually happening in the game state
- Opponent data for the waiting room on the counterparty's side

**Preview**

A tie:
![deepin-screen-recorder_select area_20190204191914](https://user-images.githubusercontent.com/118913/52241459-80b2c500-28b2-11e9-849c-e33f0b506996.gif)

A win/lose:
![deepin-screen-recorder_select area_20190204192452](https://user-images.githubusercontent.com/118913/52241481-99bb7600-28b2-11e9-9322-cc8cae428f4a.gif)
