### PR TITLE
[playground] Prevents the user from playing any dApps until the state channel has been collateralized

### DIFF
--- a/packages/playground/src/components/account/account-exchange/account-exchange.tsx
+++ b/packages/playground/src/components/account/account-exchange/account-exchange.tsx
@@ -4,13 +4,6 @@ import AccountTunnel from "../../../data/account";
 import WalletTunnel from "../../../data/wallet";
 import { UserSession } from "../../../types";
 
-const NETWORK_NAME_URL_PREFIX_ON_ETHERSCAN = {
-  "1": "",
-  "3": "ropsten",
-  "42": "kovan",
-  "4": "rinkeby"
-};
-
 const HUB_IS_DEPOSITING_ALERT =
   "The hub is currently making a deposit in the channel. Currently, this demo does not support asyncronous deposits.";
 
@@ -38,6 +31,8 @@ export class AccountExchange {
   @Prop() getBalances: () => Promise<
     { ethMultisigBalance: BigNumber; ethFreeBalanceWei: BigNumber } | undefined
   > = async () => undefined;
+  @Prop() getEtherscanAddressURL: (address: string) => string = () => "";
+  @Prop() getEtherscanTxURL: (tx: string) => string = () => "";
 
   removeError() {
     this.updateAccount({
@@ -106,18 +101,6 @@ export class AccountExchange {
         throw e;
       }
     }
-  }
-
-  getEtherscanAddressURL(address: string) {
-    return `https://${
-      NETWORK_NAME_URL_PREFIX_ON_ETHERSCAN[this.network]
-    }.etherscan.io/address/${address}`;
-  }
-
-  getEtherscanTxURL(tx: string) {
-    return `https://${
-      NETWORK_NAME_URL_PREFIX_ON_ETHERSCAN[this.network]
-    }.etherscan.io/tx/${tx}`;
   }
 
   render() {
@@ -204,4 +187,9 @@ AccountTunnel.injectProps(AccountExchange, [
   "getBalances"
 ]);
 
-WalletTunnel.injectProps(AccountExchange, ["network", "ethWeb3WalletBalance"]);
+WalletTunnel.injectProps(AccountExchange, [
+  "network",
+  "ethWeb3WalletBalance",
+  "getEtherscanAddressURL",
+  "getEtherscanTxURL"
+]);

--- a/packages/playground/src/components/app-home/app-home/app-home.scss
+++ b/packages/playground/src/components/app-home/app-home/app-home.scss
@@ -3,7 +3,6 @@
 }
 
 .blurred {
-
   filter: blur(8px);
 }
 
@@ -83,7 +82,6 @@ button:hover {
       }
     }
   }
-
 }
 
 .error-message {
@@ -105,70 +103,5 @@ button:hover {
     font-size: 1.5rem;
     font-weight: 400;
     color: #555555;
-  }
-}
-
-.loading {
-  display: flex;
-  align-items: center;
-  flex-direction: column;
-  width: 80%;
-  position: absolute;
-  top: 50%;
-  left: 50%;
-  transform: translate(-50%, -50%);
-  text-align: center;
-  font-size: 3rem;
-  font-weight: 600;
-  color: $c-mediumgrey;
-
-  .spinner {
-    width: 70px;
-    text-align: center;
-  }
-
-  .spinner > div {
-    width: 18px;
-    height: 18px;
-    background-color: $c-darkgrey;
-
-    border-radius: 100%;
-    display: inline-block;
-    -webkit-animation: sk-bouncedelay 1.4s infinite ease-in-out both;
-    animation: sk-bouncedelay 1.4s infinite ease-in-out both;
-  }
-
-  .spinner .bounce1 {
-    -webkit-animation-delay: -0.32s;
-    animation-delay: -0.32s;
-  }
-
-  .spinner .bounce2 {
-    -webkit-animation-delay: -0.16s;
-    animation-delay: -0.16s;
-  }
-
-  @-webkit-keyframes sk-bouncedelay {
-    0%,
-    80%,
-    100% {
-      -webkit-transform: scale(0);
-    }
-    40% {
-      -webkit-transform: scale(1);
-    }
-  }
-
-  @keyframes sk-bouncedelay {
-    0%,
-    80%,
-    100% {
-      -webkit-transform: scale(0);
-      transform: scale(0);
-    }
-    40% {
-      -webkit-transform: scale(1);
-      transform: scale(1);
-    }
   }
 }

