### PR TITLE
[machine,node] commitment store cleanup

### DIFF
--- a/packages/machine/src/enums.ts
+++ b/packages/machine/src/enums.ts
@@ -2,7 +2,7 @@ enum Opcode {
   /**
    * Called at the end of execution before the return value to store a commitment
    */
-  STATE_TRANSITION_COMMIT,
+  WRITE_COMMITMENT,
 
   /**
    * Requests a signature on the hash of previously generated EthereumCommitments.

--- a/packages/machine/src/index.ts
+++ b/packages/machine/src/index.ts
@@ -14,6 +14,12 @@ import {
   ProtocolExecutionFlow,
   ProtocolMessage,
   SetupParams,
+  InstallParams,
+  UpdateParams,
+  UninstallParams,
+  WithdrawParams,
+  InstallVirtualAppParams,
+  UninstallVirtualAppParams,
   Transaction
 } from "./types";
 import {
@@ -39,6 +45,12 @@ export {
   ProtocolExecutionFlow,
   ProtocolMessage,
   SetupParams,
+  InstallParams,
+  UpdateParams,
+  UninstallParams,
+  WithdrawParams,
+  InstallVirtualAppParams,
+  UninstallVirtualAppParams,
   Transaction,
   xkeyKthAddress,
   xkeyKthHDNode,

--- a/packages/machine/src/index.ts
+++ b/packages/machine/src/index.ts
@@ -9,18 +9,18 @@ import {
 } from "./models";
 import {
   Context,
+  InstallParams,
+  InstallVirtualAppParams,
   Instruction,
   Middleware,
   ProtocolExecutionFlow,
   ProtocolMessage,
   SetupParams,
-  InstallParams,
-  UpdateParams,
+  Transaction,
   UninstallParams,
-  WithdrawParams,
-  InstallVirtualAppParams,
   UninstallVirtualAppParams,
-  Transaction
+  UpdateParams,
+  WithdrawParams
 } from "./types";
 import {
   xkeyKthAddress,

--- a/packages/machine/src/middleware.ts
+++ b/packages/machine/src/middleware.ts
@@ -7,7 +7,7 @@ export class MiddlewareContainer {
     [Opcode.IO_SEND_AND_WAIT]: [],
     [Opcode.OP_SIGN]: [],
     [Opcode.OP_SIGN_AS_INTERMEDIARY]: [],
-    [Opcode.STATE_TRANSITION_COMMIT]: []
+    [Opcode.WRITE_COMMITMENT]: []
   };
 
   public add(scope: Opcode, method: Middleware) {

--- a/packages/machine/src/protocol/install-virtual-app.ts
+++ b/packages/machine/src/protocol/install-virtual-app.ts
@@ -93,7 +93,7 @@ export const INSTALL_VIRTUAL_APP_PROTOCOL: ProtocolExecutionFlow = {
       );
     },
 
-    Opcode.STATE_TRANSITION_COMMIT
+    Opcode.WRITE_COMMITMENT
   ],
 
   1: [
@@ -176,7 +176,7 @@ export const INSTALL_VIRTUAL_APP_PROTOCOL: ProtocolExecutionFlow = {
 
     Opcode.IO_SEND,
 
-    Opcode.STATE_TRANSITION_COMMIT
+    Opcode.WRITE_COMMITMENT
   ],
 
   2: [
@@ -230,7 +230,7 @@ export const INSTALL_VIRTUAL_APP_PROTOCOL: ProtocolExecutionFlow = {
       );
     },
 
-    Opcode.STATE_TRANSITION_COMMIT
+    Opcode.WRITE_COMMITMENT
   ]
 };
 
@@ -281,7 +281,7 @@ function createAndAddTarget(
 
   context.stateChannelsMap.set(key, newSc);
 
-  // Needed for STATE_TRANSITION_COMMIT presently
+  // Needed for WRITE_COMMITMENT presently
   context.appIdentityHash = target.identityHash;
 
   return target;

--- a/packages/machine/src/protocol/install.ts
+++ b/packages/machine/src/protocol/install.ts
@@ -47,7 +47,7 @@ export const INSTALL_PROTOCOL: ProtocolExecutionFlow = {
       ),
 
     // Consider the state transition finished and commit it
-    Opcode.STATE_TRANSITION_COMMIT
+    Opcode.WRITE_COMMITMENT
   ],
 
   1: [
@@ -72,7 +72,7 @@ export const INSTALL_PROTOCOL: ProtocolExecutionFlow = {
     Opcode.IO_SEND,
 
     // Consider the state transition finished and commit it
-    Opcode.STATE_TRANSITION_COMMIT
+    Opcode.WRITE_COMMITMENT
   ]
 };
 

--- a/packages/machine/src/protocol/setup.ts
+++ b/packages/machine/src/protocol/setup.ts
@@ -79,7 +79,7 @@ export const SETUP_PROTOCOL: ProtocolExecutionFlow = {
 
     (message: ProtocolMessage, context: Context) => {
       context.finalCommitment = context.commitments[0].transaction([
-        context.inbox[0].signature!,
+        message.signature!,
         context.signatures[0]
       ]);
     },

--- a/packages/machine/src/protocol/setup.ts
+++ b/packages/machine/src/protocol/setup.ts
@@ -45,6 +45,13 @@ export const SETUP_PROTOCOL: ProtocolExecutionFlow = {
         context.inbox[0].signature
       ),
 
+    (message: ProtocolMessage, context: Context) => {
+      context.finalCommitment = context.commitments[0].transaction([
+        context.inbox[0].signature!,
+        context.signatures[0]
+      ]);
+    },
+
     // Consider the state transition finished and commit it
     Opcode.WRITE_COMMITMENT
   ],
@@ -70,6 +77,13 @@ export const SETUP_PROTOCOL: ProtocolExecutionFlow = {
     // Send the message to your counterparty
     Opcode.IO_SEND,
 
+    (message: ProtocolMessage, context: Context) => {
+      context.finalCommitment = context.commitments[0].transaction([
+        context.inbox[0].signature!,
+        context.signatures[0]
+      ]);
+    },
+
     // Consider the state transition finished and commit it
     Opcode.WRITE_COMMITMENT
   ]
@@ -93,10 +107,13 @@ function proposeStateTransition(message: ProtocolMessage, context: Context) {
   );
 
   context.stateChannelsMap.set(multisigAddress, newStateChannel);
-  context.commitments[0] = constructSetupOp(context.network, newStateChannel);
+  context.commitments[0] = constructSetupCommitment(
+    context.network,
+    newStateChannel
+  );
 }
 
-export function constructSetupOp(
+export function constructSetupCommitment(
   network: NetworkContext,
   stateChannel: StateChannel
 ) {

--- a/packages/machine/src/protocol/setup.ts
+++ b/packages/machine/src/protocol/setup.ts
@@ -17,8 +17,7 @@ import { validateSignature } from "./utils/signature-validator";
 /**
  * @description This exchange is described at the following URL:
  *
- * specs.counterfactual.com/04-setup-protocol#messages
- *
+ * specs.counterfactual.com/04-setup-protocol
  */
 export const SETUP_PROTOCOL: ProtocolExecutionFlow = {
   0: [
@@ -47,7 +46,7 @@ export const SETUP_PROTOCOL: ProtocolExecutionFlow = {
       ),
 
     // Consider the state transition finished and commit it
-    Opcode.STATE_TRANSITION_COMMIT
+    Opcode.WRITE_COMMITMENT
   ],
 
   1: [
@@ -72,7 +71,7 @@ export const SETUP_PROTOCOL: ProtocolExecutionFlow = {
     Opcode.IO_SEND,
 
     // Consider the state transition finished and commit it
-    Opcode.STATE_TRANSITION_COMMIT
+    Opcode.WRITE_COMMITMENT
   ]
 };
 

--- a/packages/machine/src/protocol/uninstall.ts
+++ b/packages/machine/src/protocol/uninstall.ts
@@ -51,7 +51,7 @@ export const UNINSTALL_PROTOCOL: ProtocolExecutionFlow = {
       ),
 
     // Consider the state transition finished and commit it
-    Opcode.STATE_TRANSITION_COMMIT
+    Opcode.WRITE_COMMITMENT
   ],
 
   1: [
@@ -76,7 +76,7 @@ export const UNINSTALL_PROTOCOL: ProtocolExecutionFlow = {
     Opcode.IO_SEND,
 
     // Consider the state transition finished and commit it
-    Opcode.STATE_TRANSITION_COMMIT
+    Opcode.WRITE_COMMITMENT
   ]
 };
 

--- a/packages/machine/src/protocol/update.ts
+++ b/packages/machine/src/protocol/update.ts
@@ -57,7 +57,7 @@ export const UPDATE_PROTOCOL: ProtocolExecutionFlow = {
     },
 
     // Consider the state transition finished and commit it
-    Opcode.STATE_TRANSITION_COMMIT
+    Opcode.WRITE_COMMITMENT
   ],
 
   1: [
@@ -92,7 +92,7 @@ export const UPDATE_PROTOCOL: ProtocolExecutionFlow = {
     Opcode.IO_SEND,
 
     // Consider the state transition finished and commit it
-    Opcode.STATE_TRANSITION_COMMIT
+    Opcode.WRITE_COMMITMENT
   ]
 };
 

