### PR TITLE
[playground-server] Restricts matchmaking to user whitelist

### DIFF
--- a/packages/playground-server/.env-cmdrc
+++ b/packages/playground-server/.env-cmdrc
@@ -2,12 +2,13 @@
   "development": {
     "STORE_PREFIX": "development",
     "DB_ENGINE": "pg",
-    "DB_CONNECTION_STRING": "postgresql://postgres@localhost:5432/postgres",
+    "DB_CONNECTION_STRING": "postgresql://postgres:localdev@localhost:5432/postgres",
     "PORT": "9000",
     "NODE_PRIVATE_KEY": "0x0123456789012345678901234567890123456789012345678901234567890123",
     "FIREBASE_SERVER_HOST": "localhost",
     "FIREBASE_SERVER_PORT": "5555",
-    "NODE_MNEMONIC": "science amused table oyster text message core mirror patch bubble provide industry"
+    "NODE_MNEMONIC": "science amused table oyster text message core mirror patch bubble provide industry",
+    "MATCHMAKE_WHITELIST": "HighRollerBot,TicTacToeBot"
   },
   "test": {
     "STORE_PREFIX": "test",

--- a/packages/playground-server/src/db.ts
+++ b/packages/playground-server/src/db.ts
@@ -72,7 +72,7 @@ export async function matchmakeUser(userToMatch: User): Promise<MatchedUser> {
     throw Errors.UserAddressRequired();
   }
 
-  const query = db("users")
+  let query = db("users")
     .columns({
       id: "id",
       username: "username",
@@ -81,6 +81,13 @@ export async function matchmakeUser(userToMatch: User): Promise<MatchedUser> {
     })
     .select()
     .where("eth_address", "!=", userToMatch.attributes.ethAddress);
+
+  const { MATCHMAKE_WHITELIST } = process.env;
+
+  if (MATCHMAKE_WHITELIST) {
+    const allowedMatchmakes = MATCHMAKE_WHITELIST.split(",");
+    query = query.andWhere("username", "in", allowedMatchmakes);
+  }
 
   const matchmakeResults: {
     id: string;


### PR DESCRIPTION
This PR modifies the `matchmakeUser` DB call to consider a MATCHMAKE_WHITELIST env-var, currently set to contain a list of bot users.