### PR TITLE
[monorepo] Save dependencies cache w/ yarn.lock in key

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ jobs:
       - image: circleci/node:10
     steps:
       - checkout
-      - run: cat packages/*/package.json | shasum > .dependencies_checksum
+      - run: cat packages/*/package.json yarn.lock | shasum > .dependencies_checksum
       - restore_cache:
           key: dependency-cache-{{ checksum ".dependencies_checksum" }}
       - run: yarn
@@ -26,7 +26,7 @@ jobs:
       - image: circleci/node:10
     steps:
       - checkout
-      - run: cat packages/*/package.json | shasum > .dependencies_checksum
+      - run: cat packages/*/package.json yarn.lock | shasum > .dependencies_checksum
       - restore_cache:
           key: dependency-cache-{{ checksum ".dependencies_checksum" }}
       - run: yarn # symlink packages' node_modules
@@ -39,7 +39,7 @@ jobs:
       - image: circleci/node:10-browsers
     steps:
       - checkout
-      - run: cat packages/*/package.json | shasum > .dependencies_checksum
+      - run: cat packages/*/package.json yarn.lock | shasum > .dependencies_checksum
       - restore_cache:
           key: dependency-cache-{{ checksum ".dependencies_checksum" }}
       - run: yarn # symlink packages' node_modules
@@ -56,7 +56,7 @@ jobs:
       - image: circleci/node:10
     steps:
       - checkout
-      - run: cat packages/*/package.json | shasum > .dependencies_checksum
+      - run: cat packages/*/package.json yarn.lock | shasum > .dependencies_checksum
       - restore_cache:
           key: dependency-cache-{{ checksum ".dependencies_checksum" }}
       - attach_workspace:


### PR DESCRIPTION
Reason is that I made changes to `yarn.lock` in #773 but the tests fail because it doesn't pick them up (I did _not_ change any `package.json` files)