### PR TITLE
[playground-server] Fixes data payload for registry.local

### DIFF
--- a/packages/playground-server/registry.local.json
+++ b/packages/playground-server/registry.local.json
@@ -1,18 +1,26 @@
 {
-  "apps": [
+  "data": [
     {
+      "type": "app",
       "id": "0x903217387B06a84F4dD0bEA565Ad8765Fc7cAA58",
-      "name": "High Roller",
-      "url": "http://localhost:3333",
-      "slug": "high-roller",
-      "icon": "assets/images/logo.png"
+      "attributes": {
+        "name": "High Roller",
+        "url": "http://localhost:3333",
+        "slug": "high-roller",
+        "icon": "assets/images/logo.svg"
+      },
+      "relationships": {}
     },
     {
+      "type": "app",
       "id": "0x32Fe8ec842ca039187f9Ed59c065A922fdF52eDe",
-      "name": "Tic Tac Toe",
-      "url": "http://localhost:3000",
-      "slug": "tic-tac-toe",
-      "icon": "images/logo.png"
+      "attributes": {
+        "name": "Tic Tac Toe",
+        "url": "http://localhost:3000",
+        "slug": "tic-tac-toe",
+        "icon": "images/logo-blue.svg"
+      },
+      "relationships": {}
     }
   ]
 }

--- a/packages/playground-server/src/resources/app/processor.ts
+++ b/packages/playground-server/src/resources/app/processor.ts
@@ -19,7 +19,7 @@ export default class AppProcessor extends OperationProcessor<App> {
       );
 
       Log.info("Loaded App registry", {
-        tags: { totalApps: registry.apps.length, endpoint: "apps" }
+        tags: { totalApps: registry.data.length, endpoint: "apps" }
       });
 
       return registry.data.map((record: {}) => new App(record));


### PR DESCRIPTION
The `registry.local.json` file was using a non-JSONAPI-compliant data structure, making the App Registry endpoint fail when pointed to it. 

This PR fixes it.