### PR TITLE
[playground] [dapp-high-roller] [dapp-tic-tac-toe] Implements dApp resumability

### DIFF
--- a/packages/dapp-high-roller/src/components/app-root/app-root.scss
+++ b/packages/dapp-high-roller/src/components/app-root/app-root.scss
@@ -1,0 +1,13 @@
+.App {
+  position: relative;
+  max-width: 20rem;
+  height: 100vh;
+  margin: 0 auto;
+}
+
+.message {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  text-align: center;
+}

--- a/packages/dapp-high-roller/src/components/app-root/app-root.spec.ts
+++ b/packages/dapp-high-roller/src/components/app-root/app-root.spec.ts
@@ -2,6 +2,7 @@ import { AppRoot } from "./app-root";
 
 describe("app-root", () => {
   it("builds", () => {
+    window["addEventListener"] = jest.fn();
     expect(new AppRoot()).toBeTruthy();
   });
 });

--- a/packages/dapp-high-roller/src/components/app-root/app-root.tsx
+++ b/packages/dapp-high-roller/src/components/app-root/app-root.tsx
@@ -134,6 +134,7 @@ export class AppRoot {
         multisigAddress: "0x9499ac5A66c36447e535d252c049304D80961CED"
       };
       this.updateAccount(mockAccount);
+      this.userDataReceived = true;
     }
   }
 

--- a/packages/dapp-high-roller/src/components/app-root/app-root.tsx
+++ b/packages/dapp-high-roller/src/components/app-root/app-root.tsx
@@ -1,6 +1,6 @@
 declare var ga: any;
 
-import { Component, Prop } from "@stencil/core";
+import { Component, Prop, State } from "@stencil/core";
 import { RouterHistory } from "@stencil/router";
 
 import CounterfactualTunnel from "../../data/counterfactual";
