### PR TITLE
clarified explanation text to say that this is a demo on Ropsten

### DIFF
--- a/packages/playground/src/components/app-home/app-home/app-home.tsx
+++ b/packages/playground/src/components/app-home/app-home/app-home.tsx
@@ -214,8 +214,9 @@ export class AppHome {
           <div class="flex-item">
             <h3>What's going on here?</h3>
             <p>
-              You are now a Node in a hub-and-spoke state channels network. This
-              webpage is your state channels wallet. Our team runs the hub.
+              You are now a Node in a hub-and-spoke state channels network
+              demo called the Counterfactual Playground, running on Ropsten.
+              This webpage is your state channels wallet. Our team runs the hub.
               Users that connect to our hub can use an unlimited number of
               off-chain applications with <b>zero fees</b> and{" "}
               <b>zero block confirmation times</b>. Want to try? Register or

--- a/packages/playground/src/components/app-home/app-home/app-home.tsx
+++ b/packages/playground/src/components/app-home/app-home/app-home.tsx
@@ -214,9 +214,9 @@ export class AppHome {
           <div class="flex-item">
             <h3>What's going on here?</h3>
             <p>
-              You are now a Node in a hub-and-spoke state channels network
-              demo called the Counterfactual Playground, running on Ropsten.
-              This webpage is your state channels wallet. Our team runs the hub.
+              You are now a Node in a hub-and-spoke state channels network demo
+              called the Counterfactual Playground, running on Ropsten. This
+              webpage is your state channels wallet. Our team runs the hub.
               Users that connect to our hub can use an unlimited number of
               off-chain applications with <b>zero fees</b> and{" "}
               <b>zero block confirmation times</b>. Want to try? Register or


### PR DESCRIPTION
Earlier text was ambiguous between whether or not this was for real funds on main net or a demo on Ropsten. Changed to clarify.