### PR TITLE
[playground] Removes network type in <widget-connection>

### DIFF
--- a/packages/playground/src/components/widgets/widget-connection/widget-connection.tsx
+++ b/packages/playground/src/components/widgets/widget-connection/widget-connection.tsx
@@ -3,10 +3,10 @@ import { Component, Element, Prop } from "@stencil/core";
 import NetworkTunnel from "../../../data/network";
 
 const NETWORK_NAMES = {
-  "1": "Ethereum (Mainnet)",
-  "3": "Ropsten (Testnet)",
-  "42": "Kovan (Testnet)",
-  "4": "Rinkeby (Testnet)"
+  "1": "Ethereum",
+  "3": "Ropsten",
+  "42": "Kovan",
+  "4": "Rinkeby"
 };
 @Component({
   tag: "widget-connection",


### PR DESCRIPTION
This PR removes the "Mainnet" / "Testnet" labels next to the network name in the connection status component.

**Before**
![image](https://user-images.githubusercontent.com/118913/52749339-9ff2d600-2fc7-11e9-9552-a8ddb2f165a6.png)

**After**
![image](https://user-images.githubusercontent.com/118913/52749352-a97c3e00-2fc7-11e9-9b08-2af4ffb4265c.png)

