### PR TITLE
[dapp-tic-tac-toe] Remove publish config from TTT dapp

### DIFF
--- a/packages/dapp-tic-tac-toe/package.json
+++ b/packages/dapp-tic-tac-toe/package.json
@@ -36,9 +36,6 @@
   "files": [
     "src"
   ],
-  "publishConfig": {
-    "registry": "https://registry.yarnpkg.com"
-  },
   "repository": {
     "type": "git",
     "url": "git+https://github.com/counterfactual/monorepo.git"


### PR DESCRIPTION
### Describes

Removes the publish config info so the package can be deployed.

### Related issues

https://circleci.com/gh/counterfactual/monorepo/22906?utm_campaign=workflow-failed&utm_medium=email&utm_source=notification
