### PR TITLE
[playground-server] Consumes jsonapi-ts as an NPM package

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -43,7 +43,6 @@ jobs:
       - restore_cache:
           key: dependency-cache-{{ checksum ".dependencies_checksum" }}
       - run: yarn # symlink packages' node_modules
-      - run: yarn global add typescript # until the ebryn/jsonapi-ts no longer needs the global installation
       - attach_workspace:
           at: /home/circleci/project
       - run: cd packages/playground && yarn test

--- a/packages/playground-server/package.json
+++ b/packages/playground-server/package.json
@@ -35,7 +35,7 @@
   "dependencies": {
     "@counterfactual/node": "^0.0.1",
     "@counterfactual/types": "^0.0.1",
-    "@ebryn/jsonapi-ts": "ebryn/jsonapi-ts",
+    "@ebryn/jsonapi-ts": "^0.0.2",
     "@koa/cors": "^2.2.3",
     "escape-string-regexp": "^1.0.5",
     "jsonwebtoken": "^8.4.0",
@@ -58,7 +58,7 @@
     "jest": "^24.0.0",
     "sqlite3": "^4.0.4",
     "ts-node": "^7.0.1",
-    "typescript": "^3.1.2",
-    "tslint": "^5.11.0"
+    "tslint": "^5.11.0",
+    "typescript": "^3.1.2"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -795,13 +795,15 @@
   resolved "https://registry.yarnpkg.com/@csstools/convert-colors/-/convert-colors-1.4.0.tgz#ad495dc41b12e75d588c6db8b9834f08fa131eb7"
   integrity sha512-5a6wqoJV/xEdbRNKVo6I4hO3VjyDq//8q2f9I6PBAvMesJHFauXDorcNCsr9RzvsZnaWi5NYCcfyqP1QeFHFbw==
 
-"@ebryn/jsonapi-ts@ebryn/jsonapi-ts":
-  version "0.0.0"
-  resolved "https://codeload.github.com/ebryn/jsonapi-ts/tar.gz/f7c074bfcebcb4b7515a5d00ac6ea98e2a715a6f"
+"@ebryn/jsonapi-ts@^0.0.2":
+  version "0.0.2"
+  resolved "https://registry.yarnpkg.com/@ebryn/jsonapi-ts/-/jsonapi-ts-0.0.2.tgz#fa303da48468a9f74f326dedefed272326499c76"
+  integrity sha512-Jz8pLv60gKD7IfINGELYmlUvQNZcx1Ngu903l2izm4LmJlYLIGu1Nb61ySR9CVDCIlg//jjQt/pudYEgZhRIxw==
   dependencies:
     "@koa/cors" "^2.2.3"
     camelize "^1.0.0"
     dasherize "^2.0.0"
+    ember-cli-string-utils "^1.1.0"
     escape-string-regexp "^1.0.5"
     jsonwebtoken "^8.4.0"
     knex "~0.16.3"
@@ -1923,6 +1925,11 @@
   version "20.0.1"
   resolved "https://registry.yarnpkg.com/@types/jest-diff/-/jest-diff-20.0.1.tgz#35cc15b9c4f30a18ef21852e255fdb02f6d59b89"
   integrity sha512-yALhelO3i0hqZwhjtcr6dYyaLoCHbAMshwtj6cGxTvHZAKXHsYGdff6E8EPw3xLKY0ELUTQ69Q1rQiJENnccMA==
+
+"@types/jest@23.3.14":
+  version "23.3.14"
+  resolved "https://registry.yarnpkg.com/@types/jest/-/jest-23.3.14.tgz#37daaf78069e7948520474c87b80092ea912520a"
+  integrity sha512-Q5hTcfdudEL2yOmluA1zaSyPbzWPmJ3XfSWeP3RyoYvS9hnje1ZyagrZOuQ6+1nQC1Gw+7gap3pLNL3xL6UBug==
 
 "@types/jest@24.0.6", "@types/jest@^24.0.6":
   version "24.0.6"
@@ -17082,10 +17089,10 @@ tslint-eslint-rules@^5.4.0:
     tslib "1.9.0"
     tsutils "^3.0.0"
 
-tslint-microsoft-contrib@^6.0.0, tslint-microsoft-contrib@~5.2.1:
-  version "6.0.0"
-  resolved "https://registry.yarnpkg.com/tslint-microsoft-contrib/-/tslint-microsoft-contrib-6.0.0.tgz#7bff73c9ad7a0b7eb5cdb04906de58f42a2bf7a2"
-  integrity sha512-R//efwn+34IUjTJeYgNDAJdzG0jyLWIehygPt/PHuZAieTolFVS56FgeFW7DOLap9ghXzMiFPTmDgm54qaL7QA==
+tslint-microsoft-contrib@~5.2.1:
+  version "5.2.1"
+  resolved "https://registry.yarnpkg.com/tslint-microsoft-contrib/-/tslint-microsoft-contrib-5.2.1.tgz#a6286839f800e2591d041ea2800c77487844ad81"
+  integrity sha512-PDYjvpo0gN9IfMULwKk0KpVOPMhU6cNoT9VwCOLeDl/QS8v8W2yspRpFFuUS7/c5EIH/n8ApMi8TxJAz1tfFUA==
   dependencies:
     tsutils "^2.27.2 <2.29.0"
 


### PR DESCRIPTION
We no longer install `@ebryn/jsonapi-ts` as a git dependency. This will remove caching problems we've faced before with this consumption method, as well as enable us to stop installing TypeScript globally on CircleCI.