### PR TITLE
[playground] Fixes API call for current user

### DIFF
--- a/packages/playground/src/data/playground-api-client.ts
+++ b/packages/playground/src/data/playground-api-client.ts
@@ -151,7 +151,7 @@ export default class PlaygroundAPIClient {
 
   public static async getUser(token: string): Promise<UserSession> {
     try {
-      const json = (await get("users", token)) as APIResponse;
+      const json = (await get("users/me", token)) as APIResponse;
       const resource = json.data[0] as APIResource<UserAttributes>;
 
       return fromAPIResource<UserSession, UserAttributes>(resource);


### PR DESCRIPTION
Since #559 was merged, the Playground must call `/api/users/me` to get the user data from a token. 

This PR fixes a wrongful call to `/api/users`.