### PR TITLE
[monorepo] Returns non-zero exit code for yarn build

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -40,5 +40,9 @@ for package in $packages; do
   echo "⚙️  Building package: ${package}"
   cd packages/${package}
   yarn build
+  if [ "$?" != "0" ]
+  then
+    exit $?;
+  fi
   cd -
 done


### PR DESCRIPTION
This PR makes the build process exit-code aware, so if any package's `build` task fails, it'll stop the build pipeline.