### PR TITLE
[dapp-high-roller] fix routing bug

### DIFF
--- a/packages/dapp-high-roller/src/components/app-logo/app-logo.tsx
+++ b/packages/dapp-high-roller/src/components/app-logo/app-logo.tsx
@@ -22,6 +22,7 @@ export class AppLogo {
     history: RouterHistory,
     initialState: any
   ) => void = () => {};
+  @Prop() provideRouterHistory: (history: RouterHistory) => void = () => {};
   @Prop() appInstance: any;
   @Prop() history: RouterHistory = {} as RouterHistory;
   @Prop() cfProvider: cf.Provider = {} as cf.Provider;
@@ -38,6 +39,9 @@ export class AppLogo {
       this.updateAppInstance(appInstance);
       this.goToWaitingRoom(this.history, this.opponent);
     }
+  }
+  async componentWillLoad() {
+    this.provideRouterHistory(this.history);
   }
 
   render() {

--- a/packages/dapp-high-roller/src/components/app-root/app-root.tsx
+++ b/packages/dapp-high-roller/src/components/app-root/app-root.tsx
@@ -280,7 +280,9 @@ export class AppRoot {
                         appInstance: this.state.appInstance,
                         goToWaitingRoom: this.goToWaitingRoom,
                         updateAppInstance: this.updateAppInstance,
-                        provideRouterHistory: this.receiveRouterHistory.bind(this)
+                        provideRouterHistory: this.receiveRouterHistory.bind(
+                          this
+                        )
                       }}
                     />
                     <stencil-route

--- a/packages/dapp-high-roller/src/components/app-root/app-root.tsx
+++ b/packages/dapp-high-roller/src/components/app-root/app-root.tsx
@@ -33,6 +33,7 @@ export class AppRoot {
   @Prop({ mutable: true }) uiState: HighRollerUIState;
 
   @State() userDataReceived: boolean = false;
+  @State() history: RouterHistory = {} as RouterHistory;
 
   constructor() {
     const params = new URLSearchParams(window.location.search);
@@ -136,6 +137,10 @@ export class AppRoot {
       this.updateAccount(mockAccount);
       this.userDataReceived = true;
     }
+  }
+
+  receiveRouterHistory(history: RouterHistory) {
+    this.history = history;
   }
 
   updateAccount(account: any) {
@@ -264,6 +269,7 @@ export class AppRoot {
                       this
                     )}
                     goToGame={this.goToGame.bind(this)}
+                    history={this.history}
                   >
                     <stencil-route
                       url="/"
@@ -273,7 +279,8 @@ export class AppRoot {
                         cfProvider: this.state.cfProvider,
                         appInstance: this.state.appInstance,
                         goToWaitingRoom: this.goToWaitingRoom,
-                        updateAppInstance: this.updateAppInstance
+                        updateAppInstance: this.updateAppInstance,
+                        provideRouterHistory: this.receiveRouterHistory.bind(this)
                       }}
                     />
                     <stencil-route

--- a/packages/playground-server/.env-cmdrc
+++ b/packages/playground-server/.env-cmdrc
@@ -2,7 +2,7 @@
   "development": {
     "STORE_PREFIX": "development",
     "DB_ENGINE": "pg",
-    "DB_CONNECTION_STRING": "postgresql://postgres@localhost:5432/postgres",
+    "DB_CONNECTION_STRING": "postgresql://postgres:postgres@localhost:5432/postgres",
     "PORT": "9000",
     "NODE_PRIVATE_KEY": "0x0123456789012345678901234567890123456789012345678901234567890123",
     "FIREBASE_SERVER_HOST": "localhost",

--- a/packages/playground-server/.env-cmdrc
+++ b/packages/playground-server/.env-cmdrc
@@ -2,7 +2,7 @@
   "development": {
     "STORE_PREFIX": "development",
     "DB_ENGINE": "pg",
-    "DB_CONNECTION_STRING": "postgresql://postgres:postgres@localhost:5432/postgres",
+    "DB_CONNECTION_STRING": "postgresql://postgres@localhost:5432/postgres",
     "PORT": "9000",
     "NODE_PRIVATE_KEY": "0x0123456789012345678901234567890123456789012345678901234567890123",
     "FIREBASE_SERVER_HOST": "localhost",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8089,10 +8089,10 @@ functional-red-black-tree@^1.0.1:
   resolved "https://registry.yarnpkg.com/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz#1b0ab3bd553b2a0d6399d29c0e3ea0b252078327"
   integrity sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=
 
-ganache-cli@6.4.0:
-  version "6.4.0"
-  resolved "https://registry.yarnpkg.com/ganache-cli/-/ganache-cli-6.4.0.tgz#1443a14429726d5a1d10c2127efc9503b2f32122"
-  integrity sha512-aujOqrN6tDaoKGpP6cPZR33r9Ko529FCHHG0/0dNB9a9e4lY/rilMXqrc4KfjEWcKvD5ts+4fcFKYFhT6W8HAw==
+ganache-cli@6.4.1:
+  version "6.4.1"
+  resolved "https://registry.yarnpkg.com/ganache-cli/-/ganache-cli-6.4.1.tgz#77c1682883a544dcad160b0e8155e282aefb4f1f"
+  integrity sha512-MUZ1DNnmlTrXnH6EuINuew75AI9d/wbIC0WpZCJo5Endsf6ZwEvfnfxGMpEnVizRri1mon2WWxLGAmALDxVcRQ==
   dependencies:
     bn.js "4.11.8"
     source-map-support "0.5.9"
@@ -8133,10 +8133,10 @@ ganache-core@2.4.0:
     ethereumjs-wallet "0.6.2"
     web3 "1.0.0-beta.35"
 
-ganache-core@2.5.1:
-  version "2.5.1"
-  resolved "https://registry.yarnpkg.com/ganache-core/-/ganache-core-2.5.1.tgz#731e88db70c12ac8a7c2b56a055483338523b739"
-  integrity sha512-sqTpmUtoExsUZqCqMdIZ+kPmXXu/fab755LpCaaty2u9EHb9gfIM9f/8gTpg0biaJ7LesbdyTfAbw66wHi4ujw==
+ganache-core@2.5.2:
+  version "2.5.2"
+  resolved "https://registry.yarnpkg.com/ganache-core/-/ganache-core-2.5.2.tgz#0f8d59f46e5c4669fab388ff19ded5de74a7d02c"
+  integrity sha512-uvKqc1NOjsoe2l6jdNstQ4PMOjqGPVMLo0MSoajKcpD2r7cBqofBnIDS2JdzRbMUzrRge4o8pl4RSgOcthiuLQ==
   dependencies:
     abstract-leveldown "3.0.0"
     async "2.6.1"


### PR DESCRIPTION
Due to [this issue](https://github.com/ionic-team/stencil-router/issues/79), only `stencil-route` components get the router history injected into them. This means that other components (such as the `app-provider`) do not have access to `this,history`, which in turn is preventing the redirect from working.

To get around this issue, I pass the router history from a route element up to the `app-root` and then back down to the `app-provider`. Once the StencilRouter issue is fixed, we'll be able to simply use `injectHistory` within the `app-provider`.