### PR TITLE
[playground] Removes token if login from token fails

### DIFF
--- a/packages/playground/src/components/layout/layout-header/header-account/header-account.tsx
+++ b/packages/playground/src/components/layout/layout-header/header-account/header-account.tsx
@@ -57,7 +57,13 @@ export class HeaderAccount {
     }
 
     if (!this.user || !this.user.username) {
-      this.updateAccount({ user: await PlaygroundAPIClient.getUser(token) });
+      try {
+        const user = await PlaygroundAPIClient.getUser(token);
+        this.updateAccount({ user });
+      } catch {
+        window.localStorage.removeItem("playground:user:token");
+        return;
+      }
     }
 
     await this.getBalances();


### PR DESCRIPTION
If there's an invalid token stored in `playground:user:token` and the API returns `HTTP 404`, this PR will make the Playground remove that invalid token.