### PR TITLE
[playground] Exposes hdnode as required by the Node IIFE

### DIFF
--- a/packages/playground/src/index.html
+++ b/packages/playground/src/index.html
@@ -34,6 +34,7 @@
 
     <script>
       EventEmitter = EventEmitter3.EventEmitter;
+      hdnode = ethers.utils.HDNode;
       utils = ethers.utils;
       constants = ethers.constants;
       database = firebase.database;


### PR DESCRIPTION
This fixes the following error:

```
Uncaught ReferenceError: hdnode is not defined
    at node.js:2525
```