--- a/packages/playground/src/components/app-home/app-home/app-home.tsx
+++ b/packages/playground/src/components/app-home/app-home/app-home.tsx
@@ -16,6 +16,7 @@ export class AppHome {
 
   @Prop() history: RouterHistory = {} as RouterHistory;
   @Prop() apps: AppDefinition[] = [];
+  @Prop() canUseApps: boolean = false;
   @Prop() user: UserSession = {} as UserSession;
   @Prop() web3Detected: boolean = false;
   @Prop() hasDetectedNetwork: boolean = false;
@@ -139,15 +140,7 @@ export class AppHome {
       return;
     }
 
-    return (
-      <div class="loading">
-        <div class="spinner">
-          <div class="bounce1" />
-          <div class="bounce2" />
-          <div class="bounce3" />
-        </div>
-      </div>
-    );
+    return <widget-spinner type="dots" />;
   }
 
   checkWeb3Detected() {
@@ -188,6 +181,7 @@ export class AppHome {
       <div class="container">
         <apps-list
           apps={this.apps}
+          canUseApps={this.canUseApps}
           onAppClicked={e => this.appClickedHandler(e)}
           name="Available Apps"
         />
@@ -272,7 +266,7 @@ export class AppHome {
   }
 }
 
-AppRegistryTunnel.injectProps(AppHome, ["apps"]);
+AppRegistryTunnel.injectProps(AppHome, ["apps", "canUseApps"]);
 
 WalletTunnel.injectProps(AppHome, [
   "web3Detected",

--- a/packages/playground/src/components/app-home/apps-list-item/apps-list-item.tsx
+++ b/packages/playground/src/components/app-home/apps-list-item/apps-list-item.tsx
@@ -11,17 +11,23 @@ export class AppsListItem {
   @Prop() name: string = "";
   @Prop() notifications: number | null = null;
   @Prop() url: string = "";
+  @Prop() canUse: boolean = false;
 
   private getAppSlug() {
     return this.name.toLowerCase().replace(/ /g, "-");
   }
 
   appClickedHandler(event) {
+    event.preventDefault();
     this.appClicked.emit(event);
   }
 
   private openApp(event: MouseEvent) {
     event.preventDefault();
+
+    if (!this.canUse) {
+      return;
+    }
 
     this.appClicked.emit({
       name: this.name,
@@ -33,7 +39,10 @@ export class AppsListItem {
   render() {
     return (
       <li class="item">
-        <a href={`/dapp/${this.getAppSlug()}`} onClick={e => this.openApp(e)}>
+        <a
+          href={this.canUse ? `/dapp/${this.getAppSlug()}` : "#"}
+          onClick={e => this.openApp(e)}
+        >
           <div class="icon">
             {this.notifications ? (
               <div class="notification">{this.notifications}</div>

--- a/packages/playground/src/components/app-home/apps-list/apps-list.scss
+++ b/packages/playground/src/components/app-home/apps-list/apps-list.scss
@@ -1,3 +1,7 @@
+.apps.apps--disabled {
+  filter: blur(5px);
+}
+
 .title {
   @include f-heading;
   margin-bottom: 1.5rem;
@@ -13,7 +17,7 @@
   .title {
     text-align: center;
   }
-  
+
   .list {
     flex-direction: column;
     flex-wrap: nowrap;

--- a/packages/playground/src/components/app-home/apps-list/apps-list.tsx
+++ b/packages/playground/src/components/app-home/apps-list/apps-list.tsx
@@ -1,6 +1,8 @@
-import { Component, Event, EventEmitter, Prop } from "@stencil/core";
+import { Component, Element, Event, EventEmitter, Prop } from "@stencil/core";
 
-import { AppDefinition } from "../../../types";
+import AccountTunnel from "../../../data/account";
+import WalletTunnel from "../../../data/wallet";
+import { AppDefinition, UserSession } from "../../../types";
 
 @Component({
   tag: "apps-list",
@@ -8,17 +10,45 @@ import { AppDefinition } from "../../../types";
   shadow: true
 })
 export class AppsList {
+  @Element() el: HTMLStencilElement = {} as HTMLStencilElement;
   @Event() appClicked: EventEmitter = {} as EventEmitter;
   @Prop() apps: AppDefinition[] = [];
+  @Prop() canUseApps: boolean = false;
   @Prop() name: string = "";
+  @Prop() user: UserSession = {} as UserSession;
+  @Prop() getEtherscanAddressURL: (address: string) => string = () => "";
+  @Prop() getEtherscanTxURL: (tx: string) => string = () => "";
 
   appClickedHandler(event) {
-    this.appClicked.emit(event.detail);
+    if (this.canUseApps) {
+      this.appClicked.emit(event.detail);
+    }
+  }
+
+  get spinner() {
+    if (!this.canUseApps) {
+      const content = (
+        <div class="content">
+          <label>Please wait while we collateralize your deposit</label>
+          <a
+            target="_blank"
+            href={this.getEtherscanAddressURL(this.user.multisigAddress)}
+          >
+            See the transaction in Etherscan
+          </a>
+        </div>
+      );
+
+      return <widget-spinner type="dots" content={content} />;
+    }
+
+    return;
   }
 
   render() {
-    return (
-      <div class="apps">
+    return [
+      this.spinner,
+      <div class={["apps", !this.canUseApps ? "apps--disabled" : ""].join(" ")}>
         <h2 class="title">{this.name}</h2>
 
         <ul class="list">
@@ -26,6 +56,7 @@ export class AppsList {
             <apps-list-item
               onAppClicked={e => this.appClickedHandler(e)}
               icon={app.icon}
+              canUse={this.canUseApps}
               name={app.name}
               notifications={app.notifications}
               url={app.url}
@@ -33,6 +64,12 @@ export class AppsList {
           ))}
         </ul>
       </div>
-    );
+    ];
   }
 }
+
+WalletTunnel.injectProps(AppsList, [
+  "getEtherscanAddressURL",
+  "getEtherscanTxURL"
+]);
+AccountTunnel.injectProps(AppsList, ["user"]);

--- a/packages/playground/src/components/app-home/apps-list/apps-list.tsx
+++ b/packages/playground/src/components/app-home/apps-list/apps-list.tsx
@@ -29,7 +29,7 @@ export class AppsList {
     if (!this.canUseApps) {
       const content = (
         <div class="content">
-          <label>Please wait while we collateralize your deposit</label>
+          <label>Please wait while we collateralize your state channel</label>
           <a
             target="_blank"
             href={this.getEtherscanAddressURL(this.user.multisigAddress)}

--- a/packages/playground/src/components/app-home/apps-list/apps-list.tsx
+++ b/packages/playground/src/components/app-home/apps-list/apps-list.tsx
@@ -27,15 +27,22 @@ export class AppsList {
 
   get spinner() {
     if (!this.canUseApps) {
+      const message = this.user.multisigAddress
+        ? "Please wait while we collateralize your state channel"
+        : "Please wait while we create your state channel";
       const content = (
         <div class="content">
-          <label>Please wait while we collateralize your state channel</label>
-          <a
-            target="_blank"
-            href={this.getEtherscanAddressURL(this.user.multisigAddress)}
-          >
-            See the transaction in Etherscan
-          </a>
+          <label>{message}</label>
+          {this.user.multisigAddress ? (
+            <a
+              target="_blank"
+              href={this.getEtherscanAddressURL(this.user.multisigAddress)}
+            >
+              See the transaction in Etherscan
+            </a>
+          ) : (
+            ""
+          )}
         </div>
       );
 

--- a/packages/playground/src/components/app-root/app-root.tsx
+++ b/packages/playground/src/components/app-root/app-root.tsx
@@ -17,6 +17,13 @@ const TIER: string = "ENV:TIER";
 const FIREBASE_SERVER_HOST: string = "ENV:FIREBASE_SERVER_HOST";
 const FIREBASE_SERVER_PORT: string = "ENV:FIREBASE_SERVER_PORT";
 
+const NETWORK_NAME_URL_PREFIX_ON_ETHERSCAN = {
+  "1": "",
+  "3": "ropsten",
+  "42": "kovan",
+  "4": "rinkeby"
+};
+
 @Component({
   tag: "app-root",
   styleUrl: "app-root.scss",
@@ -448,6 +455,18 @@ export class AppRoot {
     }
   }
 
+  getEtherscanAddressURL(address: string) {
+    return `https://${
+      NETWORK_NAME_URL_PREFIX_ON_ETHERSCAN[this.walletState.network as string]
+    }.etherscan.io/address/${address}`;
+  }
+
+  getEtherscanTxURL(tx: string) {
+    return `https://${
+      NETWORK_NAME_URL_PREFIX_ON_ETHERSCAN[this.walletState.network as string]
+    }.etherscan.io/tx/${tx}`;
+  }
+
   render() {
     this.accountState = {
       ...this.accountState,
@@ -463,6 +482,12 @@ export class AppRoot {
     this.walletState.updateWalletConnection = this.updateWalletConnection.bind(
       this
     );
+
+    this.walletState.getEtherscanAddressURL = this.getEtherscanAddressURL.bind(
+      this
+    );
+    this.walletState.getEtherscanTxURL = this.getEtherscanTxURL.bind(this);
+
     this.appRegistryState.updateAppRegistry = this.updateAppRegistry.bind(this);
 
     if (this.loading) {

--- a/packages/playground/src/components/app-root/app-root.tsx
+++ b/packages/playground/src/components/app-root/app-root.tsx
@@ -279,6 +279,8 @@ export class AppRoot {
 
     await this.updateAccount(vals);
 
+    // TODO: Replace this with a more event-driven approach,
+    // based on a list of collateralized deposits.
     if (poll) {
       if (canUseApps) {
         clearTimeout(this.balancePolling);

--- a/packages/playground/src/components/app-root/app-root.tsx
+++ b/packages/playground/src/components/app-root/app-root.tsx
@@ -271,7 +271,7 @@ export class AppRoot {
     ) as BigNumber;
 
     this.updateAppRegistry({
-      canUseApps: vals.hubBalanceWei.gte(ethers.utils.parseEther("0.1"))
+      canUseApps: vals.hubBalanceWei.gt(ethers.utils.parseEther("0"))
     });
 
     await this.updateAccount(vals);
@@ -307,11 +307,11 @@ export class AppRoot {
       })
     );
 
-    node.once(Node.EventName.DEPOSIT_CONFIRMED, args =>
-      this.updateAppRegistry({
-        canUseApps: true
-      })
-    );
+    node.once(Node.EventName.COUNTER_DEPOSIT_CONFIRMED, async args => {
+      console.log(args);
+      debugger;
+      await this.getBalances();
+    });
 
     let ret;
 

--- a/packages/playground/src/components/widgets/widget-spinner/widget-spinner.scss
+++ b/packages/playground/src/components/widgets/widget-spinner/widget-spinner.scss
@@ -1,4 +1,4 @@
-.spinner {
+.spinner--spinner-circle {
   display: inline-block;
   width: 14px;
   height: 14px;
@@ -7,25 +7,102 @@
   &.spinner--hidden {
     visibility: hidden;
   }
-}
 
-.spinner:after {
-  content: " ";
-  display: block;
-  width: 14px;
-  height: 14px;
-  margin: 1px;
-  border-radius: 50%;
-  border: 2px solid #000;
-  border-color: #000 transparent #000 transparent;
-  animation: spinner 1.2s linear infinite;
-}
-
-@keyframes spinner {
-  0% {
-    transform: rotate(0deg);
+  &.spinner--circle:after {
+    content: " ";
+    display: block;
+    width: 14px;
+    height: 14px;
+    margin: 1px;
+    border-radius: 50%;
+    border: 2px solid #000;
+    border-color: #000 transparent #000 transparent;
+    animation: spinner 1.2s linear infinite;
   }
-  100% {
-    transform: rotate(360deg);
+
+  @keyframes spinner {
+    0% {
+      transform: rotate(0deg);
+    }
+    100% {
+      transform: rotate(360deg);
+    }
+  }
+}
+
+.spinner--loading {
+  display: flex;
+  align-items: center;
+  flex-direction: column;
+  width: 80%;
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  text-align: center;
+  font-size: 3rem;
+  font-weight: 600;
+  color: $c-mediumgrey;
+
+  label {
+    font-size: 1rem;
+    font-family: inherit;
+    color: $c-darkgrey;
+  }
+
+  a {
+    display: block;
+    font-size: 0.9rem;
+    font-family: inherit;
+  }
+
+  .spinner-loading {
+    width: 70px;
+    text-align: center;
+  }
+
+  .spinner-loading > div {
+    width: 18px;
+    height: 18px;
+    background-color: $c-darkgrey;
+
+    border-radius: 100%;
+    display: inline-block;
+    -webkit-animation: sk-bouncedelay 1.4s infinite ease-in-out both;
+    animation: sk-bouncedelay 1.4s infinite ease-in-out both;
+  }
+
+  .spinner-loading .bounce1 {
+    -webkit-animation-delay: -0.32s;
+    animation-delay: -0.32s;
+  }
+
+  .spinner-loading .bounce2 {
+    -webkit-animation-delay: -0.16s;
+    animation-delay: -0.16s;
+  }
+
+  @-webkit-keyframes sk-bouncedelay {
+    0%,
+    80%,
+    100% {
+      -webkit-transform: scale(0);
+    }
+    40% {
+      -webkit-transform: scale(1);
+    }
+  }
+
+  @keyframes sk-bouncedelay {
+    0%,
+    80%,
+    100% {
+      -webkit-transform: scale(0);
+      transform: scale(0);
+    }
+    40% {
+      -webkit-transform: scale(1);
+      transform: scale(1);
+    }
   }
 }

--- a/packages/playground/src/components/widgets/widget-spinner/widget-spinner.tsx
+++ b/packages/playground/src/components/widgets/widget-spinner/widget-spinner.tsx
@@ -6,8 +6,37 @@ import { Component, Prop } from "@stencil/core";
 })
 export class WidgetSpinner {
   @Prop() visible: boolean = false;
+  @Prop() type: "circle" | "dots" = "circle";
+  @Prop() content: JSX.Element = {} as JSX.Element;
 
   render() {
-    return <div class={`spinner ${!this.visible ? "spinner--hidden" : ""}`} />;
+    if (this.type === "circle") {
+      return (
+        <div
+          class={`spinner spinner--circle ${
+            !this.visible ? "spinner--hidden" : ""
+          }`}
+        />
+      );
+    }
+
+    if (this.type === "dots") {
+      return (
+        <div
+          class={`spinner spinner--loading ${
+            !this.visible ? "spinner--hidden" : ""
+          }`}
+        >
+          <div class="spinner-loading">
+            <div class="bounce1" />
+            <div class="bounce2" />
+            <div class="bounce3" />
+          </div>
+          {this.content}
+        </div>
+      );
+    }
+
+    return;
   }
 }

--- a/packages/playground/src/data/app-registry.tsx
+++ b/packages/playground/src/data/app-registry.tsx
@@ -4,11 +4,12 @@ import { AppDefinition } from "../types";
 
 export interface AppRegistryState {
   apps: AppDefinition[];
-  updateAppRegistry?(data: AppRegistryState): Promise<void>;
+  canUseApps: boolean;
+  updateAppRegistry?(data: Partial<AppRegistryState>): Promise<void>;
 }
 
 export default createProviderConsumer<AppRegistryState>(
-  { apps: [] },
+  { apps: [], canUseApps: false },
   (subscribe, child) => (
     <context-consumer subscribe={subscribe} renderer={child} />
   )

--- a/packages/playground/src/data/wallet.tsx
+++ b/packages/playground/src/data/wallet.tsx
@@ -12,6 +12,8 @@ export interface WalletState {
   metamaskUnlocked?: boolean;
   networkPermitted?: boolean;
   updateWalletConnection?(data: Partial<WalletState>): Promise<void>;
+  getEtherscanAddressURL?: (address: string) => string;
+  getEtherscanTxURL?: (tx: string) => string;
 }
 
 export default createProviderConsumer<WalletState>({}, (subscribe, child) => (


### PR DESCRIPTION
This PR introduces an UI blocker to prevent access to the dApps until the state channel is fully prepared.
It also unifies the currently two implemented spinners into a single widget. :) 

Balance check is done via polling, eventually it can be improved to a transaction array check-up.

**Preview**

![deepin-screen-recorder_vivaldi-stable_20190302131007](https://user-images.githubusercontent.com/118913/53687705-b8affb00-3cec-11e9-8ab1-136a5008d6c1.gif)
