### PR TITLE
[monorepo] Rename initiating and responding in proposal messages

### DIFF
--- a/packages/cf.js/src/app-factory.ts
+++ b/packages/cf.js/src/app-factory.ts
@@ -56,8 +56,8 @@ export class AppFactory {
    * @return ID of proposed app instance
    */
   async proposeInstall(params: {
-    /** Address of peer to install instance with */
-    respondingAddress: Address;
+    /** Xpub of peer being proposed to install instance with */
+    proposedToIdentifier: Address;
     /** Asset to use for deposit */
     asset: BlockchainAsset;
     /** Amount to be deposited by you */
@@ -80,7 +80,7 @@ export class AppFactory {
         peerDeposit,
         myDeposit,
         asset: params.asset,
-        respondingAddress: params.respondingAddress,
+        proposedToIdentifier: params.proposedToIdentifier,
         initialState: params.initialState,
         appId: this.appId,
         abiEncodings: this.encodings
@@ -98,8 +98,8 @@ export class AppFactory {
    * @return ID of proposed app instance
    */
   async proposeInstallVirtual(params: {
-    /** Address of peer to install instance with */
-    respondingAddress: Address;
+    /** Xpub of peer being proposed to install instance with */
+    proposedToIdentifier: Address;
     /** Asset to use for deposit */
     asset: BlockchainAsset;
     /** Amount to be deposited by you */
@@ -124,7 +124,7 @@ export class AppFactory {
         peerDeposit,
         myDeposit,
         asset: params.asset,
-        respondingAddress: params.respondingAddress,
+        proposedToIdentifier: params.proposedToIdentifier,
         initialState: params.initialState,
         intermediaries: params.intermediaries,
         appId: this.appId,

--- a/packages/cf.js/test/app-factory.spec.ts
+++ b/packages/cf.js/test/app-factory.spec.ts
@@ -4,7 +4,7 @@ import { parseEther } from "ethers/utils";
 import { AppFactory } from "../src/app-factory";
 import { Provider } from "../src/provider";
 
-import { TestNodeProvider } from "./fixture";
+import { TEST_XPUBS, TestNodeProvider } from "./fixture";
 
 const TEST_APP = {
   abiEncodings: { actionEncoding: "uint256", stateEncoding: "uint256" },
@@ -48,7 +48,7 @@ describe("CF.js AppFactory", () => {
         });
       });
       const appInstanceId = await appFactory.proposeInstall({
-        respondingAddress: "0x0101010101010101010101010101010101010101",
+        proposedToIdentifier: TEST_XPUBS[0],
         asset: {
           assetType: AssetType.ETH
         },
@@ -66,9 +66,7 @@ describe("CF.js AppFactory", () => {
       const expectedDeposit = parseEther("0.5");
       const expectedState = "4000";
       const expectedAppInstanceId = "TEST_ID";
-      const expectedIntermediaries = [
-        "0x6001600160016001600160016001600160016001"
-      ];
+      const expectedIntermediaries = [TEST_XPUBS[1]];
 
       nodeProvider.onMethodRequest(
         Node.MethodName.PROPOSE_INSTALL_VIRTUAL,
@@ -88,7 +86,7 @@ describe("CF.js AppFactory", () => {
         }
       );
       const appInstanceId = await appFactory.proposeInstallVirtual({
-        respondingAddress: "0x0101010101010101010101010101010101010101",
+        proposedToIdentifier: TEST_XPUBS[0],
         asset: {
           assetType: AssetType.ETH
         },
@@ -104,7 +102,7 @@ describe("CF.js AppFactory", () => {
     it("throws an error if BigNumber param invalid", async done => {
       try {
         await appFactory.proposeInstall({
-          respondingAddress: "0x0101010101010101010101010101010101010101",
+          proposedToIdentifier: TEST_XPUBS[0],
           asset: {
             assetType: AssetType.ETH
           },

--- a/packages/cf.js/test/app-instance.spec.ts
+++ b/packages/cf.js/test/app-instance.spec.ts
@@ -1,11 +1,11 @@
 import { AppInstanceInfo, AssetType, Node } from "@counterfactual/types";
-import { bigNumberify, getAddress, hexlify, randomBytes } from "ethers/utils";
+import { bigNumberify } from "ethers/utils";
 
 import { Provider } from "../src";
 import { AppInstance, AppInstanceEventType } from "../src/app-instance";
 import { ErrorEventData, UpdateStateEventData } from "../src/types";
 
-import { TestNodeProvider } from "./fixture";
+import { TEST_XPUBS, TestNodeProvider } from "./fixture";
 
 describe("CF.js AppInstance", () => {
   let nodeProvider: TestNodeProvider;
@@ -20,8 +20,8 @@ describe("CF.js AppInstance", () => {
     myDeposit: bigNumberify(1000),
     peerDeposit: bigNumberify(1000),
     timeout: bigNumberify(10),
-    initiatingAddress: getAddress(hexlify(randomBytes(20))),
-    respondingAddress: getAddress(hexlify(randomBytes(20)))
+    proposedByIdentifier: TEST_XPUBS[0],
+    proposedToIdentifier: TEST_XPUBS[1]
   };
 
   beforeEach(async () => {

--- a/packages/cf.js/test/fixture.ts
+++ b/packages/cf.js/test/fixture.ts
@@ -1,6 +1,12 @@
 import { INodeProvider, Node } from "@counterfactual/types";
 import EventEmitter from "eventemitter3";
 
+// Randomly generated
+export const TEST_XPUBS = [
+  "xpub6EAvo4pQADUK1nFB2UnC9nC5G9iDN3YaeVQ8vA77eU7GEjaZK8H5jDP8M89kJeajTqXJrfbKXgptCqtvpaG1ydED657Kj6dbfjYse6F7Uxy",
+  "xpub6E7Ww5YRUry7BRUNAqyNGqR1A3AyaRP1dKy8adD5N5nniqkDJpibhspkiLzyhKe9o5TFnHpEhdtautQLqxahWQFCDCeQdBFmRwUiChfUXP4"
+];
+
 export class TestNodeProvider implements INodeProvider {
   public postedMessages: Node.Message[] = [];
   readonly callbacks: ((message: Node.Message) => void)[] = [];

--- a/packages/cf.js/test/provider.spec.ts
+++ b/packages/cf.js/test/provider.spec.ts
@@ -1,6 +1,5 @@
 import { AppInstanceInfo, AssetType, Node } from "@counterfactual/types";
 import { Zero } from "ethers/constants";
-import { getAddress, hexlify, randomBytes } from "ethers/utils";
 
 import { AppInstance } from "../src/app-instance";
 import { NODE_REQUEST_TIMEOUT, Provider } from "../src/provider";
@@ -12,7 +11,7 @@ import {
   RejectInstallEventData
 } from "../src/types";
 
-import { TestNodeProvider } from "./fixture";
+import { TEST_XPUBS, TestNodeProvider } from "./fixture";
 
 describe("CF.js Provider", () => {
   let nodeProvider: TestNodeProvider;
@@ -26,8 +25,8 @@ describe("CF.js Provider", () => {
     myDeposit: Zero,
     peerDeposit: Zero,
     timeout: Zero,
-    initiatingAddress: getAddress(hexlify(randomBytes(20))),
-    respondingAddress: getAddress(hexlify(randomBytes(20)))
+    proposedByIdentifier: TEST_XPUBS[0],
+    proposedToIdentifier: TEST_XPUBS[1]
   };
 
   beforeEach(() => {

--- a/packages/node/src/events/propose-install-virtual/controller.ts
+++ b/packages/node/src/events/propose-install-virtual/controller.ts
@@ -21,7 +21,7 @@ export default async function proposeInstallVirtualEventController(
     requestHandler.store,
     nodeMsg.data.params,
     nodeMsg.data.appInstanceId,
-    nodeMsg.data.initiatingAddress,
+    nodeMsg.data.proposedByAddress,
     nodeMsg.from!
   );
 
@@ -43,7 +43,7 @@ export default async function proposeInstallVirtualEventController(
   const nextNodeAddress = getNextNodeAddress(
     requestHandler.publicIdentifier,
     nodeMsg.data.params.intermediaries,
-    nodeMsg.data.params.respondingAddress
+    nodeMsg.data.params.proposedToIdentifier
   );
 
   await requestHandler.messagingService.send(

--- a/packages/node/src/events/propose-install-virtual/controller.ts
+++ b/packages/node/src/events/propose-install-virtual/controller.ts
@@ -21,7 +21,7 @@ export default async function proposeInstallVirtualEventController(
     requestHandler.store,
     nodeMsg.data.params,
     nodeMsg.data.appInstanceId,
-    nodeMsg.data.proposedByAddress,
+    nodeMsg.data.proposedByIdentifier,
     nodeMsg.from!
   );
 

--- a/packages/node/src/events/propose-install-virtual/operation.ts
+++ b/packages/node/src/events/propose-install-virtual/operation.ts
@@ -17,14 +17,14 @@ export async function setAppInstanceIDForProposeInstallVirtual(
   store: Store,
   params: Node.ProposeInstallVirtualParams,
   appInstanceId: string,
-  initiatingAddress: Address,
-  incomingAddress: Address
+  proposedByIdentifier: string,
+  incomingIdentifier: Address
 ) {
   await store.addAppInstanceProposal(
-    await getChannelFromPeerAddress(selfAddress, incomingAddress, store),
+    await getChannelFromPeerAddress(selfAddress, incomingIdentifier, store),
     new ProposedAppInstanceInfo(appInstanceId, {
       ...params,
-      initiatingAddress
+      proposedByIdentifier
     })
   );
 }

--- a/packages/node/src/events/propose-install-virtual/operation.ts
+++ b/packages/node/src/events/propose-install-virtual/operation.ts
@@ -6,14 +6,14 @@ import { getChannelFromPeerAddress } from "../../utils";
 
 /**
  *
- * @param selfAddress
+ * @param myIdentifier
  * @param store
  * @param params
  * @param appInstanceId
  * @param incomingAddress The address of the Node who is relaying the proposal.
  */
 export async function setAppInstanceIDForProposeInstallVirtual(
-  selfAddress: Address,
+  myIdentifier: string,
   store: Store,
   params: Node.ProposeInstallVirtualParams,
   appInstanceId: string,
@@ -21,7 +21,7 @@ export async function setAppInstanceIDForProposeInstallVirtual(
   incomingIdentifier: Address
 ) {
   await store.addAppInstanceProposal(
-    await getChannelFromPeerAddress(selfAddress, incomingIdentifier, store),
+    await getChannelFromPeerAddress(myIdentifier, incomingIdentifier, store),
     new ProposedAppInstanceInfo(appInstanceId, {
       ...params,
       proposedByIdentifier

--- a/packages/node/src/events/propose-install/operation.ts
+++ b/packages/node/src/events/propose-install/operation.ts
@@ -1,18 +1,21 @@
-import { Address, Node } from "@counterfactual/types";
+import { Node } from "@counterfactual/types";
 
 import { ProposedAppInstanceInfo } from "../../models";
 import { Store } from "../../store";
 import { getChannelFromPeerAddress } from "../../utils";
 
 export async function setAppInstanceIDForProposeInstall(
-  selfAddress: Address,
+  selfAddress: string,
   store: Store,
   params: Node.ProposeInstallParams,
   appInstanceId: string,
-  initiatingAddress: Address
+  proposedByIdentifier: string
 ) {
   await store.addAppInstanceProposal(
-    await getChannelFromPeerAddress(selfAddress, initiatingAddress, store),
-    new ProposedAppInstanceInfo(appInstanceId, { ...params, initiatingAddress })
+    await getChannelFromPeerAddress(selfAddress, proposedByIdentifier, store),
+    new ProposedAppInstanceInfo(appInstanceId, {
+      ...params,
+      proposedByIdentifier
+    })
   );
 }

--- a/packages/node/src/events/propose-install/operation.ts
+++ b/packages/node/src/events/propose-install/operation.ts
@@ -5,14 +5,14 @@ import { Store } from "../../store";
 import { getChannelFromPeerAddress } from "../../utils";
 
 export async function setAppInstanceIDForProposeInstall(
-  selfAddress: string,
+  myIdentifier: string,
   store: Store,
   params: Node.ProposeInstallParams,
   appInstanceId: string,
   proposedByIdentifier: string
 ) {
   await store.addAppInstanceProposal(
-    await getChannelFromPeerAddress(selfAddress, proposedByIdentifier, store),
+    await getChannelFromPeerAddress(myIdentifier, proposedByIdentifier, store),
     new ProposedAppInstanceInfo(appInstanceId, {
       ...params,
       proposedByIdentifier

--- a/packages/node/src/methods/app-instance/install-virtual/controller.ts
+++ b/packages/node/src/methods/app-instance/install-virtual/controller.ts
@@ -20,7 +20,7 @@ export default async function installVirtualAppInstanceController(
     requestHandler.store,
     requestHandler.instructionExecutor,
     requestHandler.publicIdentifier,
-    proposedAppInstanceInfo.respondingAddress,
+    proposedAppInstanceInfo.proposedToIdentifier,
     params
   );
 
@@ -35,7 +35,7 @@ export default async function installVirtualAppInstanceController(
   };
 
   await requestHandler.messagingService.send(
-    proposedAppInstanceInfo.initiatingAddress,
+    proposedAppInstanceInfo.proposedByIdentifier,
     installVirtualApprovalMsg
   );
 

--- a/packages/node/src/methods/app-instance/install-virtual/operation.ts
+++ b/packages/node/src/methods/app-instance/install-virtual/operation.ts
@@ -18,8 +18,8 @@ import { ERRORS } from "../../errors";
 export async function installVirtual(
   store: Store,
   instructionExecutor: InstructionExecutor,
-  initiatingAddress: string,
-  respondingAddress: string,
+  proposedByIdentifier: string,
+  proposedToIdentifier: string,
   params: Node.InstallParams
 ): Promise<AppInstanceInfo> {
   const { appInstanceId } = params;

--- a/packages/node/src/methods/app-instance/propose-install-virtual/controller.ts
+++ b/packages/node/src/methods/app-instance/propose-install-virtual/controller.ts
@@ -41,7 +41,7 @@ export default async function proposeInstallVirtualAppInstanceController(
     data: {
       params,
       appInstanceId,
-      proposedByAddress: requestHandler.publicIdentifier
+      proposedByIdentifier: requestHandler.publicIdentifier
     }
   };
 

--- a/packages/node/src/methods/app-instance/propose-install-virtual/controller.ts
+++ b/packages/node/src/methods/app-instance/propose-install-virtual/controller.ts
@@ -41,14 +41,14 @@ export default async function proposeInstallVirtualAppInstanceController(
     data: {
       params,
       appInstanceId,
-      initiatingAddress: requestHandler.publicIdentifier
+      proposedByAddress: requestHandler.publicIdentifier
     }
   };
 
   const nextNodeAddress = getNextNodeAddress(
     requestHandler.publicIdentifier,
     params.intermediaries,
-    params.respondingAddress
+    params.proposedToIdentifier
   );
 
   await requestHandler.messagingService.send(nextNodeAddress, proposalMsg);

--- a/packages/node/src/methods/app-instance/propose-install-virtual/operation.ts
+++ b/packages/node/src/methods/app-instance/propose-install-virtual/operation.ts
@@ -22,7 +22,7 @@ export async function createProposedVirtualAppInstance(
   const nextIntermediaryAddress = getNextNodeAddress(
     selfAddress,
     params.intermediaries,
-    params.respondingAddress
+    params.proposedToIdentifier
   );
 
   const channel = await getChannelFromPeerAddress(
@@ -33,7 +33,7 @@ export async function createProposedVirtualAppInstance(
 
   const proposedAppInstance = new ProposedAppInstanceInfo(appInstanceId, {
     ...params,
-    initiatingAddress: selfAddress
+    proposedByIdentifier: selfAddress
   });
 
   await store.addAppInstanceProposal(channel, proposedAppInstance);

--- a/packages/node/src/methods/app-instance/propose-install-virtual/operation.ts
+++ b/packages/node/src/methods/app-instance/propose-install-virtual/operation.ts
@@ -8,32 +8,32 @@ import { getChannelFromPeerAddress } from "../../../utils";
 /**
  * Creates a ProposedAppInstanceInfo to reflect the proposal received from
  * the client.
- * @param selfAddress
+ * @param myIdentifier
  * @param store
  * @param params
  */
 export async function createProposedVirtualAppInstance(
-  selfAddress: string,
+  myIdentifier: string,
   store: Store,
   params: Node.ProposeInstallVirtualParams
 ): Promise<string> {
   const appInstanceId = generateUUID();
 
   const nextIntermediaryAddress = getNextNodeAddress(
-    selfAddress,
+    myIdentifier,
     params.intermediaries,
     params.proposedToIdentifier
   );
 
   const channel = await getChannelFromPeerAddress(
-    selfAddress,
+    myIdentifier,
     nextIntermediaryAddress,
     store
   );
 
   const proposedAppInstance = new ProposedAppInstanceInfo(appInstanceId, {
     ...params,
-    proposedByIdentifier: selfAddress
+    proposedByIdentifier: myIdentifier
   });
 
   await store.addAppInstanceProposal(channel, proposedAppInstance);

--- a/packages/node/src/methods/app-instance/propose-install/controller.ts
+++ b/packages/node/src/methods/app-instance/propose-install/controller.ts
@@ -36,7 +36,7 @@ export default async function proposeInstallAppInstanceController(
   };
 
   await requestHandler.messagingService.send(
-    params.respondingAddress,
+    params.proposedToIdentifier,
     proposalMsg
   );
 

--- a/packages/node/src/methods/app-instance/propose-install/operation.ts
+++ b/packages/node/src/methods/app-instance/propose-install/operation.ts
@@ -18,16 +18,15 @@ export async function createProposedAppInstance(
   params: Node.ProposeInstallParams
 ): Promise<string> {
   const appInstanceId = generateUUID();
-
   const channel = await getChannelFromPeerAddress(
     selfAddress,
-    params.respondingAddress,
+    params.proposedToIdentifier,
     store
   );
 
   const proposedAppInstance = new ProposedAppInstanceInfo(appInstanceId, {
     ...params,
-    initiatingAddress: selfAddress
+    proposedByIdentifier: selfAddress
   });
 
   await store.addAppInstanceProposal(channel, proposedAppInstance);

--- a/packages/node/src/methods/app-instance/propose-install/operation.ts
+++ b/packages/node/src/methods/app-instance/propose-install/operation.ts
@@ -8,25 +8,25 @@ import { getChannelFromPeerAddress } from "../../../utils";
 /**
  * Creates a ProposedAppInstanceInfo to reflect the proposal received from
  * the client.
- * @param selfAddress
+ * @param myIdentifier
  * @param store
  * @param params
  */
 export async function createProposedAppInstance(
-  selfAddress: string,
+  myIdentifier: string,
   store: Store,
   params: Node.ProposeInstallParams
 ): Promise<string> {
   const appInstanceId = generateUUID();
   const channel = await getChannelFromPeerAddress(
-    selfAddress,
+    myIdentifier,
     params.proposedToIdentifier,
     store
   );
 
   const proposedAppInstance = new ProposedAppInstanceInfo(appInstanceId, {
     ...params,
-    proposedByIdentifier: selfAddress
+    proposedByIdentifier: myIdentifier
   });
 
   await store.addAppInstanceProposal(channel, proposedAppInstance);

--- a/packages/node/src/methods/app-instance/reject-install-virtual/controller.ts
+++ b/packages/node/src/methods/app-instance/reject-install-virtual/controller.ts
@@ -23,7 +23,7 @@ export default async function rejectInstallVirtualController(
   };
 
   await requestHandler.messagingService.send(
-    appInstanceInfo.initiatingAddress,
+    appInstanceInfo.proposedByIdentifier,
     rejectInstallVirtualMsg
   );
 

--- a/packages/node/src/methods/app-instance/reject-install/controller.ts
+++ b/packages/node/src/methods/app-instance/reject-install/controller.ts
@@ -28,7 +28,7 @@ export default async function rejectInstallController(
   };
 
   await requestHandler.messagingService.send(
-    appInstanceInfo.initiatingAddress,
+    appInstanceInfo.proposedByIdentifier,
     rejectProposalMsg
   );
 

--- a/packages/node/src/methods/app-instance/take-action/controller.ts
+++ b/packages/node/src/methods/app-instance/take-action/controller.ts
@@ -52,8 +52,8 @@ export default async function takeActionController(
   );
 
   const to = getCounterpartyAddress(requestHandler.publicIdentifier, [
-    appInstanceInfo.initiatingAddress,
-    appInstanceInfo.respondingAddress
+    appInstanceInfo.proposedByIdentifier,
+    appInstanceInfo.proposedToIdentifier
   ]);
 
   await requestHandler.messagingService.send(to, updateStateMessage);

--- a/packages/node/src/methods/app-instance/uninstall/controller.ts
+++ b/packages/node/src/methods/app-instance/uninstall/controller.ts
@@ -38,10 +38,11 @@ export default async function uninstallController(
   await requestHandler.store.saveStateChannel(updatedChannel);
 
   const to = getCounterpartyAddress(requestHandler.publicIdentifier, [
-    appInstanceInfo.initiatingAddress,
-    appInstanceInfo.respondingAddress
+    appInstanceInfo.proposedByIdentifier,
+    appInstanceInfo.proposedToIdentifier
   ]);
 
   await requestHandler.messagingService.send(to, uninstallMsg);
+
   return {};
 }

--- a/packages/node/src/models/proposed-app-instance-info.ts
+++ b/packages/node/src/models/proposed-app-instance-info.ts
@@ -17,9 +17,9 @@ export interface IProposedAppInstanceInfo {
   peerDeposit: BigNumber;
   timeout: BigNumber;
   initialState: SolidityABIEncoderV2Struct;
-  initiatingAddress: Address;
-  respondingAddress: Address;
-  intermediaries?: Address[];
+  proposedByIdentifier: string;
+  proposedToIdentifier: string;
+  intermediaries?: string[];
 }
 
 export interface ProposedAppInstanceInfoJSON {
@@ -31,9 +31,9 @@ export interface ProposedAppInstanceInfoJSON {
   peerDeposit: string;
   timeout: string;
   initialState: SolidityABIEncoderV2Struct;
-  initiatingAddress: Address;
-  respondingAddress: Address;
-  intermediaries?: Address[];
+  proposedByIdentifier: string;
+  proposedToIdentifier: string;
+  intermediaries?: string[];
 }
 
 /**
@@ -55,9 +55,9 @@ export class ProposedAppInstanceInfo implements AppInstanceInfo {
   peerDeposit: BigNumber;
   timeout: BigNumber;
   initialState: SolidityABIEncoderV2Struct;
-  initiatingAddress: Address;
-  respondingAddress: Address;
-  intermediaries?: Address[];
+  proposedByIdentifier: string;
+  proposedToIdentifier: string;
+  intermediaries?: string[];
 
   constructor(
     appInstanceId: AppInstanceID,
@@ -70,8 +70,8 @@ export class ProposedAppInstanceInfo implements AppInstanceInfo {
     this.myDeposit = proposeParams.myDeposit;
     this.peerDeposit = proposeParams.peerDeposit;
     this.timeout = proposeParams.timeout;
-    this.initiatingAddress = proposeParams.initiatingAddress;
-    this.respondingAddress = proposeParams.respondingAddress;
+    this.proposedByIdentifier = proposeParams.proposedByIdentifier;
+    this.proposedToIdentifier = proposeParams.proposedToIdentifier;
     this.initialState = proposeParams.initialState;
     this.intermediaries = proposeParams.intermediaries;
   }
@@ -86,8 +86,8 @@ export class ProposedAppInstanceInfo implements AppInstanceInfo {
       peerDeposit: this.peerDeposit,
       initialState: this.initialState,
       timeout: this.timeout,
-      initiatingAddress: this.initiatingAddress,
-      respondingAddress: this.respondingAddress,
+      proposedByIdentifier: this.proposedByIdentifier,
+      proposedToIdentifier: this.proposedToIdentifier,
       intermediaries: this.intermediaries
     };
   }
@@ -102,8 +102,8 @@ export class ProposedAppInstanceInfo implements AppInstanceInfo {
       peerDeposit: bigNumberify(json.peerDeposit),
       timeout: bigNumberify(json.timeout),
       initialState: json.initialState,
-      initiatingAddress: json.initiatingAddress,
-      respondingAddress: json.respondingAddress,
+      proposedByIdentifier: json.proposedByIdentifier,
+      proposedToIdentifier: json.proposedToIdentifier,
       intermediaries: json.intermediaries
     };
     return new ProposedAppInstanceInfo(json.id, proposeParams);

--- a/packages/node/src/types.ts
+++ b/packages/node/src/types.ts
@@ -44,7 +44,7 @@ export interface ProposeVirtualMessage extends NodeMessage {
   data: {
     params: Node.ProposeInstallVirtualParams;
     appInstanceId: string;
-    proposedByAddress: string;
+    proposedByIdentifier: string;
   };
 }
 

--- a/packages/node/src/types.ts
+++ b/packages/node/src/types.ts
@@ -44,7 +44,7 @@ export interface ProposeVirtualMessage extends NodeMessage {
   data: {
     params: Node.ProposeInstallVirtualParams;
     appInstanceId: string;
-    initiatingAddress: Address;
+    proposedByAddress: string;
   };
 }
 

--- a/packages/node/src/utils.ts
+++ b/packages/node/src/utils.ts
@@ -10,18 +10,21 @@ export function hashOfOrderedPublicIdentifiers(addresses: Address[]): string {
 
 /**
  *
- * @param selfAddress
+ * @param myIdentifier
  * @param peerAddress Peer Address could either be an intermediary or a
  *        `respondingAddress` which is the targeted peer in a Virtual AppInstance
  *        operation.
  * @param store
  */
 export async function getChannelFromPeerAddress(
-  selfAddress: string,
+  myIdentifier: string,
   peerAddress: string,
   store: Store
 ): Promise<StateChannel> {
-  const ownersHash = hashOfOrderedPublicIdentifiers([selfAddress, peerAddress]);
+  const ownersHash = hashOfOrderedPublicIdentifiers([
+    myIdentifier,
+    peerAddress
+  ]);
 
   const multisigAddress = await store.getMultisigAddressFromOwnersHash(
     ownersHash
@@ -29,7 +32,7 @@ export async function getChannelFromPeerAddress(
 
   if (!multisigAddress) {
     return Promise.reject(
-      `No channel exists between the current user ${selfAddress} and the peer ${peerAddress}`
+      `No channel exists between the current user ${myIdentifier} and the peer ${peerAddress}`
     );
   }
 
@@ -37,7 +40,7 @@ export async function getChannelFromPeerAddress(
 }
 
 export async function getPeersAddressFromAppInstanceID(
-  selfAddress: Address,
+  myIdentifier: Address,
   store: Store,
   appInstanceId: string
 ): Promise<Address[]> {
@@ -46,7 +49,7 @@ export async function getPeersAddressFromAppInstanceID(
   );
   const stateChannel = await store.getStateChannel(multisigAddress);
   const owners = stateChannel.userNeuteredExtendedKeys;
-  return owners.filter(owner => owner !== selfAddress);
+  return owners.filter(owner => owner !== myIdentifier);
 }
 
 export function isNotDefinedOrEmpty(str?: string) {
@@ -54,10 +57,10 @@ export function isNotDefinedOrEmpty(str?: string) {
 }
 
 export function getCounterpartyAddress(
-  selfAddress: Address,
+  myIdentifier: Address,
   appInstanceAddresses: Address[]
 ) {
   return appInstanceAddresses.filter(address => {
-    return address !== selfAddress;
+    return address !== myIdentifier;
   })[0];
 }

--- a/packages/node/test/integration/cant-take-action.spec.ts
+++ b/packages/node/test/integration/cant-take-action.spec.ts
@@ -148,14 +148,14 @@ describe("Node method follows spec - takeAction", () => {
 });
 
 function makeTTTAppInstanceProposalReq(
-  respondingAddress: Address,
+  proposedToIdentifier: string,
   appId: Address,
   initialState: SolidityABIEncoderV2Struct,
   abiEncodings: AppABIEncodings
 ): NodeTypes.MethodRequest {
   return {
     params: {
-      respondingAddress,
+      proposedToIdentifier,
       appId,
       initialState,
       abiEncodings,

--- a/packages/node/test/integration/install-virtual.spec.ts
+++ b/packages/node/test/integration/install-virtual.spec.ts
@@ -147,7 +147,7 @@ describe("Node method follows spec - proposeInstallVirtual", () => {
               proposedAppInstanceC
             );
 
-            expect(proposedAppInstanceC.initiatingAddress).toEqual(
+            expect(proposedAppInstanceC.proposedByIdentifier).toEqual(
               nodeA.publicIdentifier
             );
             expect(proposedAppInstanceA.id).toEqual(proposedAppInstanceC.id);

--- a/packages/node/test/integration/propose-install-virtual.spec.ts
+++ b/packages/node/test/integration/propose-install-virtual.spec.ts
@@ -131,7 +131,7 @@ describe("Node method follows spec - proposeInstallVirtual", () => {
               proposedAppInstanceC
             );
 
-            expect(proposedAppInstanceC.initiatingAddress).toEqual(
+            expect(proposedAppInstanceC.proposedByIdentifier).toEqual(
               nodeA.publicIdentifier
             );
             expect(proposedAppInstanceA.id).toEqual(proposedAppInstanceB.id);

--- a/packages/node/test/integration/reject-install-virtual.spec.ts
+++ b/packages/node/test/integration/reject-install-virtual.spec.ts
@@ -136,7 +136,7 @@ describe("Node method follows spec - rejectInstallVirtual", () => {
               proposedAppInstanceC
             );
 
-            expect(proposedAppInstanceC.initiatingAddress).toEqual(
+            expect(proposedAppInstanceC.proposedByIdentifier).toEqual(
               nodeA.publicIdentifier
             );
             expect(proposedAppInstanceA.id).toEqual(proposedAppInstanceC.id);

--- a/packages/node/test/integration/take-action-virtual.spec.ts
+++ b/packages/node/test/integration/take-action-virtual.spec.ts
@@ -207,16 +207,16 @@ describe("Node method follows spec - takeAction", () => {
 });
 
 function makeTTTVirtualAppInstanceProposalReq(
-  respondingAddress: Address,
+  proposedToIdentifier: string,
   appId: Address,
   initialState: SolidityABIEncoderV2Struct,
   abiEncodings: AppABIEncodings,
-  intermediaries: Address[]
+  intermediaries: string[]
 ): NodeTypes.MethodRequest {
   return {
     params: {
       intermediaries,
-      respondingAddress,
+      proposedToIdentifier,
       appId,
       initialState,
       abiEncodings,

--- a/packages/node/test/integration/take-action.spec.ts
+++ b/packages/node/test/integration/take-action.spec.ts
@@ -176,14 +176,14 @@ describe("Node method follows spec - takeAction", () => {
 });
 
 function makeTTTAppInstanceProposalReq(
-  respondingAddress: Address,
+  proposedToIdentifier: string,
   appId: Address,
   initialState: SolidityABIEncoderV2Struct,
   abiEncodings: AppABIEncodings
 ): NodeTypes.MethodRequest {
   return {
     params: {
-      respondingAddress,
+      proposedToIdentifier,
       appId,
       initialState,
       abiEncodings,

--- a/packages/node/test/integration/uninstall-virtual.spec.ts
+++ b/packages/node/test/integration/uninstall-virtual.spec.ts
@@ -163,7 +163,7 @@ describe("Node method follows spec - uninstall", () => {
               proposedAppInstanceC
             );
 
-            expect(proposedAppInstanceC.initiatingAddress).toEqual(
+            expect(proposedAppInstanceC.proposedByIdentifier).toEqual(
               nodeA.publicIdentifier
             );
             expect(proposedAppInstanceA.id).toEqual(proposedAppInstanceC.id);

--- a/packages/node/test/integration/utils.ts
+++ b/packages/node/test/integration/utils.ts
@@ -138,7 +138,7 @@ export function makeRejectInstallRequest(
 }
 
 export function makeInstallProposalRequest(
-  respondingAddress: Address,
+  proposedToIdentifier: string,
   nullInitialState: boolean = false
 ): NodeTypes.MethodRequest {
   let initialState = null;
@@ -151,7 +151,7 @@ export function makeInstallProposalRequest(
   }
 
   const params: NodeTypes.ProposeInstallParams = {
-    respondingAddress,
+    proposedToIdentifier,
     initialState,
     appId: AddressZero,
     abiEncodings: {
@@ -187,12 +187,12 @@ export function makeInstallVirtualRequest(
 }
 
 export function makeInstallVirtualProposalRequest(
-  respondingAddress: string,
+  proposedToIdentifier: string,
   intermediaries: string[],
   nullInitialState: boolean = false
 ): NodeTypes.MethodRequest {
   const installProposalParams = makeInstallProposalRequest(
-    respondingAddress,
+    proposedToIdentifier,
     nullInitialState
   ).params as NodeTypes.ProposeInstallParams;
 

--- a/packages/node/test/unit/utils.ts
+++ b/packages/node/test/unit/utils.ts
@@ -5,15 +5,21 @@ import {
   BlockchainAsset,
   SolidityABIEncoderV2Struct
 } from "@counterfactual/types";
+import { Wallet } from "ethers";
 import { AddressZero, One, Zero } from "ethers/constants";
 import { bigNumberify, getAddress, hexlify, randomBytes } from "ethers/utils";
+import { fromMnemonic } from "ethers/utils/hdnode";
 
 import { ProposedAppInstanceInfo } from "../../src/models";
 
+export function computeRandomXpub() {
+  return fromMnemonic(Wallet.createRandom().mnemonic).neuter().extendedKey;
+}
+
 export function createProposedAppInstanceInfo(appInstanceId: string) {
   return new ProposedAppInstanceInfo(appInstanceId, {
-    initiatingAddress: getAddress(hexlify(randomBytes(20))),
-    respondingAddress: getAddress(hexlify(randomBytes(20))),
+    proposedByIdentifier: computeRandomXpub(),
+    proposedToIdentifier: computeRandomXpub(),
     appId: AddressZero,
     abiEncodings: {
       stateEncoding: "tuple(address foo, uint256 bar)",

--- a/packages/types/src/data-types.ts
+++ b/packages/types/src/data-types.ts
@@ -12,8 +12,8 @@ export type AppInstanceInfo = {
   myDeposit: BigNumber;
   peerDeposit: BigNumber;
   timeout: BigNumber;
-  initiatingAddress: Address;
-  respondingAddress: Address;
+  proposedByIdentifier: Address;
+  proposedToIdentifier: Address;
   intermediaries?: Address[];
 };
 

--- a/packages/types/src/node-protocol.ts
+++ b/packages/types/src/node-protocol.ts
@@ -83,14 +83,14 @@ export namespace Node {
     peerDeposit: BigNumber;
     timeout: BigNumber;
     initialState: SolidityABIEncoderV2Struct;
-    respondingAddress: Address;
+    proposedToIdentifier: string;
   };
   export type ProposeInstallResult = {
     appInstanceId: AppInstanceID;
   };
 
   export type ProposeInstallVirtualParams = ProposeInstallParams & {
-    intermediaries: Address[];
+    intermediaries: string[];
   };
   export type ProposeInstallVirtualResult = ProposeInstallResult;
 
@@ -107,7 +107,7 @@ export namespace Node {
   };
 
   export type InstallVirtualParams = InstallParams & {
-    intermediaries: Address[];
+    intermediaries: string[];
   };
   export type InstallVirtualResult = InstallResult;
 


### PR DESCRIPTION
The fact that `initiatingAddress` and `respondingAddress` were the same variable names for _proposals_ as they are for _actual protocol messages_ was confusing. This makes them explicitly different. Also changed some stale `Address` types to `string` since `xpub...` is not an address.