@@ -31,6 +31,8 @@ const { AddressZero, HashZero } = ethers.constants;
 export class AppRoot {
   @Prop({ mutable: true }) state: any;
   @Prop({ mutable: true }) uiState: HighRollerUIState;
+
+  @State() userDataReceived: boolean = false;
 
   constructor() {
     const params = new URLSearchParams(window.location.search);
@@ -85,6 +87,8 @@ export class AppRoot {
         const [, data] = event.data.split("|");
         const account = JSON.parse(data);
         this.updateAccount(account);
+
+        this.userDataReceived = true;
 
         if (this.state.appInstance) {
           this.updateOpponent({
@@ -239,7 +243,7 @@ export class AppRoot {
   }
 
   render() {
-    return (
+    return this.userDataReceived ? (
       <div class="height-100">
         <main class="height-100">
           <CounterfactualTunnel.Provider state={this.state}>
@@ -291,6 +295,8 @@ export class AppRoot {
           </CounterfactualTunnel.Provider>
         </main>
       </div>
+    ) : (
+      <h1 class="App message">connecting....</h1>
     );
   }
 }

--- a/packages/dapp-high-roller/src/components/app-root/app-root.tsx
+++ b/packages/dapp-high-roller/src/components/app-root/app-root.tsx
@@ -67,6 +67,13 @@ export class AppRoot {
         playerSecondNumber: 0
       } as HighRollerAppState
     };
+
+    window.addEventListener("popstate", () => {
+      window.parent.postMessage(
+        `playground:send:dappRoute|${location.hash}`,
+        "*"
+      );
+    });
   }
 
   setupPlaygroundMessageListeners() {
@@ -237,7 +244,7 @@ export class AppRoot {
         <main class="height-100">
           <CounterfactualTunnel.Provider state={this.state}>
             <HighRollerUITunnel.Provider state={this.uiState}>
-              <stencil-router>
+              <stencil-router historyType="hash">
                 <stencil-route-switch scrollTopOffset={0}>
                   <app-provider
                     updateAppInstance={this.state.updateAppInstance.bind(this)}

--- a/packages/dapp-tic-tac-toe/src/App.js
+++ b/packages/dapp-tic-tac-toe/src/App.js
@@ -3,6 +3,7 @@ import Welcome from "./Welcome";
 import Wager from "./Wager";
 import Waiting from "./Waiting";
 import Game from "./Game";
+import RouterListener from "./RouterListener";
 import { BrowserRouter as Router, Route } from "react-router-dom";
 import MockNodeProvider from "./MockNodeProvider";
 
@@ -90,7 +91,7 @@ export default class App extends Component {
   render() {
     return this.state.connected ? (
       <Router>
-        <div className="App">
+        <RouterListener>
           <Route
             exact
             path="/"
@@ -136,7 +137,7 @@ export default class App extends Component {
               />
             )}
           />
-        </div>
+        </RouterListener>
       </Router>
     ) : (
       <h1 className="App message">connecting....</h1>

--- a/packages/dapp-tic-tac-toe/src/RouterListener.jsx
+++ b/packages/dapp-tic-tac-toe/src/RouterListener.jsx
@@ -6,7 +6,7 @@ class RouterListener extends Component {
     this.unlisten = this.props.history.listen(location => {
       if (window.parent) {
         window.parent.postMessage(
-          `playground:send:dappRoute|${location.pathname}`,
+          `playground:send:dappRoute|${location.pathname}${location.search}`,
           "*"
         );
       }

--- a/packages/dapp-tic-tac-toe/src/RouterListener.jsx
+++ b/packages/dapp-tic-tac-toe/src/RouterListener.jsx
@@ -1,0 +1,25 @@
+import React, { Component } from "react";
+import withRouter from "react-router-dom/withRouter";
+
+class RouterListener extends Component {
+  componentWillMount() {
+    this.unlisten = this.props.history.listen(location => {
+      if (window.parent) {
+        window.parent.postMessage(
+          `playground:send:dappRoute|${location.pathname}`,
+          "*"
+        );
+      }
+    });
+  }
+
+  componentWillUnmount() {
+    this.unlisten();
+  }
+
+  render() {
+    return <div className="App">{this.props.children}</div>;
+  }
+}
+
+export default withRouter(RouterListener);

--- a/packages/playground/src/components/dapp-container/dapp-container.tsx
+++ b/packages/playground/src/components/dapp-container/dapp-container.tsx
@@ -47,12 +47,14 @@ export class DappContainer {
   getDappUrl(): string {
     const dappSlug = this.match.params.dappName;
     const dapp = this.apps.find(app => app.slug === dappSlug);
+    const dappState =
+      new URLSearchParams(window.location.search).get("dappState") || "";
 
     if (!dapp) {
       return "";
     }
 
-    return dapp.url;
+    return `${dapp.url}${dappState}`;
   }
 
   componentDidLoad(): void {
@@ -106,7 +108,7 @@ export class DappContainer {
   }
 
   private async handlePlaygroundMessage(event: MessageEvent): Promise<void> {
-    if (!this.frameWindow) {
+    if (!this.frameWindow || typeof event.data !== "string") {
       return;
     }
 
@@ -116,6 +118,14 @@ export class DappContainer {
 
     if (event.data === "playground:request:matchmake") {
       await this.sendResponseForMatchmakeRequest(this.frameWindow);
+    }
+
+    if (event.data.startsWith("playground:send:dappRoute")) {
+      const [, data] = event.data.split("|");
+      const searchParams = new URLSearchParams(window.location.search);
+      searchParams.set("dappState", data);
+      const newURL = `${window.location.pathname}?${searchParams.toString()}`;
+      history.pushState(null, "", newURL);
     }
   }
 


### PR DESCRIPTION
This PR implements resumability by sending the dApps' URL to the Playground so when the user refreshes, the dApp's iframe can be loaded with the last known URL. 

:construction: Pending to test if the game state resumes where it left (specially in High Roller). 

**Some notes:**

- `stencil-router` has no support for listening to route changes, so I'm forced to use `hash` routing on the High Roller dApp and listen to `popstate` events. Browser-mode routing isn't event-driven, and polling is not a preferred solution.

- The `app-root` component now delegates control to the Router after it's finished processing the user data sent via the `playground:response:user` postMessage() reply.

![deepin-screen-recorder_vivaldi-stable_20190228135424](https://user-images.githubusercontent.com/118913/53583846-20d1d600-3b61-11e9-96f8-ff7e8c600d05.gif)
