### PR TITLE
correctly observe web3dectect to ensure that node events are bound

### DIFF
--- a/packages/playground/src/components/node-listener/node-listener.tsx
+++ b/packages/playground/src/components/node-listener/node-listener.tsx
@@ -24,7 +24,7 @@ export class NodeListener {
   @State() private currentErrorType: any;
 
   @Prop() apps: AppDefinition[] = [];
-  @State() networkState: NetworkState = {};
+  @Prop() web3Detected: boolean = false;
   @Prop() history: RouterHistory = {} as RouterHistory;
   @Prop() provider: Web3Provider = {} as Web3Provider;
   @Prop() balance: any;
@@ -40,7 +40,7 @@ export class NodeListener {
   }
 
   async componentWillLoad() {
-    if (this.networkState.web3Detected) {
+    if (this.web3Detected) {
       this.bindNodeEvents();
     }
   }
@@ -190,4 +190,4 @@ export class NodeListener {
 
 AppRegistryTunnel.injectProps(NodeListener, ["apps"]);
 AccountTunnel.injectProps(NodeListener, ["balance", "provider"]);
-NetworkTunnel.injectProps(NodeListener, ["network"]);
+NetworkTunnel.injectProps(NodeListener, ["web3Detected"]);


### PR DESCRIPTION
The modal dialogs weren't opening because `this.networkState.web3Detected` was `undefined` and so `bindNodeEvents` was never running.