### PR TITLE
[playground-server] Increases Node.js HTTP timeout to 5 minutes

### DIFF
--- a/packages/playground-server/src/index.ts
+++ b/packages/playground-server/src/index.ts
@@ -5,12 +5,17 @@ import NodeWrapper from "./node";
 
 Log.setOutputLevel((process.env.API_LOG_LEVEL as LogLevel) || LogLevel.INFO);
 
+const API_TIMEOUT = 5 * 60 * 1000;
+
 (async () => {
   await NodeWrapper.createNodeSingleton("ropsten");
 
   const api = mountApi();
   const port = process.env.PORT || 9000;
-  await api.listen(port);
+
+  const server = await api.listen(port);
+  server.setTimeout(API_TIMEOUT);
+
   Log.info("API is now ready", { tags: { port } });
 })();
 


### PR DESCRIPTION
Due to the API responding from time to time with an `HTTP 504` error code, we've increased the timeout up to 5 minutes.

This will be a temporary measure as we develop a fully asynchronous version of the registration flow.

:information_source: This PR requires immediate deployment to the server VPS.