### PR TITLE
[node] Add a block num confirmation property on request handler

### DIFF
--- a/packages/node/src/methods/state-channel/create/controller.ts
+++ b/packages/node/src/methods/state-channel/create/controller.ts
@@ -14,7 +14,6 @@ import { ERRORS } from "../../errors";
 
 // TODO: Add good estimate for ProxyFactory.createProxy
 const CREATE_PROXY_AND_SETUP_GAS = 6e6;
-const CONFIRMATION_NUM_BLOCKS = 1;
 
 /**
  * This instantiates a StateChannel object to encapsulate the "channel"
@@ -45,11 +44,15 @@ export default class CreateChannelController extends NodeController {
     params: Node.CreateChannelParams
   ): Promise<Node.CreateChannelTransactionResult> {
     const { owners } = params;
-    const { wallet, networkContext } = requestHandler;
+    const {
+      wallet,
+      networkContext,
+      blocksNeededForConfirmation
+    } = requestHandler;
 
     const tx = await this.sendMultisigDeployTx(owners, wallet, networkContext);
 
-    tx.wait(CONFIRMATION_NUM_BLOCKS).then(receipt =>
+    tx.wait(blocksNeededForConfirmation).then(receipt =>
       this.handleDeployedMultisigOnChain(receipt, requestHandler, params)
     );
 

--- a/packages/node/src/request-handler.ts
+++ b/packages/node/src/request-handler.ts
@@ -13,6 +13,8 @@ import { IMessagingService, IStoreService } from "./services";
 import { Store } from "./store";
 import { NODE_EVENTS, NodeEvents, NodeMessage } from "./types";
 
+const REASONABLE_NUM_BLOCKS_TO_WAIT_ON_ROPSTEN = 3;
+
 /**
  * This class registers handlers for requests to get or set some information
  * about app instances and channels for this Node and any relevant peer Nodes.
@@ -33,11 +35,16 @@ export class RequestHandler {
     readonly networkContext: NetworkContext,
     readonly provider: BaseProvider,
     readonly wallet: Signer,
-    storeKeyPrefix: string
+    storeKeyPrefix: string,
+    readonly blocksNeededForConfirmation: number = REASONABLE_NUM_BLOCKS_TO_WAIT_ON_ROPSTEN
   ) {
     this.store = new Store(storeService, storeKeyPrefix);
     this.mapPublicApiMethods();
     this.mapEventHandlers();
+
+    if (this.provider.network.name === "unknown") {
+      this.blocksNeededForConfirmation = 1;
+    }
   }
 
   /**

--- a/packages/node/src/request-handler.ts
+++ b/packages/node/src/request-handler.ts
@@ -36,14 +36,19 @@ export class RequestHandler {
     readonly provider: BaseProvider,
     readonly wallet: Signer,
     storeKeyPrefix: string,
-    readonly blocksNeededForConfirmation: number = REASONABLE_NUM_BLOCKS_TO_WAIT_ON_ROPSTEN
+    readonly blocksNeededForConfirmation?: number
   ) {
     this.store = new Store(storeService, storeKeyPrefix);
     this.mapPublicApiMethods();
     this.mapEventHandlers();
 
-    if (this.provider.network.name === "unknown") {
-      this.blocksNeededForConfirmation = 1;
+    if (!this.blocksNeededForConfirmation) {
+      const name = provider.network ? provider.network.name : "unknown";
+      if (name === "ropsten") {
+        this.blocksNeededForConfirmation = REASONABLE_NUM_BLOCKS_TO_WAIT_ON_ROPSTEN;
+      } else {
+        this.blocksNeededForConfirmation = 1;
+      }
     }
   }
 


### PR DESCRIPTION
Locally when testing it needs to be `1` because `ganache-cli` does not progress blocks unless you tell it to. However on staging and other normal environments we want some reasonable number for the testnet. When I have been testing, 3 seems to work.