### PR TITLE
[playground] Fix visibility of etherscan link

### DIFF
--- a/packages/playground/src/components/widgets/widget-spinner/widget-spinner.scss
+++ b/packages/playground/src/components/widgets/widget-spinner/widget-spinner.scss
@@ -43,6 +43,7 @@
   font-size: 3rem;
   font-weight: 600;
   color: $c-mediumgrey;
+  z-index: 1;
 
   label {
     font-size: 1rem;


### PR DESCRIPTION
### Description

This ensures the Etherscan link being mentioned in the UI is clickable.

### Related issues

- [x] Deploy preview is functional
