### PR TITLE
[playground] Adds widget-dev-flags component to monitor `playground:*` dev flags

### DIFF
--- a/packages/playground/src/components/layout/layout-header/header-content/header-content.tsx
+++ b/packages/playground/src/components/layout/layout-header/header-content/header-content.tsx
@@ -1,11 +1,4 @@
-import {
-  Component,
-  Event,
-  EventEmitter,
-  Prop,
-  State,
-  Watch
-} from "@stencil/core";
+import { Component, Event, EventEmitter, Prop, State } from "@stencil/core";
 
 @Component({
   tag: "header-content",

--- a/packages/playground/src/components/layout/layout-header/header-content/header-content.tsx
+++ b/packages/playground/src/components/layout/layout-header/header-content/header-content.tsx
@@ -43,6 +43,7 @@ export class HeaderContent {
           <div class="connection">
             <widget-connection />
           </div>
+          <widget-dev-flags />
         </div>
         <header-account
           onAuthenticationChanged={e => this.updateConnectionWidget(e)}

--- a/packages/playground/src/components/widgets/widget-dev-flags/widget-dev-flags.scss
+++ b/packages/playground/src/components/widgets/widget-dev-flags/widget-dev-flags.scss
@@ -1,0 +1,7 @@
+:host {
+  padding-left: 10px;
+}
+
+widget-tooltip {
+  cursor: pointer;
+}

--- a/packages/playground/src/components/widgets/widget-dev-flags/widget-dev-flags.tsx
+++ b/packages/playground/src/components/widgets/widget-dev-flags/widget-dev-flags.tsx
@@ -11,7 +11,7 @@ export class WidgetDevFlags {
   }
 
   @State() get hasAnyFlags() {
-    return [this.matchmakeWith].map(Boolean).some(flag => flag === true);
+    return [this.matchmakeWith].some(flag => Boolean(flag) === true);
   }
 
   @State() showingModal: boolean = false;

--- a/packages/playground/src/components/widgets/widget-dev-flags/widget-dev-flags.tsx
+++ b/packages/playground/src/components/widgets/widget-dev-flags/widget-dev-flags.tsx
@@ -1,4 +1,4 @@
-import { Component, State, Watch } from "@stencil/core";
+import { Component, State } from "@stencil/core";
 
 @Component({
   tag: "widget-dev-flags",

--- a/packages/playground/src/components/widgets/widget-dev-flags/widget-dev-flags.tsx
+++ b/packages/playground/src/components/widgets/widget-dev-flags/widget-dev-flags.tsx
@@ -35,7 +35,7 @@ export class WidgetDevFlags {
 
   buildFlagRow(key: string, propName: string) {
     return (
-      <tr data-key="playground:matchmakeWith">
+      <tr>
         <td>{key}</td>
         <td>{this[propName]}</td>
         <td>

--- a/packages/playground/src/components/widgets/widget-dev-flags/widget-dev-flags.tsx
+++ b/packages/playground/src/components/widgets/widget-dev-flags/widget-dev-flags.tsx
@@ -11,7 +11,9 @@ export class WidgetDevFlags {
   }
 
   @State() get hasAnyFlags() {
-    return [this.matchmakeWith].some(flag => Boolean(flag) === true);
+    // When we support multiple flags, this should turn into:
+    // [this.matchmakeWith].some(flag => Boolean(flag) === true);
+    return this.matchmakeWith;
   }
 
   @State() showingModal: boolean = false;

--- a/packages/playground/src/components/widgets/widget-dev-flags/widget-dev-flags.tsx
+++ b/packages/playground/src/components/widgets/widget-dev-flags/widget-dev-flags.tsx
@@ -1,0 +1,96 @@
+import { Component, State, Watch } from "@stencil/core";
+
+@Component({
+  tag: "widget-dev-flags",
+  styleUrl: "widget-dev-flags.scss",
+  shadow: true
+})
+export class WidgetDevFlags {
+  @State() get matchmakeWith() {
+    return localStorage.getItem("playground:matchmakeWith");
+  }
+
+  @State() get hasAnyFlags() {
+    return [this.matchmakeWith].map(Boolean).some(flag => flag === true);
+  }
+
+  @State() showingModal: boolean = false;
+
+  showModal() {
+    this.showingModal = true;
+  }
+
+  hideModal() {
+    this.showingModal = false;
+  }
+
+  unset(key: string, event: Event) {
+    event.preventDefault();
+
+    localStorage.removeItem(key);
+
+    const target = event.target as HTMLElement;
+    target.outerHTML = "Cleared!";
+  }
+
+  buildFlagRow(key: string, propName: string) {
+    return (
+      <tr data-key="playground:matchmakeWith">
+        <td>{key}</td>
+        <td>{this[propName]}</td>
+        <td>
+          <a href="#" onClick={e => this.unset(key, e)}>
+            Unset
+          </a>
+        </td>
+      </tr>
+    );
+  }
+
+  @State() get dialog() {
+    const rows: JSX.Element[] = [];
+
+    if (this.matchmakeWith) {
+      rows.push(this.buildFlagRow("playground:matchmakeWith", "matchmakeWith"));
+    }
+
+    const content = (
+      <table cellSpacing={0} cellPadding={0}>
+        <tr>
+          <th>Flag</th>
+          <th>Value</th>
+          <th />
+        </tr>
+        {...rows}
+      </table>
+    );
+
+    return (
+      <widget-dialog
+        dialogTitle="Using dev flags"
+        content={content}
+        dialogClass="dialog--dev-flags"
+        contentClass="dialog-content--dev-flags"
+        visible={this.showingModal}
+        primaryButtonText="Close"
+        onPrimaryButtonClicked={this.hideModal.bind(this)}
+      />
+    );
+  }
+
+  render() {
+    return this.hasAnyFlags ? (
+      [
+        <widget-tooltip
+          onClick={this.showModal.bind(this)}
+          message="Click here for full details"
+        >
+          ⚠️ Using dev flags
+        </widget-tooltip>,
+        this.dialog
+      ]
+    ) : (
+      <div />
+    );
+  }
+}

--- a/packages/playground/src/components/widgets/widget-dialog/widget-dialog.scss
+++ b/packages/playground/src/components/widgets/widget-dialog/widget-dialog.scss
@@ -9,6 +9,7 @@
   align-items: center;
   justify-content: center;
   background: rgba(0, 0, 0, 0.8);
+  z-index: 1;
 }
 
 dialog {
@@ -77,6 +78,31 @@ dialog {
       &:hover {
         background: darken($color: $c-blue, $amount: 10%);
       }
+    }
+  }
+}
+
+.dialog--dev-flags {
+  width: 600px;
+}
+
+.dialog-content--dev-flags {
+  font-size: 14px;
+
+  table {
+    width: 100%;
+
+    th {
+      border-bottom: 1px solid #ccc;
+    }
+
+    th,
+    td {
+      text-align: left;
+    }
+
+    form-button {
+      background: none;
     }
   }
 }

--- a/packages/playground/src/components/widgets/widget-dialog/widget-dialog.tsx
+++ b/packages/playground/src/components/widgets/widget-dialog/widget-dialog.tsx
@@ -11,6 +11,8 @@ export class WidgetDialog {
   @Prop() dialogTitle: string = "";
   @Prop() icon: string = "";
   @Prop() content: JSX.Element = {} as JSX.Element;
+  @Prop() contentClass: string = "";
+  @Prop() dialogClass: string = "";
   @Prop() primaryButtonText: string = "";
   @Prop() secondaryButtonText: string = "";
 
@@ -30,11 +32,11 @@ export class WidgetDialog {
       <div
         class={this.visible ? "dialog-wrapper dialog--open" : "dialog-wrapper"}
       >
-        <dialog open={this.visible}>
+        <dialog open={this.visible} class={this.dialogClass}>
           <header>
             <widget-logo caption={this.dialogTitle} />
           </header>
-          <main>
+          <main class={this.contentClass}>
             {this.icon ? <img src={this.icon} /> : {}}
             {this.content}
           </main>


### PR DESCRIPTION
This PR adds a `<widget-dev-flags />` component to monitor whatever `playground:*` flags we want to monitor in the Playground UI. It also provides a utility function to unset any of those flags.

**Currently monitored flags**
- `playground:matchmakeWith`

**Preview**

![deepin-screen-recorder_select area_20190302111148](https://user-images.githubusercontent.com/118913/53686478-5c44df80-3cdc-11e9-8feb-5b63b20d2789.gif)
