### PR TITLE
[dapp-high-roller] [dapp-tic-tac-toe] Removes gas check on wager deposits

### DIFF
--- a/packages/dapp-high-roller/src/components/app-wager/app-wager.tsx
+++ b/packages/dapp-high-roller/src/components/app-wager/app-wager.tsx
@@ -77,22 +77,13 @@ export class AppWager {
         ]
       };
 
-      const provider = new ethers.providers.Web3Provider(
-        window["web3"].currentProvider
-      );
       const currentEthBalance = ethers.utils.parseEther(this.account.balance);
       const bet = ethers.utils.parseEther(this.betAmount);
-      const minimumEthBalance = bet.add(
-        await provider.estimateGas({
-          to: this.opponent.attributes.ethAddress,
-          value: ethers.utils.parseEther(this.betAmount)
-        })
-      );
 
-      if (currentEthBalance.lt(minimumEthBalance)) {
-        this.error = `Insufficient funds: You need at least ${ethers.utils.formatEther(
-          minimumEthBalance
-        )} ETH to play.`;
+      if (currentEthBalance.lt(bet)) {
+        this.error = `Insufficient funds: You need at least ${
+          this.betAmount
+        } ETH to play.`;
         return;
       }
 

--- a/packages/dapp-tic-tac-toe/src/Wager.jsx
+++ b/packages/dapp-tic-tac-toe/src/Wager.jsx
@@ -87,25 +87,16 @@ class Wager extends Component {
     const myAddress = user.ethAddress;
     const appFactory = this.createAppFactory();
 
-    const provider = new window.ethers.providers.Web3Provider(
-      window["web3"].currentProvider
-    );
     const currentEthBalance = window.ethers.utils.parseEther(
       this.props.balance
     );
     const bet = window.ethers.utils.parseEther(this.props.gameInfo.betAmount);
-    const minimumEthBalance = bet.add(
-      await provider.estimateGas({
-        to: opponent.nodeAddress,
-        value: window.ethers.utils.parseEther(this.props.gameInfo.betAmount)
-      })
-    );
 
-    if (currentEthBalance.lt(minimumEthBalance)) {
+    if (currentEthBalance.lt(bet)) {
       this.setState({
-        error: `Insufficient funds: You need at least ${window.ethers.utils.formatEther(
-          minimumEthBalance
-        )} ETH to play.`
+        error: `Insufficient funds: You need at least ${
+          this.props.gameInfo.betAmount
+        } ETH to play.`
       });
       return;
     }


### PR DESCRIPTION
Since the Playground now uses safe deposits through the Node, gas estimates are no longer necessary. This PR removes the validation checks for both dapps on their wager screens.