### PR TITLE
[machine] [discussion] runtime validation of message.params

### DIFF
--- a/packages/machine/src/protocol/withdraw-eth.ts
+++ b/packages/machine/src/protocol/withdraw-eth.ts
@@ -13,7 +13,12 @@ import {
   WithdrawETHCommitment
 } from "../ethereum";
 import { AppInstance, StateChannel } from "../models";
-import { Context, ProtocolMessage, WithdrawParams } from "../types";
+import {
+  asWithdrawParams,
+  Context,
+  ProtocolMessage,
+  WithdrawParams
+} from "../types";
 import { xkeyKthAddress } from "../xkeys";
 
 import { verifyInboxLengthEqualTo1 } from "./utils/inbox-validator";
@@ -146,11 +151,9 @@ function addInstallRefundAppCommitmentToContext(
   message: ProtocolMessage,
   context: Context
 ) {
-  const {
-    recipient,
-    amount,
-    multisigAddress
-  } = message.params as WithdrawParams;
+  const { recipient, amount, multisigAddress } = asWithdrawParams(
+    message.params
+  );
 
   const stateChannel = context.stateChannelsMap.get(multisigAddress)!;
 

--- a/packages/machine/src/types.ts
+++ b/packages/machine/src/types.ts
@@ -107,15 +107,7 @@ export function asWithdrawParams(params: ProtocolParameters): WithdrawParams {
     !getAddress(ret.recipient) ||
     !BigNumber.isBigNumber(ret.amount)
   ) {
-    let message: string;
-    try {
-      message = `Expected ${params} to be a WithdrawParam, but it is not`;
-    } catch (e) {
-      throw Error(
-        `Expected params to be a WithdrawParam, but it is not; failed to serialize`
-      );
-    }
-    throw Error(message);
+    throw  Error(`Expected ${params} to be a WithdrawParam, but it is not`);
   }
   return ret;
 }

--- a/packages/machine/src/types.ts
+++ b/packages/machine/src/types.ts
@@ -1,5 +1,5 @@
 import { AppInterface, NetworkContext, Terms } from "@counterfactual/types";
-import { BigNumber, BigNumberish, Signature } from "ethers/utils";
+import { BigNumber, BigNumberish, getAddress, Signature } from "ethers/utils";
 
 import { Opcode, Protocol } from "./enums";
 import { Transaction } from "./ethereum/types";
@@ -89,6 +89,34 @@ export type WithdrawParams = {
   recipient: string;
   amount: BigNumber;
 };
+
+function isValidXpub(s?: string): boolean {
+  if (s === undefined) return false;
+  if (s.slice(0, 4) !== "xpub") {
+    return false;
+  }
+  return true;
+}
+
+export function asWithdrawParams(params: ProtocolParameters): WithdrawParams {
+  const ret = params as WithdrawParams;
+  if (
+    !isValidXpub(ret.initiatingXpub) ||
+    !isValidXpub(ret.respondingXpub) ||
+    !getAddress(ret.multisigAddress) ||
+    !getAddress(ret.recipient) ||
+    !BigNumber.isBigNumber(ret.amount)
+  ) {
+    try {
+      throw Error(`Expected ${params} to be a WithdrawParam, but it is not`);
+    } catch (e) {
+      throw Error(
+        `Expected params to be a WithdrawParam, but it is not; failed to serialize`
+      );
+    }
+  }
+  return ret;
+}
 
 export type InstallParams = {
   initiatingXpub: string;

--- a/packages/machine/src/types.ts
+++ b/packages/machine/src/types.ts
@@ -107,7 +107,7 @@ export function asWithdrawParams(params: ProtocolParameters): WithdrawParams {
     !getAddress(ret.recipient) ||
     !BigNumber.isBigNumber(ret.amount)
   ) {
-    throw  Error(`Expected ${params} to be a WithdrawParam, but it is not`);
+    throw Error(`Expected ${params} to be a WithdrawParam, but it is not`);
   }
   return ret;
 }

--- a/packages/machine/src/types.ts
+++ b/packages/machine/src/types.ts
@@ -107,13 +107,15 @@ export function asWithdrawParams(params: ProtocolParameters): WithdrawParams {
     !getAddress(ret.recipient) ||
     !BigNumber.isBigNumber(ret.amount)
   ) {
+    let message: string;
     try {
-      throw Error(`Expected ${params} to be a WithdrawParam, but it is not`);
+      message = `Expected ${params} to be a WithdrawParam, but it is not`;
     } catch (e) {
       throw Error(
         `Expected params to be a WithdrawParam, but it is not; failed to serialize`
       );
     }
+    throw Error(message);
   }
   return ret;
 }


### PR DESCRIPTION
I don't think any other code is doing runtime validation of this so an invalid message will be caught as late as possible (e.g. when trying to do `new HDNode(undefined)`; this PR proposes one early place to do runtime validation; what do people think?