### PR TITLE
Increase node provider api timeout

### DIFF
--- a/packages/cf.js/src/provider.ts
+++ b/packages/cf.js/src/provider.ts
@@ -19,7 +19,7 @@ import {
 /**
  * Milliseconds until a method request to the Node is considered timed out.
  */
-export const NODE_REQUEST_TIMEOUT = 5000;
+export const NODE_REQUEST_TIMEOUT = 20000;
 
 /**
  * Provides convenience methods for interacting with a Counterfactual node


### PR DESCRIPTION
Because the forthcoming #927 PR adds a bunch of `eth_call`s inside the protocols, the API requests can take a while. Uninstall virtual app for example takes like 8 seconds locally. We can improve this in the future by using an local JS based EVM interpreter. `runCode` from here: https://github.com/ethereumjs/ethereumjs-vm works