### PR TITLE
[dapp-high-roller] [dapp-tic-tac-toe] Allows more precise decimals in the dApps' wager screens

### DIFF
--- a/packages/dapp-high-roller/src/components/app-wager/app-wager.tsx
+++ b/packages/dapp-high-roller/src/components/app-wager/app-wager.tsx
@@ -261,7 +261,7 @@ export class AppWager {
               onInput={e => this.handleChange(e, "betAmount")}
               min={0}
               max={0.01}
-              step={0.001}
+              step={0.00000001}
             />
             {this.isError ? (
               <label class="message__error">

--- a/packages/dapp-tic-tac-toe/src/Wager.jsx
+++ b/packages/dapp-tic-tac-toe/src/Wager.jsx
@@ -199,7 +199,7 @@ class Wager extends Component {
             placeholder="0.01 eth"
             min={0}
             max={0.01}
-            step={0.001}
+            step={0.00000001}
             onChange={e => (this.props.gameInfo.betAmount = e.target.value)}
             defaultValue={this.props.gameInfo.betAmount}
           />


### PR DESCRIPTION
This PR fixes the form validation for the bet amounts on both dApps' wager screens. 

Setting a `step` parameter on the input also limits the precision of the decimal number the user can enter into the numeric field. The solution was to add more decimal digits to the number.