### PR TITLE
[dapp-high-roller] [dapp-tic-tac-toe] Fixes build processes

### DIFF
--- a/packages/dapp-high-roller/netlify.sh
+++ b/packages/dapp-high-roller/netlify.sh
@@ -9,7 +9,7 @@
 
 npm i -g yarn@1.10.1
 
-packages="contracts types cf.js node-provider dapp-high-roller"
+packages="contracts types node-provider cf.js dapp-high-roller"
 
 cd ../..
 
@@ -17,5 +17,9 @@ for package in $packages; do
   echo ">>> Building package: $package"
   cd packages/$package
   yarn build
+    if [ "$?" != "0" ]
+  then
+    exit $?;
+  fi
   cd ../..
 done

--- a/packages/dapp-tic-tac-toe/netlify.sh
+++ b/packages/dapp-tic-tac-toe/netlify.sh
@@ -9,7 +9,7 @@
 
 npm i -g yarn@1.10.1
 
-packages="contracts types cf.js node-provider dapp-tic-tac-toe"
+packages="contracts types node-provider cf.js dapp-tic-tac-toe"
 
 cd ../..
 
@@ -17,5 +17,9 @@ for package in $packages; do
   echo ">>> Building package: $package"
   cd packages/$package
   yarn build
+  if [ "$?" != "0" ]
+  then
+    exit $?;
+  fi
   cd ../..
 done


### PR DESCRIPTION
The `yarn netlify` commands for both dApps broke because of a change in the dependency order since #620. This PR fixes that.