### PR TITLE
[playground] Uses Node.publicIdentifier instead of address

### DIFF
--- a/packages/playground/src/components/account/account-register/account-register.tsx
+++ b/packages/playground/src/components/account/account-register/account-register.tsx
@@ -34,7 +34,7 @@ export class AccountRegister {
     username: "",
     email: "",
     ethAddress: this.user.ethAddress,
-    nodeAddress: CounterfactualNode.getInstance().address
+    nodeAddress: CounterfactualNode.getInstance().publicIdentifier
   };
 
   @State() errors: UserChangeset = {

--- a/packages/playground/src/data/counterfactual.ts
+++ b/packages/playground/src/data/counterfactual.ts
@@ -13,7 +13,7 @@ export declare class Node {
     // @ts-ignore
     provider: ethers.providers.Provider
   ): Promise<Node>;
-  readonly address: string;
+  readonly publicIdentifier: string;
   on(event: string, callback: (res: any) => void): void;
   emit(event: string, req: NodeTypes.MethodRequest): void;
   call(


### PR DESCRIPTION
This PR updates account creation to use `publicIdentifier` instead of `address`.

:warning: **Important notice:** After this PR gets merged and deployed, currently-registered Playground accounts will no longer be valid. Any local/staging accounts must be wiped and re-created.