### PR TITLE
Move .once to a .on for CREATE_CHANNEL

### DIFF
--- a/packages/cf.js/API_REFERENCE.md
+++ b/packages/cf.js/API_REFERENCE.md
@@ -441,6 +441,8 @@ Note: On the Node calling the creation of the channel, this event _must_ have a 
 Data:
 
 - `CreateChannelResult`
+    - `counterpartyXpub: string`
+        - Xpub of the counterparty that the channel was opened with
     - `multisigAddress: Address`
         - The address of the multisig that was created
     - `owners: Address[]`

--- a/packages/node/src/methods/state-channel/create/controller.ts
+++ b/packages/node/src/methods/state-channel/create/controller.ts
@@ -95,7 +95,11 @@ export default class CreateChannelController extends NodeController {
     const msg: CreateChannelMessage = {
       from: publicIdentifier,
       type: NODE_EVENTS.CREATE_CHANNEL,
-      data: { multisigAddress, owners } as Node.CreateChannelResult
+      data: {
+        multisigAddress,
+        owners,
+        counterpartyXpub: respondingXpub
+      } as Node.CreateChannelResult
     };
 
     await messagingService.send(respondingXpub, msg);

--- a/packages/playground-server/src/db.ts
+++ b/packages/playground-server/src/db.ts
@@ -305,13 +305,13 @@ export async function createUser(user: User): Promise<User> {
 }
 
 export async function bindMultisigToUser(
-  user: User,
+  nodeAddress: string,
   multisigAddress: string
 ): Promise<boolean> {
   const db = getDatabase();
 
   const query = db("users")
-    .where({ id: user.id })
+    .where({ node_address: nodeAddress })
     .update("multisig_address", multisigAddress);
 
   try {

--- a/packages/playground-server/src/resources/user/processor.ts
+++ b/packages/playground-server/src/resources/user/processor.ts
@@ -1,10 +1,8 @@
-import { Node as NodeTypes } from "@counterfactual/types";
 import { Operation, OperationProcessor } from "@ebryn/jsonapi-ts";
 import { sign } from "jsonwebtoken";
 import { Log } from "logepi";
 
 import {
-  bindMultisigToUser,
   bindTransactionHashToUser,
   createUser,
   ethAddressAlreadyRegistered,
@@ -71,10 +69,7 @@ export default class UserProcessor extends OperationProcessor<User> {
     });
 
     const { transactionHash } = await NodeWrapper.createStateChannelFor(
-      nodeAddress as string,
-      async (result: NodeTypes.CreateChannelResult) => {
-        await bindMultisigToUser(newUser, result.multisigAddress);
-      }
+      nodeAddress
     );
 
     newUser.attributes.transactionHash = transactionHash;

--- a/packages/playground-server/test/api.spec.ts
+++ b/packages/playground-server/test/api.spec.ts
@@ -114,27 +114,12 @@ describe("playground-server", () => {
       table.unique(["username"], "uk_users__username");
     });
 
-    NodeWrapper.createStateChannelFor = jest.fn(
-      async (
-        userAddress: string,
-        onChannelCreated: (result: NodeTypes.CreateChannelResult) => void
-      ) => {
-        setTimeout(
-          () =>
-            onChannelCreated({
-              multisigAddress: "0xc5F6047a22A5582f62dBcD278f1A2275ab39001A",
-              owners: [playgroundNode.publicIdentifier, userAddress],
-              counterpartyXpub: userAddress
-            }),
-          100
-        );
-
-        return Promise.resolve({
-          transactionHash:
-            "0xf517872f3c466c2e1520e35ad943d833fdca5a6739cfea9e686c4c1b3ab1022e"
-        } as NodeTypes.CreateChannelTransactionResult);
-      }
-    );
+    NodeWrapper.createStateChannelFor = jest.fn(async (userAddress: string) => {
+      return Promise.resolve({
+        transactionHash:
+          "0xf517872f3c466c2e1520e35ad943d833fdca5a6739cfea9e686c4c1b3ab1022e"
+      } as NodeTypes.CreateChannelTransactionResult);
+    });
   });
 
   beforeAll(done => {

--- a/packages/playground-server/test/api.spec.ts
+++ b/packages/playground-server/test/api.spec.ts
@@ -123,7 +123,8 @@ describe("playground-server", () => {
           () =>
             onChannelCreated({
               multisigAddress: "0xc5F6047a22A5582f62dBcD278f1A2275ab39001A",
-              owners: [playgroundNode.publicIdentifier, userAddress]
+              owners: [playgroundNode.publicIdentifier, userAddress],
+              counterpartyXpub: userAddress
             }),
           100
         );

--- a/packages/types/src/node-protocol.ts
+++ b/packages/types/src/node-protocol.ts
@@ -188,6 +188,7 @@ export namespace Node {
   export type CreateChannelResult = {
     multisigAddress: string;
     owners: string[];
+    counterpartyXpub: string;
   };
 
   export type GetChannelAddressesParams = {};


### PR DESCRIPTION
The usage of `.once` was wrong. The playground server needs to listen to all `CREATE_CHANNEL` events and handle them accordingly to bind actual on-chain deployed addresses to `User` objects.

Included in this PR is a MVP of this functionality. Perhaps not the optimal design, but it works.