### PR TITLE
[playground] Move provider and signer into WalletState

### DIFF
--- a/packages/playground/src/components/account/account-deposit/account-deposit.tsx
+++ b/packages/playground/src/components/account/account-deposit/account-deposit.tsx
@@ -4,6 +4,7 @@ import { RouterHistory } from "@stencil/router";
 
 import AccountTunnel from "../../../data/account";
 import CounterfactualNode from "../../../data/counterfactual";
+import WalletTunnel from "../../../data/wallet";
 import { UserSession } from "../../../types";
 
 @Component({
@@ -82,9 +83,5 @@ export class AccountDeposit {
   }
 }
 
-AccountTunnel.injectProps(AccountDeposit, [
-  "balance",
-  "updateAccount",
-  "user",
-  "signer"
-]);
+AccountTunnel.injectProps(AccountDeposit, ["balance", "updateAccount", "user"]);
+WalletTunnel.injectProps(AccountDeposit, ["signer"]);

--- a/packages/playground/src/components/account/account-register/account-register.tsx
+++ b/packages/playground/src/components/account/account-register/account-register.tsx
@@ -220,6 +220,6 @@ export class AccountRegister {
   }
 }
 
-AccountTunnel.injectProps(AccountRegister, ["updateAccount", "user", "signer"]);
+AccountTunnel.injectProps(AccountRegister, ["updateAccount", "user"]);
 
-WalletTunnel.injectProps(AccountRegister, ["connected"]);
+WalletTunnel.injectProps(AccountRegister, ["connected", "signer"]);

--- a/packages/playground/src/components/app-root/app-root.tsx
+++ b/packages/playground/src/components/app-root/app-root.tsx
@@ -49,7 +49,7 @@ export class AppRoot {
     this.bindProviderEvents();
   }
 
-  async updateNetwork(newProps: WalletState) {
+  async updateWalletConnection(newProps: WalletState) {
     this.walletState = { ...this.walletState, ...newProps };
   }
 
@@ -102,6 +102,7 @@ export class AppRoot {
       storageBucket: "foobar-91a31.appspot.com",
       messagingSenderId: "432199632441"
     };
+
     if (TIER === "dev") {
       configuration = {
         databaseURL: `ws://${FIREBASE_SERVER_HOST}:${FIREBASE_SERVER_PORT}`,
@@ -112,11 +113,13 @@ export class AppRoot {
         messagingSenderId: ""
       };
     }
+
     FirebaseDataProvider.create(configuration);
 
     const messagingService = FirebaseDataProvider.createMessagingService(
       "messaging"
     );
+
     const storeService = {
       // This implements partial path look ups for localStorage
       async get(desiredKey: string): Promise<any> {
@@ -170,7 +173,8 @@ export class AppRoot {
   }
 
   bindProviderEvents() {
-    const { provider, user } = this.accountState;
+    const { user } = this.accountState;
+    const { provider } = this.walletState;
 
     if (!provider) {
       return;
@@ -194,7 +198,9 @@ export class AppRoot {
   }
 
   async login() {
-    const { signer, user } = this.accountState;
+    const { user } = this.accountState;
+    const { signer } = this.walletState;
+
     const signature = await signer.signMessage(
       this.buildSignatureMessageForLogin(user.ethAddress)
     );
@@ -219,7 +225,8 @@ export class AppRoot {
   }
 
   async getBalances() {
-    const { user, provider } = this.accountState;
+    const { user } = this.accountState;
+    const { provider } = this.walletState;
 
     if (!user.multisigAddress || !user.ethAddress) {
       return;
@@ -311,7 +318,8 @@ export class AppRoot {
   }
 
   waitForMultisig() {
-    const { provider, user } = this.accountState;
+    const { user } = this.accountState;
+    const { provider } = this.walletState;
 
     provider.once(user.transactionHash, async () => {
       await this.fetchMultisig();
@@ -409,7 +417,9 @@ export class AppRoot {
       withdraw: this.withdraw.bind(this)
     };
 
-    this.walletState.updateNetwork = this.updateNetwork.bind(this);
+    this.walletState.updateWalletConnection = this.updateWalletConnection.bind(
+      this
+    );
     this.appRegistryState.updateAppRegistry = this.updateAppRegistry.bind(this);
 
     if (this.loading) {

--- a/packages/playground/src/components/node-listener/node-listener.tsx
+++ b/packages/playground/src/components/node-listener/node-listener.tsx
@@ -191,5 +191,5 @@ export class NodeListener {
 }
 
 AppRegistryTunnel.injectProps(NodeListener, ["apps"]);
-AccountTunnel.injectProps(NodeListener, ["balance", "provider"]);
-WalletTunnel.injectProps(NodeListener, ["web3Detected"]);
+AccountTunnel.injectProps(NodeListener, ["balance"]);
+WalletTunnel.injectProps(NodeListener, ["web3Detected", "provider"]);

--- a/packages/playground/src/data/account.tsx
+++ b/packages/playground/src/data/account.tsx
@@ -9,8 +9,6 @@ export type AccountState = {
   accountBalance?: number;
   balance?: number;
   unconfirmedBalance?: number;
-  provider: Web3Provider;
-  signer: Signer;
   pendingAccountFunding?: any;
 
   updateAccount?(data: AccountState): Promise<void>;

--- a/packages/playground/src/data/counterfactual.ts
+++ b/packages/playground/src/data/counterfactual.ts
@@ -23,6 +23,7 @@ export declare class Node {
     req: NodeTypes.MethodRequest
   ): Promise<NodeTypes.MethodResponse>;
 }
+
 export interface NodeConfig {
   STORE_KEY_PREFIX: string;
 }
@@ -49,8 +50,7 @@ export default class CounterfactualNode {
       settings.messagingService,
       settings.storeService,
       settings.nodeConfig,
-      // @ts-ignore
-      new ethers.providers.Web3Provider(web3.currentProvider),
+      new ethers.providers.Web3Provider(window["web3"].currentProvider),
       settings.network
     );
 

--- a/packages/playground/src/data/wallet.tsx
+++ b/packages/playground/src/data/wallet.tsx
@@ -1,6 +1,8 @@
 import { createProviderConsumer } from "@stencil/state-tunnel";
 
 export interface WalletState {
+  signer?: Signer;
+  provider?: Web3Provider;
   hasDetectedNetwork?: boolean;
   network?: string;
   connected?: boolean;
@@ -8,15 +10,9 @@ export interface WalletState {
   web3Enabled?: boolean;
   metamaskUnlocked?: boolean;
   networkPermitted?: boolean;
-  updateNetwork?(data: WalletState): Promise<void>;
+  updateWalletConnection?(data: WalletState): Promise<void>;
 }
 
-export default createProviderConsumer<WalletState>(
-  {
-    network: "Unknown network",
-    web3Detected: typeof window["web3"] !== undefined
-  },
-  (subscribe, child) => (
-    <context-consumer subscribe={subscribe} renderer={child} />
-  )
-);
+export default createProviderConsumer<WalletState>({}, (subscribe, child) => (
+  <context-consumer subscribe={subscribe} renderer={child} />
+));


### PR DESCRIPTION
Incremental PR. Makes sense for `provider` and `signer` to be properties of the wallet and not of the account (which represents your account with the `playground-server`)

- [x] Deploy preview is functional
