### PR TITLE
[playground] Fixes multisig fetching async bug

### DIFF
--- a/packages/playground/src/components/app-root/app-root.tsx
+++ b/packages/playground/src/components/app-root/app-root.tsx
@@ -24,7 +24,8 @@ const NETWORK_NAME_URL_PREFIX_ON_ETHERSCAN = {
   "4": "rinkeby"
 };
 
-const delay = (timeInMilliseconds: number) => new Promise(resolve => setTimeout(resolve, timeInMilliseconds));
+const delay = (timeInMilliseconds: number) =>
+  new Promise(resolve => setTimeout(resolve, timeInMilliseconds));
 
 @Component({
   tag: "app-root",

--- a/packages/playground/src/components/app-root/app-root.tsx
+++ b/packages/playground/src/components/app-root/app-root.tsx
@@ -24,6 +24,8 @@ const NETWORK_NAME_URL_PREFIX_ON_ETHERSCAN = {
   "4": "rinkeby"
 };
 
+const delay = (timeInMilliseconds: number) => new Promise(resolve => setTimeout(resolve, timeInMilliseconds));
+
 @Component({
   tag: "app-root",
   styleUrl: "app-root.scss",
@@ -420,7 +422,8 @@ export class AppRoot {
     await this.updateAccount({ user });
 
     if (!user.multisigAddress) {
-      setTimeout(this.fetchMultisig.bind(this, userToken), 1000);
+      await delay(1000);
+      await this.fetchMultisig(userToken);
     } else {
       await this.requestToDepositInitialFunding();
     }


### PR DESCRIPTION
The Playground UI had a buggy implementation of a retry policy to fetch the multisig address, due to the use of `setTimeout` without properly wiring it to promises. This PR implements a `delay()` method as seen in 5132b7101bc860a68e601eb5854b2f606ae1274d.

**Preview**
![deepin-screen-recorder_vivaldi-stable_20190304085059](https://user-images.githubusercontent.com/118913/53748975-4578c700-3e5b-11e9-96d7-d49a73d98551.gif)
