### PR TITLE
[playground] [node-provider] Shows error screen if LocalStorage is not available

### DIFF
--- a/packages/node-provider/src/node-provider.ts
+++ b/packages/node-provider/src/node-provider.ts
@@ -38,20 +38,39 @@ export default class NodeProvider implements INodeProvider {
         };
       }
     } catch {
-      if (window.localStorage.getItem("cf:node-provider:debug") === "true") {
-        this.debugMode = "browser";
-        this.debugEmitter = (source: string, message: string, data?: any) => {
-          console.log(
-            ["%c[NodeProvider]", `%c#${source}()`, `%c${message}`].join(" "),
-            "color: gray;",
-            "color: green;",
-            "color: black;"
-          );
+      try {
+        if (window.localStorage.getItem("cf:node-provider:debug") === "true") {
+          this.debugMode = "browser";
+          this.debugEmitter = (source: string, message: string, data?: any) => {
+            console.log(
+              ["%c[NodeProvider]", `%c#${source}()`, `%c${message}`].join(" "),
+              "color: gray;",
+              "color: green;",
+              "color: black;"
+            );
 
-          if (data) {
-            console.log("   ", data);
-          }
-        };
+            if (data) {
+              console.log("   ", data);
+            }
+          };
+        }
+      } catch {
+        // Fallback to allow debugging without Local Storage flag.
+        if (window.location.href.includes("#cf:node-provider:debug")) {
+          this.debugMode = "browser";
+          this.debugEmitter = (source: string, message: string, data?: any) => {
+            console.log(
+              ["%c[NodeProvider]", `%c#${source}()`, `%c${message}`].join(" "),
+              "color: gray;",
+              "color: green;",
+              "color: black;"
+            );
+
+            if (data) {
+              console.log("   ", data);
+            }
+          };
+        }
       }
     }
   }

