### PR TITLE
[monorepo] do not use lsof if not present

### DIFF
--- a/packages/contracts/scripts/test.sh
+++ b/packages/contracts/scripts/test.sh
@@ -8,7 +8,7 @@ function clean {
 
 trap clean INT TERM EXIT
 
-if lsof -ti :8545
+if [[ $(command -v lsof) && $(lsof -ti :8545) ]]
 then
   echo "Detected a process (probably an existing ganache instance) listening on 8545. Exiting."
   exit 1

--- a/packages/machine/scripts/test.sh
+++ b/packages/machine/scripts/test.sh
@@ -32,7 +32,7 @@ export DEV_GANACHE_MNEMONIC=$(
   "brain surround have swap horror body response double fire dumb bring hazard"
 )
 
-if lsof -ti :${DEV_GANACHE_PORT}
+if [[ $(command -v lsof) && $(lsof -ti :{DEV_GANACHE_PORT}) ]]
 then
   echo "Detected a process (probably an existing ganache instance) listening on ${DEV_GANACHE_PORT}. Exiting."
   exit 1


### PR DESCRIPTION
unfortunately `lsof` is sometimes not present on the CI machines. even more unfortunately there doesn't seem to be a POSIX utility that has the same functionality we need