### PR TITLE
[playground] [playground-server] Fixes matchmaking bug when not using `matchmakeWith` flag

### DIFF
--- a/packages/playground-server/src/resources/matchmaking-request/processor.ts
+++ b/packages/playground-server/src/resources/matchmaking-request/processor.ts
@@ -17,7 +17,7 @@ export default class MatchmakingRequestProcessor extends OperationProcessor<
     const user = this.app.user as User;
     let matchedUser: MatchedUser;
 
-    if (op.data.attributes) {
+    if (op.data.attributes && op.data.attributes.matchmakeWith) {
       const [matchedUserResource] = await getUsers({
         username: op.data.attributes.matchmakeWith
       });

--- a/packages/playground-server/test/api.spec.ts
+++ b/packages/playground-server/test/api.spec.ts
@@ -415,6 +415,51 @@ describe("playground-server", () => {
       done();
     });
 
+    it("returns the requested user as a match", async done => {
+      await db("users").insert([
+        USR_BOB_KNEX,
+        USR_ALICE_KNEX,
+        USR_CHARLIE_KNEX
+      ]);
+
+      const response = await client
+        .post(
+          "/matchmaking-requests",
+          {
+            data: {
+              type: "matchmakingRequest",
+              attributes: {
+                matchmakeWith: USR_CHARLIE.username
+              }
+            }
+          },
+          {
+            headers: {
+              Authorization: `Bearer ${TOKEN_BOB}`
+            }
+          }
+        )
+        .catch(error => {
+          console.error(error.message, error.response.data);
+          throw error;
+        });
+
+      const json = response.data as JsonApiDocument<MatchmakingRequest>;
+      const data = json.data as MatchmakingRequest;
+
+      expect(data.type).toEqual("matchmakingRequest");
+      expect(data.id).toBeDefined();
+      expect(data.attributes).toEqual({
+        intermediary: getNodeAddress(),
+        username: USR_CHARLIE.username,
+        ethAddress: USR_CHARLIE.ethAddress,
+        nodeAddress: USR_CHARLIE.nodeAddress
+      });
+
+      expect(response.status).toEqual(HttpStatusCode.Created);
+      done();
+    });
+
     it("returns one of three possible users as a match", async done => {
       // Mock an extra user into the DB first.
       await db("users").insert([USR_BOB_KNEX, USR_CHARLIE_KNEX]);

--- a/packages/playground/src/data/playground-api-client.ts
+++ b/packages/playground/src/data/playground-api-client.ts
@@ -177,9 +177,10 @@ export default class PlaygroundAPIClient {
     try {
       return await post(
         "matchmaking-requests",
-        matchmakeWith
-          ? { type: "matchmaking-request", attributes: { matchmakeWith } }
-          : ({} as APIResource<APIResourceAttributes>),
+        {
+          type: "matchmakingRequest",
+          attributes: matchmakeWith ? { matchmakeWith } : {}
+        },
         token,
         "Bearer"
       );

--- a/packages/playground/src/types.ts
+++ b/packages/playground/src/types.ts
@@ -63,7 +63,7 @@ export type APIResourceAttributes = {
 
 export type APIResourceType =
   | "user"
-  | "matchmaking-request"
+  | "matchmakingRequest"
   | "matchedUser"
   | "session"
   | "app";


### PR DESCRIPTION
The Matchmaking API was trying to force-matchmake all requests due to bad checking of the flag's existence. This PR fixes the API to work as expected and adds an extra test case for the flag.