--- a/packages/machine/src/protocol/withdraw-eth.ts
+++ b/packages/machine/src/protocol/withdraw-eth.ts
@@ -85,8 +85,8 @@ export const WITHDRAW_ETH_PROTOCOL: ProtocolExecutionFlow = {
 
     (message: ProtocolMessage, context: Context) => {
       context.finalCommitment = context.commitments[1].transaction([
-        context.inbox[0].signature2!,
-        context.signatures[1]
+        context.inbox[0].signature2!, // s4
+        context.signatures[1] // s3
       ]);
     },
 
@@ -115,6 +115,13 @@ export const WITHDRAW_ETH_PROTOCOL: ProtocolExecutionFlow = {
     },
 
     Opcode.OP_SIGN,
+
+    (message: ProtocolMessage, context: Context) => {
+      context.finalCommitment = context.commitments[1].transaction([
+        context.inbox[0].signature2!, // s3
+        context.signatures[1] // s4
+      ]);
+    },
 
     (message: ProtocolMessage, context: Context) => {
       context.outbox[0] = {

--- a/packages/machine/src/protocol/withdraw-eth.ts
+++ b/packages/machine/src/protocol/withdraw-eth.ts
@@ -118,7 +118,7 @@ export const WITHDRAW_ETH_PROTOCOL: ProtocolExecutionFlow = {
 
     (message: ProtocolMessage, context: Context) => {
       context.finalCommitment = context.commitments[1].transaction([
-        context.inbox[0].signature2!, // s3
+        message.signature2!, // s3
         context.signatures[1] // s4
       ]);
     },

--- a/packages/machine/src/protocol/withdraw-eth.ts
+++ b/packages/machine/src/protocol/withdraw-eth.ts
@@ -83,6 +83,13 @@ export const WITHDRAW_ETH_PROTOCOL: ProtocolExecutionFlow = {
 
     Opcode.IO_SEND,
 
+    (message: ProtocolMessage, context: Context) => {
+      context.finalCommitment = context.commitments[1].transaction([
+        context.inbox[0].signature2!,
+        context.signatures[1]
+      ]);
+    },
+
     Opcode.STATE_TRANSITION_COMMIT
   ],
 

--- a/packages/machine/src/protocol/withdraw-eth.ts
+++ b/packages/machine/src/protocol/withdraw-eth.ts
@@ -90,7 +90,7 @@ export const WITHDRAW_ETH_PROTOCOL: ProtocolExecutionFlow = {
       ]);
     },
 
-    Opcode.STATE_TRANSITION_COMMIT
+    Opcode.WRITE_COMMITMENT
   ],
 
   1: [
@@ -148,7 +148,7 @@ export const WITHDRAW_ETH_PROTOCOL: ProtocolExecutionFlow = {
       );
     },
 
-    Opcode.STATE_TRANSITION_COMMIT
+    Opcode.WRITE_COMMITMENT
   ]
 };
 