--- a/packages/playground/src/components/app-home/app-home/app-home.scss
+++ b/packages/playground/src/components/app-home/app-home/app-home.scss
@@ -1,3 +1,7 @@
+:host {
+  width: 100%;
+}
+
 button {
   background: #5851ff;
   color: white;
@@ -8,15 +12,15 @@ button {
   text-transform: uppercase;
   padding: 16px 20px;
   border-radius: 2px;
-  box-shadow: 0 8px 16px rgba(0,0,0,.1), 0 3px 6px rgba(0,0,0,.08);
+  box-shadow: 0 8px 16px rgba(0, 0, 0, 0.1), 0 3px 6px rgba(0, 0, 0, 0.08);
   outline: 0;
-  letter-spacing: .04em;
-  transition: all .15s ease;
+  letter-spacing: 0.04em;
+  transition: all 0.15s ease;
   cursor: pointer;
 }
 
 button:hover {
-  box-shadow: 0 3px 6px rgba(0,0,0,.1), 0 1px 3px rgba(0,0,0,.1);
+  box-shadow: 0 3px 6px rgba(0, 0, 0, 0.1), 0 1px 3px rgba(0, 0, 0, 0.1);
   transform: translateY(1px);
 }
 
@@ -29,11 +33,11 @@ button:hover {
   display: flex;
   align-items: center;
   flex-direction: column;
-  width: 80%;
+  width: 50%;
   position: absolute;
   top: 50%;
   left: 50%;
-  transform: translate(-50%,-50%);
+  transform: translate(-50%, -50%);
   text-align: center;
 
   h1 {
@@ -43,7 +47,7 @@ button:hover {
   h2 {
     font-size: 1.5rem;
     font-weight: 400;
-    color: #555555
+    color: #555555;
   }
 }
 
@@ -55,7 +59,7 @@ button:hover {
   position: absolute;
   top: 50%;
   left: 50%;
-  transform: translate(-50%,-50%);
+  transform: translate(-50%, -50%);
   text-align: center;
   font-size: 3rem;
   font-weight: 600;
@@ -69,7 +73,7 @@ button:hover {
   .spinner > div {
     width: 18px;
     height: 18px;
-    background-color: $c-darkgrey;;
+    background-color: $c-darkgrey;
 
     border-radius: 100%;
     display: inline-block;
@@ -88,18 +92,26 @@ button:hover {
   }
 
   @-webkit-keyframes sk-bouncedelay {
-    0%, 80%, 100% { -webkit-transform: scale(0) }
-    40% { -webkit-transform: scale(1.0) }
-  }
-
-  @keyframes sk-bouncedelay {
-    0%, 80%, 100% {
+    0%,
+    80%,
+    100% {
       -webkit-transform: scale(0);
-      transform: scale(0);
-    } 40% {
-      -webkit-transform: scale(1.0);
-      transform: scale(1.0);
+    }
+    40% {
+      -webkit-transform: scale(1);
     }
   }
 
+  @keyframes sk-bouncedelay {
+    0%,
+    80%,
+    100% {
+      -webkit-transform: scale(0);
+      transform: scale(0);
+    }
+    40% {
+      -webkit-transform: scale(1);
+      transform: scale(1);
+    }
+  }
 }

--- a/packages/playground/src/components/app-home/app-home/app-home.tsx
+++ b/packages/playground/src/components/app-home/app-home/app-home.tsx
@@ -18,6 +18,8 @@ export class AppHome {
   @Prop() web3Detected: boolean = false;
   @Prop() hasDetectedNetwork: boolean = false;
   @Prop() networkPermitted: boolean = false;
+
+  @Prop() hasLocalStorage: boolean = false;
   @State() runningApps: AppDefinition[] = [];
 
   appClickedHandler(e) {
@@ -29,53 +31,177 @@ export class AppHome {
     this.runningApps = [{ ...this.apps[0], notifications: 11 }];
   }
 
-  render() {
-    let content;
+  checkLocalStorage() {
+    if (this.hasLocalStorage) {
+      return;
+    }
 
-    if (!this.hasDetectedNetwork) {
-      content = (
-        <div class="loading">
-          <div class="spinner">
-            <div class="bounce1" />
-            <div class="bounce2" />
-            <div class="bounce3" />
-          </div>
-        </div>
-      );
-    } else if (!this.web3Detected) {
-      content = (
-        <div class="error-message">
-          <h1>404: Wallet Not Found :(</h1>
-          <h2>
-            This demo has been designed to be used with a Web3-compatible wallet
-            such as <a href="https://metamask.io/">Metamask</a> to function.
-            Please enable or download one to continue!
-          </h2>
-        </div>
-      );
-    } else if (!this.networkPermitted) {
-      content = (
-        <div class="error-message">
-          <h1>Please Switch to Ropsten</h1>
-          <h2>
-            The Playground demo is currently only deployed on the Ropsten test
-            network. Please switch to continue.
-          </h2>
-        </div>
-      );
+    const texts = {
+      brave: {
+        title: "Please, lower your Shields!",
+        instruction: (
+          <span>
+            Please, turn off the \"Shields Up\" feature for this site to
+            continue.
+          </span>
+        )
+      },
+      chrome: {
+        title: "Please, allow site data!",
+        instruction: (
+          <span>
+            Please, unblock <i>Cookies</i> in your settings, under{" "}
+            <i>Privacy → Content settings</i>.
+          </span>
+        )
+      },
+      edge: {
+        title: "Please, unblock us!",
+        instruction: (
+          <span>
+            Please, uncheck the <i>Block all cookies</i> option in your
+            settings, under <i>Advanced Settings → Cookies</i>.
+          </span>
+        )
+      },
+      firefox: {
+        title: "Please, enable DOM Storage!",
+        instruction: (
+          <span>
+            Please, set the <code>dom.storage.enabled</code> key to{" "}
+            <code>true</code> in your <code>about:config</code> screen.
+          </span>
+        )
+      },
+      safari: {
+        title: "Please, unblock us!",
+        instruction: (
+          <span>
+            Please, uncheck the <i>Always block</i> option in your settings,
+            under <i>Preferences → Privacy → Cookies and website data</i>.
+          </span>
+        )
+      },
+      default: {
+        title: "Please, allow us to store data",
+        instruction: (
+          <span>
+            The Playground demo uses Local Storage to work properly. Please,
+            configure your browser to grant us access.
+          </span>
+        )
+      }
+    };
+
+    let text: { title: string; instruction: JSX.Element } = {} as {
+      title: string;
+      instruction: JSX.Element;
+    };
+
+    if (navigator.userAgent.indexOf("brave") >= 0) {
+      text = texts.brave;
+    } else if (
+      navigator.userAgent.indexOf("Chrome") >= 0 &&
+      navigator.vendor.indexOf("Google") >= 0
+    ) {
+      text = texts.chrome;
+    } else if (navigator.userAgent.indexOf("Edge") >= 0) {
+      text = texts.edge;
+    } else if (navigator.userAgent.indexOf("Safari") >= 0) {
+      text = texts.safari;
+    } else if (navigator.userAgent.indexOf("Firefox") >= 0) {
+      text = texts.firefox;
     } else {
-      content = (
-        <div class="container">
-          <apps-list
-            apps={this.apps}
-            onAppClicked={e => this.appClickedHandler(e)}
-            name="Available Apps"
-          />
-        </div>
-      );
+      text = texts.default;
     }
 
     return (
+      <div class="error-message">
+        <h1>{text.title}</h1>
+        <h2>
+          The Playground Demo uses Local Storage to work properly.{" "}
+          {text.instruction}
+        </h2>
+        <p>
+          <strong>What do we store?</strong> Basic information the demo needs to
+          work, such as a mnemonic key to generate the address for your local
+          Node instance, and the data the Node itself stores about the activity
+          in the state channels you are part of.
+        </p>
+      </div>
+    );
+  }
+
+  checkDetectedNetwork() {
+    if (this.hasDetectedNetwork) {
+      return;
+    }
+
+    return (
+      <div class="loading">
+        <div class="spinner">
+          <div class="bounce1" />
+          <div class="bounce2" />
+          <div class="bounce3" />
+        </div>
+      </div>
+    );
+  }
+
+  checkWeb3Detected() {
+    if (this.web3Detected) {
+      return;
+    }
+
+    return (
+      <div class="error-message">
+        <h1>404: Wallet Not Found :(</h1>
+        <h2>
+          This demo has been designed to be used with a Web3-compatible wallet
+          such as <a href="https://metamask.io/">Metamask</a> to function.
+          Please enable or download one to continue!
+        </h2>
+      </div>
+    );
+  }
+
+  checkNetworkPermitted() {
+    if (this.networkPermitted) {
+      return;
+    }
+
+    return (
+      <div class="error-message">
+        <h1>Please Switch to Ropsten</h1>
+        <h2>
+          The Playground demo is currently only deployed on the Ropsten test
+          network. Please switch to continue.
+        </h2>
+      </div>
+    );
+  }
+
+  showApps() {
+    return (
+      <div class="container">
+        <apps-list
+          apps={this.apps}
+          onAppClicked={e => this.appClickedHandler(e)}
+          name="Available Apps"
+        />
+      </div>
+    );
+  }
+
+  render() {
+    const content =
+      this.checkLocalStorage() ||
+      this.checkDetectedNetwork() ||
+      this.checkWeb3Detected() ||
+      this.checkNetworkPermitted() ||
+      this.showApps();
+
+    return this.hasLocalStorage ? (
       <node-listener history={this.history}>
         <layout-header />
         <section class="section fill">
@@ -83,6 +209,14 @@ export class AppHome {
           {/* <apps-list apps={this.runningApps} name="Running Apps" /> */}
         </section>
       </node-listener>
+    ) : (
+      <div>
+        <layout-header />
+        <section class="section fill">
+          {content}
+          {/* <apps-list apps={this.runningApps} name="Running Apps" /> */}
+        </section>
+      </div>
     );
   }
 }

--- a/packages/playground/src/components/app-home/app-home/app-home.tsx
+++ b/packages/playground/src/components/app-home/app-home/app-home.tsx
@@ -41,7 +41,7 @@ export class AppHome {
         title: "Please, lower your Shields!",
         instruction: (
           <span>
-            Please, turn off the \"Shields Up\" feature for this site to
+            Please, turn off the <i>Shields Up</i> feature for this site to
             continue.
           </span>
         )

--- a/packages/playground/src/components/app-root/app-root.tsx
+++ b/packages/playground/src/components/app-root/app-root.tsx
@@ -27,10 +27,20 @@ export class AppRoot {
   @State() accountState: AccountState = {} as AccountState;
   @State() walletState: WalletState = {};
   @State() appRegistryState: AppRegistryState = { apps: [] };
+  @State() hasLocalStorage: boolean = false;
 
   modal: JSX.Element = <div />;
 
   componentWillLoad() {
+    // Test for Local Storage.
+    try {
+      localStorage.setItem("playground:localStorage", "true");
+      localStorage.removeItem("playground:localStorage");
+      this.hasLocalStorage = true;
+    } catch {
+      this.hasLocalStorage = false;
+    }
+
     this.setup();
   }
 
@@ -78,6 +88,10 @@ export class AppRoot {
   }
 
   async createNodeProvider() {
+    if (!this.hasLocalStorage) {
+      return;
+    }
+
     // TODO: This is a dummy firebase data provider.
     // TODO: This configuration should come from the backend.
     let configuration: FirebaseAppConfiguration = {
@@ -408,25 +422,39 @@ export class AppRoot {
           <AppRegistryTunnel.Provider state={this.appRegistryState}>
             <div class="app-root wrapper">
               <main class="wrapper__content">
-                <stencil-router>
-                  <stencil-route-switch scrollTopOffset={0}>
-                    <stencil-route url="/" component="app-home" exact={true} />
-                    <stencil-route
-                      url="/dapp/:dappName"
-                      component="dapp-container"
-                    />
-                    <stencil-route url="/account" component="account-edit" />
-                    <stencil-route
-                      url="/exchange"
-                      component="account-exchange"
-                    />
-                    <stencil-route
-                      url="/register"
-                      component="account-register"
-                    />
-                    <stencil-route url="/deposit" component="account-deposit" />
-                  </stencil-route-switch>
-                </stencil-router>
+                {this.hasLocalStorage ? (
+                  <stencil-router>
+                    <stencil-route-switch scrollTopOffset={0}>
+                      <stencil-route
+                        url="/"
+                        component="app-home"
+                        exact={true}
+                        componentProps={{
+                          hasLocalStorage: this.hasLocalStorage
+                        }}
+                      />
+                      <stencil-route
+                        url="/dapp/:dappName"
+                        component="dapp-container"
+                      />
+                      <stencil-route url="/account" component="account-edit" />
+                      <stencil-route
+                        url="/exchange"
+                        component="account-exchange"
+                      />
+                      <stencil-route
+                        url="/register"
+                        component="account-register"
+                      />
+                      <stencil-route
+                        url="/deposit"
+                        component="account-deposit"
+                      />
+                    </stencil-route-switch>
+                  </stencil-router>
+                ) : (
+                  <app-home hasLocalStorage={this.hasLocalStorage} />
+                )}
               </main>
               <webthree-connector
                 accountState={this.accountState}


### PR DESCRIPTION
This PR implements feature detection code for Local Storage. It also includes UA sniffing to attempt to guide the user in the correct way to disable whatever is blocking LS from being used. 

For the Node Provider, it enables a third debug-mode by scanning the URL for the hash `#cf:node-provider:debug`. 

:thought_balloon: _Fun fact:_ Stencil Router relies on Session Storage to work, so in order to show the error screen, it was necessary to bypass the router altogether and forcefully render the `app-home` component. Also, since everything is wrapped on the `node-listener` component, which also uses LS, if it's not enabled, the component isn't rendered.

**Example screen on Chrome:**
![image](https://user-images.githubusercontent.com/118913/53349506-064af300-38fc-11e9-9d5f-513578837b52.png)
