### PR TITLE
[monorepo] Get ethers back on semver

### DIFF
--- a/packages/apps/package.json
+++ b/packages/apps/package.json
@@ -27,7 +27,7 @@
     "@types/mocha": "^5.2.5",
     "chai": "^4.2.0",
     "ethereum-waffle": "2.0.5",
-    "ethers": "https://github.com/ethers-io/ethers.js.git",
+    "ethers": "4.0.25",
     "ethlint": "^1.2.3",
     "mocha": "^5.2.0",
     "truffle-deploy-registry": "0.5.1",

--- a/packages/cf.js/package.json
+++ b/packages/cf.js/package.json
@@ -31,7 +31,7 @@
   "dependencies": {
     "@counterfactual/node-provider": "0.0.1",
     "@counterfactual/types": "0.0.1",
-    "ethers": "https://github.com/ethers-io/ethers.js.git",
+    "ethers": "4.0.25",
     "eventemitter3": "^3.1.0"
   },
   "jest": {

--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -35,7 +35,7 @@
     "dotenv": "^6.1.0",
     "eth-gas-reporter": "0.1.12",
     "ethereum-waffle": "2.0.5",
-    "ethers": "https://github.com/ethers-io/ethers.js.git",
+    "ethers": "4.0.25",
     "ethlint": "1.2.3",
     "ganache-cli": "6.3.0",
     "openzeppelin-solidity": "2.1.2",

--- a/packages/machine/package.json
+++ b/packages/machine/package.json
@@ -32,7 +32,7 @@
     "rollup-plugin-typescript2": "^0.19.0",
     "truffle-hdwallet-provider": "^1.0.4",
     "truffle": "5.0.4",
-    "ts-jest": "23.10.5",
+    "ts-jest": "24.0.0",
     "tslint": "^5.11.0",
     "typescript": "^3.1.2",
     "typescript-memoize": "^1.0.0-alpha.3"
@@ -40,7 +40,7 @@
   "peerDependencies": {
     "@counterfactual/contracts": "0.0.3",
     "@counterfactual/types": "0.0.1",
-    "ethers": "https://github.com/ethers-io/ethers.js.git",
+    "ethers": "4.0.25",
     "typescript-memoize": "^1.0.0-alpha.3"
   }
 }

--- a/packages/node-provider/package.json
+++ b/packages/node-provider/package.json
@@ -24,7 +24,7 @@
     "rollup-plugin-commonjs": "^9.2.0",
     "rollup-plugin-node-resolve": "^4.0.0",
     "rollup-plugin-typescript2": "^0.19.0",
-    "ts-jest": "23.10.5",
+    "ts-jest": "24.0.0",
     "tslint": "^5.11.0",
     "typescript": "^3.1.2"
   },

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -26,7 +26,7 @@
     "rollup-plugin-json": "^3.1.0",
     "rollup-plugin-node-resolve": "^4.0.0",
     "rollup-plugin-typescript2": "^0.19.0",
-    "ts-jest": "23.10.5",
+    "ts-jest": "24.0.0",
     "ts-mockito": "^2.3.1",
     "tslint": "^5.11.0",
     "typescript": "^3.1.2"
@@ -36,7 +36,7 @@
     "@counterfactual/contracts": "0.0.3",
     "@counterfactual/machine": "0.0.1",
     "@counterfactual/types": "0.0.1",
-    "ethers": "https://github.com/ethers-io/ethers.js.git",
+    "ethers": "4.0.25",
     "eventemitter3": "^3.1.0",
     "firebase": "5.7.1",
     "uuid": "^3.3.2"

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -11,7 +11,7 @@
     "build": "tsc -p . && rollup -c"
   },
   "devDependencies": {
-    "ethers": "https://github.com/ethers-io/ethers.js.git",
+    "ethers": "4.0.25",
     "rollup-plugin-typescript2": "^0.19.0",
     "rollup": "^1.0.1",
     "typescript": "^3.1.2"

--- a/packages/typescript-typings/package.json
+++ b/packages/typescript-typings/package.json
@@ -12,7 +12,7 @@
   },
   "devDependencies": {
     "copyfiles": "^2.0.0",
-    "ethers": "https://github.com/ethers-io/ethers.js.git",
+    "ethers": "4.0.25",
     "ethereum-waffle": "2.0.5",
     "tslint": "5.12.0",
     "typescript": "^3.1.2"


### PR DESCRIPTION
Previously we pegged it to the github repo because the `HDNode` code wasn't pushed yet.