### PR TITLE
[playground-server] Create user iff multisig deployment tx is successfully sent to network

### DIFF
--- a/packages/playground-server/src/resources/user/processor.ts
+++ b/packages/playground-server/src/resources/user/processor.ts
@@ -62,6 +62,12 @@ export default class UserProcessor extends OperationProcessor<User> {
       throw errors.AddressAlreadyRegistered();
     }
 
+    const { transactionHash } = await NodeWrapper.createStateChannelFor(
+      nodeAddress
+    );
+
+    user.attributes.transactionHash = transactionHash;
+
     // Create the Playground User.
     const newUser = await createUser(user);
 
@@ -69,11 +75,6 @@ export default class UserProcessor extends OperationProcessor<User> {
       tags: { userId: user.id, endpoint: "createAccount" }
     });
 
-    const { transactionHash } = await NodeWrapper.createStateChannelFor(
-      nodeAddress
-    );
-
-    newUser.attributes.transactionHash = transactionHash;
     await bindTransactionHashToUser(newUser, transactionHash);
 
     Log.info("Multisig has been requested", {


### PR DESCRIPTION
### Description

When a new user tries to register, if the multisig deployment fails server side, then the registration will not be considered successful.

If the user tries to register again, they can't because they'll receive the error "User already registered."

This ensures that the user is saved if and only if the multisig deployment transaction is successfully sent to the network. If it is not, the user is not saved and hence the user can try to register again.

- [x] Deploy preview is functional
