### PR TITLE
[playground][dapp-tic-tac-toe] balance safe guards and test faucet link

### DIFF
--- a/packages/dapp-tic-tac-toe/src/Wager.jsx
+++ b/packages/dapp-tic-tac-toe/src/Wager.jsx
@@ -194,6 +194,7 @@ class Wager extends Component {
             className="form__input"
             type="number"
             placeholder="0.01 eth"
+            disabled={true}
             min={0}
             max={0.01}
             step={0.00000001}

--- a/packages/playground/src/components/account/account-deposit/account-deposit.tsx
+++ b/packages/playground/src/components/account/account-deposit/account-deposit.tsx
@@ -85,9 +85,11 @@ export class AccountDeposit {
         <account-eth-form
           onSubmit={this.formSubmitionHandler.bind(this)}
           autofocus={true}
+          provideFaucetLink={true}
           button="Deposit"
           available={this.ethWeb3WalletBalance}
-          max={1}
+          min={0}
+          max={Number(ethers.utils.formatEther(this.ethWeb3WalletBalance))}
           error={this.error}
         />
       </widget-screen>

--- a/packages/playground/src/components/account/account-eth-form/account-eth-form.tsx
+++ b/packages/playground/src/components/account/account-eth-form/account-eth-form.tsx
@@ -11,6 +11,7 @@ export class AccountEthForm {
   @Prop() header: string = "";
   @Prop() button: string = "";
   @Prop() disabled: boolean = false;
+  @Prop() provideFaucetLink: boolean = false;
   @Prop() min: number = 0.01;
   @Prop() max: number = 1;
   @Prop() available: BigNumber = { _hex: "0x00" } as BigNumber;
@@ -22,6 +23,10 @@ export class AccountEthForm {
   update(event) {
     this.error = "";
     this.value = event.target.value;
+  }
+
+  openFaucet() {
+    window.open("https://faucet.metamask.io/", "_blank");
   }
 
   handleSubmit(event) {
@@ -78,6 +83,15 @@ export class AccountEthForm {
           >
             {this.button}
           </form-button>
+
+          {this.provideFaucetLink ?
+            <form-button
+              class="button button--secondary"
+              onButtonPressed={this.openFaucet.bind(this)}
+            >
+              Get Free ETH (test faucet)
+            </form-button>
+          : undefined}
         </form-container>
       </div>
     );

--- a/packages/playground/src/components/account/account-eth-form/account-eth-form.tsx
+++ b/packages/playground/src/components/account/account-eth-form/account-eth-form.tsx
@@ -84,14 +84,16 @@ export class AccountEthForm {
             {this.button}
           </form-button>
 
-          {this.provideFaucetLink ?
+          {this.provideFaucetLink ? (
             <form-button
               class="button button--secondary"
               onButtonPressed={this.openFaucet.bind(this)}
             >
               Get Free ETH (test faucet)
             </form-button>
-          : undefined}
+          ) : (
+            undefined
+          )}
         </form-container>
       </div>
     );

--- a/packages/playground/src/components/account/account-exchange/account-exchange.tsx
+++ b/packages/playground/src/components/account/account-exchange/account-exchange.tsx
@@ -157,10 +157,11 @@ export class AccountExchange {
             button={this.isDepositPending ? "Deposit in progress" : "Deposit"}
             disabled={this.isDepositPending ? true : false}
             loading={this.isDepositPending ? true : false}
+            provideFaucetLink={true}
             error={this.depositError}
             available={this.ethWeb3WalletBalance}
-            min={0.01}
-            max={1}
+            min={0}
+            max={Number(ethers.utils.formatEther(this.ethWeb3WalletBalance))}
           />
         </div>
 


### PR DESCRIPTION
* validate that deposit is not larger than eth account balance
* force ttt players to bet .1 eth
* add button beneath deposit forms that links to ropsten faucet

![screenshot from 2019-03-07 15-53-02](https://user-images.githubusercontent.com/2700872/53997519-59d5f180-40f1-11e9-842f-adb1c60c4d20.png)
![screenshot from 2019-03-07 15-52-20](https://user-images.githubusercontent.com/2700872/53997521-5b9fb500-40f1-11e9-98e1-0cc29c4f51dd.png)
