### PR TITLE
Fix problems in ldct/virtual-app-set-state-test

### DIFF
--- a/packages/machine/test/integration/virtual-app-set-state-commitment.spec.ts
+++ b/packages/machine/test/integration/virtual-app-set-state-commitment.spec.ts
@@ -3,6 +3,7 @@ import ETHBucket from "@counterfactual/contracts/build/ETHBucket.json";
 import StateChannelTransaction from "@counterfactual/contracts/build/StateChannelTransaction.json";
 import { VirtualAppSetStateCommitment } from "@counterfactual/machine/src/ethereum/virtual-app-set-state-commitment";
 import { AssetType, NetworkContext } from "@counterfactual/types";
+import * as chai from "chai";
 import { solidity, WaffleLegacyOutput } from "ethereum-waffle";
 import { Contract, Wallet } from "ethers";
 import { AddressZero, WeiPerEther } from "ethers/constants";

--- a/patches/scrypt+6.0.3.patch
+++ b/patches/scrypt+6.0.3.patch
@@ -1,0 +1,12 @@
+diff --git a/node_modules/scrypt/index.js b/node_modules/scrypt/index.js
+index 7b13a79..1e40d76 100644
+--- a/node_modules/scrypt/index.js
++++ b/node_modules/scrypt/index.js
+@@ -1,6 +1,6 @@
+ "use strict";
+ 
+-var scryptNative = require("./build/Release/scrypt")
++var scryptNative = require("./build/Release/scrypt.node")
+   , Crypto = require("crypto")
+   , Os = require("os");
+ 


### PR DESCRIPTION
```sh
$ yarn test virtual-app-set
yarn run v1.10.1
$ ./scripts/test.sh virtual-app-set
📧 Reading environment values from .env, defaulting to values in test.sh
⛓ Starting ganache-cli at http://127.0.0.1:8546 (network_id: 8888888)
⚙️ Running migrations with build artifacts from @counterfactual/contracts
🧪 Starting jest test suites
 PASS  test/integration/virtual-app-set-state-commitment.spec.ts (5.023s)

Test Suites: 1 passed, 1 total
Tests:       2 passed, 2 total
Snapshots:   0 total
Time:        5.833s
Ran all test suites matching /virtual-app-set/i.
✨  Done in 15.45s.
```