### PR TITLE
[node] Add beforeExecution and afterExecution to Node

### DIFF
--- a/packages/node/src/methods/controller.ts
+++ b/packages/node/src/methods/controller.ts
@@ -16,13 +16,29 @@ export abstract class NodeController {
       return await this.executeMethodImplementation(requestHandler, params);
     };
 
-    return await (shardedQueue ? shardedQueue.add(execute) : execute());
+    await this.beforeExecution(requestHandler, params);
+
+    const ret = await (shardedQueue ? shardedQueue.add(execute) : execute());
+
+    await this.afterExecution(requestHandler, params);
+
+    return ret;
   }
 
   protected abstract executeMethodImplementation(
     requestHandler: RequestHandler,
     params: Node.MethodParams
   ): Promise<Node.MethodResult>;
+
+  protected async beforeExecution(
+    requestHandler: RequestHandler,
+    params: Node.MethodParams
+  ): Promise<void> {}
+
+  protected async afterExecution(
+    requestHandler: RequestHandler,
+    params: Node.MethodParams
+  ): Promise<void> {}
 
   // This method is the logic by which the waiting on the queue happens
   // per controller which needs to be overrided.

--- a/packages/node/src/methods/state-channel/deposit/controller.ts
+++ b/packages/node/src/methods/state-channel/deposit/controller.ts
@@ -23,10 +23,10 @@ export default class DepositController extends NodeController {
     return requestHandler.getShardedQueue(params.multisigAddress);
   }
 
-  protected async executeMethodImplementation(
+  protected async beforeExecution(
     requestHandler: RequestHandler,
     params: Node.DepositParams
-  ): Promise<Node.DepositResult> {
+  ): Promise<void> {
     const { store, provider } = requestHandler;
     const { multisigAddress, amount } = params;
 
@@ -47,6 +47,16 @@ export default class DepositController extends NodeController {
     if (balanceOfSigner < amount) {
       return Promise.reject(ERRORS.INSUFFICIENT_FUNDS);
     }
+  }
+
+  protected async executeMethodImplementation(
+    requestHandler: RequestHandler,
+    params: Node.DepositParams
+  ): Promise<Node.DepositResult> {
+    const { store } = requestHandler;
+    const { multisigAddress } = params;
+
+    const channel = await store.getStateChannel(multisigAddress);
 
     await installBalanceRefundApp(requestHandler, params);
 

--- a/packages/node/src/methods/state-channel/withdraw/controller.ts
+++ b/packages/node/src/methods/state-channel/withdraw/controller.ts
@@ -20,26 +20,28 @@ export default class WithdrawController extends NodeController {
     return requestHandler.getShardedQueue(params.multisigAddress);
   }
 
-  protected async executeMethodImplementation(
+  protected async beforeExecution(
     requestHandler: RequestHandler,
-    params: Node.WithdrawParams
-  ): Promise<Node.WithdrawResult> {
-    const {
-      store,
-      provider,
-      networkContext,
-      wallet,
-      publicIdentifier
-    } = requestHandler;
-    const { multisigAddress, amount, recipient } = params;
-
-    params.recipient = recipient || xkeyKthAddress(publicIdentifier, 0);
+    params: Node.DepositParams
+  ): Promise<void> {
+    const { store, networkContext } = requestHandler;
+    const { multisigAddress } = params;
 
     const channel = await store.getStateChannel(multisigAddress);
 
     if (channel.hasAppInstanceOfKind(networkContext.ETHBalanceRefund)) {
       return Promise.reject(ERRORS.CANNOT_WITHDRAW);
     }
+  }
+
+  protected async executeMethodImplementation(
+    requestHandler: RequestHandler,
+    params: Node.WithdrawParams
+  ): Promise<Node.WithdrawResult> {
+    const { store, provider, wallet, publicIdentifier } = requestHandler;
+    const { multisigAddress, amount, recipient } = params;
+
+    params.recipient = recipient || xkeyKthAddress(publicIdentifier, 0);
 
     await runWithdrawProtocol(requestHandler, params);
 


### PR DESCRIPTION
Useful for situations when the method will throw but you could know that before its at-bat.

Example:
- Clicking Withdraw or Deposit while Withdraw or Deposit is pending