### PR TITLE
[playground] [dapp-high-roller] [dapp-tic-tac-toe] Fixes proposeInstallVirtual call to use proposedByIdentifier & proposedToIdentifier

### DIFF
--- a/packages/dapp-high-roller/src/components/app-wager/app-wager.tsx
+++ b/packages/dapp-high-roller/src/components/app-wager/app-wager.tsx
@@ -83,7 +83,7 @@ export class AppWager {
 
       await this.appFactory.proposeInstallVirtual({
         initialState,
-        respondingAddress: this.opponent.attributes.nodeAddress as string,
+        proposedToIdentifier: this.opponent.attributes.nodeAddress as string,
         asset: {
           assetType: 0 /* AssetType.ETH */
         },

--- a/packages/dapp-high-roller/src/data/types.ts
+++ b/packages/dapp-high-roller/src/data/types.ts
@@ -309,14 +309,14 @@ export namespace cf {
       provider: cf.Provider
     ): AppFactory;
     proposeInstall(parameters: {
-      respondingAddress: Address;
+      proposedToIdentifier: Address;
       asset: BlockchainAsset;
       myDeposit: BigNumberish;
       peerDeposit: BigNumberish;
       initialState: SolidityABIEncoderV2Struct;
     }): Promise<AppInstanceID>;
     proposeInstallVirtual(parameters: {
-      respondingAddress: Address;
+      proposedToIdentifier: Address;
       asset: BlockchainAsset;
       myDeposit: BigNumberish;
       peerDeposit: BigNumberish;

--- a/packages/dapp-tic-tac-toe/src/Wager.jsx
+++ b/packages/dapp-tic-tac-toe/src/Wager.jsx
@@ -91,7 +91,7 @@ class Wager extends Component {
 
     this.setState({
       appInstance: await appFactory.proposeInstallVirtual({
-        respondingAddress: opponent.nodeAddress,
+        proposedToIdentifier: opponent.nodeAddress,
         asset: {
           assetType: 0 /* AssetType.ETH */
         },

--- a/packages/playground/src/components/node-listener/dialogs/propose-install/dialog-propose-install.tsx
+++ b/packages/playground/src/components/node-listener/dialogs/propose-install/dialog-propose-install.tsx
@@ -20,7 +20,7 @@ export class DialogProposeInstall {
   async componentWillLoad() {
     if (this.message.data) {
       this.user = await PlaygroundAPIClient.getUserByNodeAddress(
-        this.message.data.initiatingAddress
+        this.message.data.proposedByIdentifier
       );
     }
   }


### PR DESCRIPTION
PR #719 renamed the following parameters in the API call for `proposeInstallVirtual`:

- initiatingAddress => proposedByIdentifier
- respondingAddress => proposedToIdentifier

These changes weren't applied to the Playground and the dApps, hence no install proposals could be executed.

This PR applies the new names where necessary.