### PR TITLE
[playground-server] [playground] [dapp-high-roller] [dapp-tic-tac-toe] Fixes signature validation, account registration and matchmaking problems

### DIFF
--- a/packages/dapp-high-roller/src/components/app-wager/app-wager.tsx
+++ b/packages/dapp-high-roller/src/components/app-wager/app-wager.tsx
@@ -101,10 +101,13 @@ export class AppWager {
     try {
       const result = await this.fetchMatchmake();
 
-      this.opponent = result.included.find(
-        resource =>
-          resource.id === result.data.relationships.matchedUser.data.id
-      );
+      this.opponent = {
+        attributes: {
+          username: result.data.attributes.username,
+          nodeAddress: result.data.attributes.nodeAddress,
+          ethAddress: result.data.attributes.ethAddress
+        }
+      };
       this.intermediary = result.data.attributes.intermediary;
       this.isError = false;
       this.error = null;
@@ -199,7 +202,11 @@ export class AppWager {
               <h1 class="message__title">Oops! :/</h1>
               <p class="message__body">
                 Something went wrong:
-                <textarea>{JSON.stringify(this.error)}</textarea>
+                <textarea>
+                  {this.error instanceof Error
+                    ? `${this.error.message}: ${this.error.stack}`
+                    : JSON.stringify(this.error)}
+                </textarea>
               </p>
             </div>
           </div>

--- a/packages/dapp-tic-tac-toe/src/Wager.jsx
+++ b/packages/dapp-tic-tac-toe/src/Wager.jsx
@@ -23,10 +23,14 @@ class Wager extends Component {
     try {
       const result = await this.matchmake();
 
-      const opponent = result.included.find(
-        resource =>
-          resource.id === result.data.relationships.matchedUser.data.id
-      );
+      const opponent = {
+        id: "opponent",
+        attributes: {
+          username: result.data.attributes.username,
+          nodeAddress: result.data.attributes.nodeAddress,
+          ethAddress: result.data.attributes.ethAddress
+        }
+      };
 
       this.setState({
         isLoaded: true,

--- a/packages/playground-server/src/api.ts
+++ b/packages/playground-server/src/api.ts
@@ -37,8 +37,7 @@ export default function mountApi() {
 
   api
     .use(cors({ keepHeadersOnError: false }))
-    .use(validateSignature(app))
-    .use(jsonApiKoa(app))
+    .use(jsonApiKoa(app, validateSignature(app)))
     .use(logs());
 
   return api;

--- a/packages/playground-server/src/resources/app/processor.ts
+++ b/packages/playground-server/src/resources/app/processor.ts
@@ -10,7 +10,7 @@ import App from "./resource";
 export default class AppProcessor extends OperationProcessor<App> {
   public resourceClass = App;
 
-  protected async get(op: Operation): Promise<App[]> {
+  public async get(op: Operation): Promise<App[]> {
     try {
       const registry = JSON.parse(
         fs

--- a/packages/playground-server/src/resources/matchmaking-request/processor.ts
+++ b/packages/playground-server/src/resources/matchmaking-request/processor.ts
@@ -13,7 +13,7 @@ export default class MatchmakingRequestProcessor extends OperationProcessor<
   public resourceClass = MatchmakingRequest;
 
   @Authorize()
-  protected async add(op: Operation): Promise<MatchmakingRequest> {
+  public async add(op: Operation): Promise<MatchmakingRequest> {
     const user = this.app.user as User;
     let matchedUser: MatchedUser;
 

--- a/packages/playground-server/src/resources/session-request/processor.ts
+++ b/packages/playground-server/src/resources/session-request/processor.ts
@@ -11,7 +11,7 @@ export default class SessionRequestProcessor extends OperationProcessor<
 > {
   public resourceClass = SessionRequest;
 
-  protected async add(op: Operation): Promise<User> {
+  public async add(op: Operation): Promise<User> {
     const user = await getUser(op.data);
 
     user.attributes.token = sign(

--- a/packages/playground-server/src/resources/user/processor.ts
+++ b/packages/playground-server/src/resources/user/processor.ts
@@ -10,7 +10,7 @@ import User from "./resource";
 export default class UserProcessor extends OperationProcessor {
   public resourceClass = User;
 
-  protected async get(op: Operation): Promise<User[]> {
+  public async get(op: Operation): Promise<User[]> {
     if (op.ref.id === "me") {
       if (this.app.user) {
         op.ref.id = this.app.user.id;
@@ -22,7 +22,7 @@ export default class UserProcessor extends OperationProcessor {
     return getUsers({ id: op.ref.id });
   }
 
-  async add(op: Operation): Promise<User> {
+  public async add(op: Operation): Promise<User> {
     // Create the multisig and return its address.
     const user = op.data;
     const { nodeAddress } = user.attributes;

--- a/packages/playground/src/data/playground-api-client.ts
+++ b/packages/playground/src/data/playground-api-client.ts
@@ -14,7 +14,7 @@ import {
 } from "../types";
 
 const BASE_URL = `ENV:API_HOST`;
-const API_TIMEOUT = 5000;
+const API_TIMEOUT = 30000;
 
 function timeout(delay: number = API_TIMEOUT) {
   const handler = setTimeout(() => {
@@ -176,9 +176,9 @@ export default class PlaygroundAPIClient {
   public static async matchmake(token: string, matchmakeWith: string | null) {
     try {
       return await post(
-        "matchmaking",
+        "matchmaking-requests",
         matchmakeWith
-          ? { type: "matchmaking", attributes: { matchmakeWith } }
+          ? { type: "matchmaking-request", attributes: { matchmakeWith } }
           : ({} as APIResource<APIResourceAttributes>),
         token,
         "Bearer"

--- a/packages/playground/src/types.ts
+++ b/packages/playground/src/types.ts
@@ -62,11 +62,11 @@ export type APIResourceAttributes = {
 };
 
 export type APIResourceType =
-  | "users"
-  | "matchmaking"
+  | "user"
+  | "matchmaking-request"
   | "matchedUser"
   | "session"
-  | "apps";
+  | "app";
 
 export type APIResourceRelationships = {
   [key in APIResourceType]?: APIDataContainer


### PR DESCRIPTION
This PR implements the following changes:

**`validateSignature()` is now called by passing it to `jsonApiKoa`**

`jsonapi-ts` includes `koa-bodyparser`, and in order to validate the signature we also need to inspect the request body. Reading the body a second time resulted in no request body available, therefore the processors couldn't be executed. `jsonapi-ts` now features a `middlewares` argument that injects those functions _after_ `koa-body` but _before_ the JSON API handler itself. This allowed account registration and login to work again.

**Matchmaking is now calling the correct API, and dApps are using the new response format**

Since `jsonapi-ts` support for `includes` is still WIP, we changed how the API responds to a matchmaking request. Instead of using relationships and sideloading, now it just returns the matched user data. Therefore, changes were necessary on the dApps to conform to the new payload.