### PR TITLE
[node] Implement ioDeferral handling based on unique message, not just sender

### DIFF
--- a/packages/node/src/node.ts
+++ b/packages/node/src/node.ts
@@ -46,9 +46,10 @@ export class Node {
   private readonly instructionExecutor: InstructionExecutor;
   private readonly networkContext: NetworkContext;
 
-  private ioSendDeferrals: {
-    [address: string]: Deferred<NodeMessageWrappedProtocolMessage>;
-  } = {};
+  private ioSendDeferrals = new Map<
+    string,
+    Deferred<NodeMessageWrappedProtocolMessage>
+  >();
 
   // These properties don't have initializers in the constructor and get
   // initialized in the `asynchronouslySetupUsingRemoteServices` function
@@ -188,11 +189,12 @@ export class Node {
         const from = this.publicIdentifier;
         const to = data.toAddress;
 
-        this.ioSendDeferrals[to] = new Deferred<
-          NodeMessageWrappedProtocolMessage
-        >();
+        const key = this.encodeProtocolMessage(message);
+        const deferral = new Deferred<NodeMessageWrappedProtocolMessage>();
 
-        const counterpartyResponse = this.ioSendDeferrals[to].promise;
+        this.ioSendDeferrals.set(key, deferral);
+
+        const counterpartyResponse = deferral.promise;
 
         await this.messagingService.send(to, {
           from,
@@ -206,7 +208,7 @@ export class Node {
         // its promise has been resolved and the necessary callback (above)
         // has been called. Note that, as is, only one defferal can be open
         // per counterparty at the moment.
-        delete this.ioSendDeferrals[to];
+        this.ioSendDeferrals.delete(key);
 
         context.inbox.push(msg.data);
 
@@ -339,11 +341,16 @@ export class Node {
       console.error(`Received message with unknown event type: ${msg.type}`);
     }
 
-    const isIoSendDeferral = (msg: NodeMessage) =>
-      msg.type === NODE_EVENTS.PROTOCOL_MESSAGE_EVENT &&
-      this.ioSendDeferrals[msg.from] !== undefined;
+    const isProtocolMessage = (msg: NodeMessage) =>
+      msg.type === NODE_EVENTS.PROTOCOL_MESSAGE_EVENT;
 
-    if (isIoSendDeferral(msg)) {
+    const isExpectingResponse = (msg: NodeMessageWrappedProtocolMessage) =>
+      this.ioSendDeferrals.has(this.encodeProtocolMessage(msg.data));
+
+    if (
+      isProtocolMessage(msg) &&
+      isExpectingResponse(msg as NodeMessageWrappedProtocolMessage)
+    ) {
       this.handleIoSendDeferral(msg as NodeMessageWrappedProtocolMessage);
     } else {
       await this.requestHandler.callEvent(msg.type, msg);
@@ -351,13 +358,30 @@ export class Node {
   }
 
   private async handleIoSendDeferral(msg: NodeMessageWrappedProtocolMessage) {
+    const key = this.encodeProtocolMessage(msg.data);
+
+    if (!this.ioSendDeferrals.has(key)) {
+      throw Error(
+        "Node received message intended for machine but no handler was present"
+      );
+    }
+
+    const promise = this.ioSendDeferrals.get(key)!;
+
     try {
-      this.ioSendDeferrals[msg.from].resolve(msg);
+      promise.resolve(msg);
     } catch (error) {
       console.error(
         `Error while executing callback registered by IO_SEND_AND_WAIT middleware hook`,
         { error, msg }
       );
     }
+  }
+
+  private encodeProtocolMessage(msg: ProtocolMessage) {
+    return JSON.stringify({
+      protocol: msg.protocol,
+      params: JSON.stringify(msg.params, Object.keys(msg.params).sort())
+    });
   }
 }


### PR DESCRIPTION
Can potentially solve some issues with messages being received from the same counterparty that are mistakenly perceived as being intended for an `IO_SEND_AND_WAIT` hook that it is not meant for.