--- a/packages/machine/src/types.ts
+++ b/packages/machine/src/types.ts
@@ -17,11 +17,8 @@ export type Middleware = {
 export type Instruction = Function | Opcode;
 
 /// TODO(xuanji): the following fields are hacked in to make install-virtual-app work:
-/// - commitment2, signature2: the intermediary needs to generate three signatures:
+/// - commitments[], signatures[]: the intermediary needs to generate three signatures:
 ///   two sigs authorizing ETHVirtualAppAgreements, and one authorizing virtualAppSetState.
-/// - targetVirtualAppInstance: this is a state modification that should be returned to called, but the current
-///   mechanism for returning stuff like this is to modify the `statechannel` parameter. But this parameter
-///   is already used for the ledger channel (we write the ETHVirtualAppAgreement instance into it).
 export interface Context {
   network: NetworkContext;
   outbox: ProtocolMessage[];
@@ -30,6 +27,7 @@ export interface Context {
   commitments: EthereumCommitment[];
   signatures: Signature[];
   appIdentityHash?: string;
+  finalCommitment?: Transaction; // todo: is one enough?
 }
 
 // The application-specific state of an app instance, to be interpreted by the

--- a/packages/machine/test/unit/instruction-executor.spec.ts
+++ b/packages/machine/test/unit/instruction-executor.spec.ts
@@ -39,7 +39,7 @@ describe("InstructionExecutor", () => {
     // will fail with an error like "While executing op number <x> at seq
     // <y> of protocol setup, execution failed with the following error.
     // TypeError: Cannot read property 'method' of undefined"
-    instructionExecutor.register(Opcode.STATE_TRANSITION_COMMIT, () => {});
+    instructionExecutor.register(Opcode.WRITE_COMMITMENT, () => {});
   });
 
   describe("the result of proposeStateTransition for the Setup Protocol", () => {

--- a/packages/machine/test/unit/instruction-executor.spec.ts
+++ b/packages/machine/test/unit/instruction-executor.spec.ts
@@ -58,6 +58,13 @@ describe("InstructionExecutor", () => {
           throw Error("could not find stateChannelAfterSetup");
         }
         stateChannelAfterSetup = maybeStateChannelAfterSetup;
+
+        const signingKey = new SigningKey(
+          xkeyKthHDNode(responder.extendedKey, 0).privateKey
+        );
+        context.signatures = context.commitments.map(commitment =>
+          signingKey.signDigest(commitment.hashToSign())
+        );
       });
 
       // Ensure validateSignature in Setup Protocol does not throw

--- a/packages/node/src/events/protocol-message/controller.ts
+++ b/packages/node/src/events/protocol-message/controller.ts
@@ -2,7 +2,7 @@ import { Protocol, StateChannel } from "@counterfactual/machine";
 import {
   UninstallVirtualAppParams,
   WithdrawParams
-} from "@counterfactual/machine/dist/src/types";
+} from "@counterfactual/machine";
 
 import { RequestHandler } from "../../request-handler";
 import {

--- a/packages/node/src/events/protocol-message/controller.ts
+++ b/packages/node/src/events/protocol-message/controller.ts
@@ -1,5 +1,6 @@
-import { Protocol, StateChannel } from "@counterfactual/machine";
 import {
+  Protocol,
+  StateChannel,
   UninstallVirtualAppParams,
   WithdrawParams
 } from "@counterfactual/machine";

--- a/packages/node/src/node.ts
+++ b/packages/node/src/node.ts
@@ -4,16 +4,14 @@ import {
   Opcode,
   Protocol,
   ProtocolMessage,
-  SetupParams
+  SetupParams,
+  UpdateParams,
+  WithdrawParams,
+  Transaction
 } from "@counterfactual/machine";
 import {
-  UpdateParams,
-  WithdrawParams
-} from "@counterfactual/machine/dist/src/types";
-import {
   NetworkContext,
-  Node as NodeTypes,
-  Transaction
+  Node as NodeTypes
 } from "@counterfactual/types";
 import { Wallet } from "ethers";
 import { BaseProvider, JsonRpcProvider } from "ethers/providers";

--- a/packages/node/src/node.ts
+++ b/packages/node/src/node.ts
@@ -217,14 +217,14 @@ export class Node {
     );
 
     instructionExecutor.register(
-      Opcode.STATE_TRANSITION_COMMIT,
+      Opcode.WRITE_COMMITMENT,
       async (message: ProtocolMessage, next: Function, context: Context) => {
         const { protocol } = message;
         if (protocol === Protocol.Withdraw) {
           const params = message.params as WithdrawParams;
           if (context.finalCommitment === undefined) {
             throw Error(
-              "called STATE_TRANSITION_COMMIT with empty context.finalCommitment"
+              "called WRITE_COMMITMENT with empty context.finalCommitment"
             );
           }
           await this.requestHandler.store.storeWithdrawalCommitment(

--- a/packages/node/src/node.ts
+++ b/packages/node/src/node.ts
@@ -5,14 +5,11 @@ import {
   Protocol,
   ProtocolMessage,
   SetupParams,
+  Transaction,
   UpdateParams,
-  WithdrawParams,
-  Transaction
+  WithdrawParams
 } from "@counterfactual/machine";
-import {
-  NetworkContext,
-  Node as NodeTypes
-} from "@counterfactual/types";
+import { NetworkContext, Node as NodeTypes } from "@counterfactual/types";
 import { Wallet } from "ethers";
 import { BaseProvider, JsonRpcProvider } from "ethers/providers";
 import { SigningKey } from "ethers/utils";


### PR DESCRIPTION
- rename `STATE_TRANSITION_COMMIT ` -> `WRITE_COMMITMENT`, since the state commitment change actually happens outside of any middlewares
- add `context.finalCommitment`, for `WRITE_COMMITMENT` to read
- use `context.finalCommitment` with withdraw and setup
- add actual signing to `instruction-executor.spec.ts` to avoid errors
- export more params via `machine` instead of `dist`