### PR TITLE
[dapp-high-roller] fix: Estimating gas to be done with ethAddress not nodeAddress

### DIFF
--- a/packages/dapp-high-roller/src/components/app-wager/app-wager.tsx
+++ b/packages/dapp-high-roller/src/components/app-wager/app-wager.tsx
@@ -85,7 +85,7 @@ export class AppWager {
       const currentEthBalance = ethers.utils.parseEther(this.account.balance);
       const minimumEthBalance = ethers.utils.parseEther(this.betAmount).add(
         await provider.estimateGas({
-          to: this.opponent.attributes.nodeAddress,
+          to: this.opponent.attributes.ethAddress,
           value: ethers.utils.parseEther(this.betAmount)
         })
       );


### PR DESCRIPTION
### Description

Fix estimating gas to be done with ethAddress not nodeAddress

This was causing an error to be thrown when proposeInstalling in High Roller

- [ ] Deploy preview is functional
