### PR TITLE
[machine] Add retry logic for fetching blockchain state on resolve

### DIFF
--- a/packages/machine/package.json
+++ b/packages/machine/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@counterfactual/machine",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "main": "dist/index.js",
   "types": "dist/src/index.d.ts",
   "module": "dist/index.es.js",

--- a/packages/machine/src/protocol/utils/get-resolution-increments.ts
+++ b/packages/machine/src/protocol/utils/get-resolution-increments.ts
@@ -38,7 +38,7 @@ export async function computeFreeBalanceIncrements(
   //        arbitrary asset types. Presently it only works for ETH resolutions.
   //        This was added to get the Playground demo launched sooner.
   const wait = (ms: number) => new Promise(r => setTimeout(r, ms));
-  while (resolution.value.every(v => v.eq(Zero)) && attempts < 10) {
+  while (resolution.value.every(v => v.eq(Zero)) && attempts < 15) {
     console.log(
       `Found empty resolution. Querying blockchain again. Attempt #${attempts}`
     );

--- a/packages/machine/src/protocol/utils/get-resolution-increments.ts
+++ b/packages/machine/src/protocol/utils/get-resolution-increments.ts
@@ -3,7 +3,7 @@ import { AssetType } from "@counterfactual/types";
 import { Contract } from "ethers";
 import { Zero } from "ethers/constants";
 import { BaseProvider } from "ethers/providers";
-import { BigNumber } from "ethers/utils";
+import { BigNumber, bigNumberify } from "ethers/utils";
 
 import { StateChannel } from "../../models";
 
@@ -38,10 +38,13 @@ export async function computeFreeBalanceIncrements(
   //        arbitrary asset types. Presently it only works for ETH resolutions.
   //        This was added to get the Playground demo launched sooner.
   const wait = (ms: number) => new Promise(r => setTimeout(r, ms));
-  while (resolution.value.every(v => v.eq(Zero)) && attempts < 15) {
-    console.log(
-      `Found empty resolution. Querying blockchain again. Attempt #${attempts}`
-    );
+  while (
+    bigNumberify(appInstance.terms.limit).gt(Zero) &&
+    resolution.value.every(v => v.eq(Zero)) &&
+    attempts < 15
+  ) {
+    console.log(appInstance.terms);
+    console.log(`Empty resolution. Querying chain again. Attempt #${attempts}`);
 
     resolution = await appContract.functions.resolve(
       appInstance.encodedLatestState,

--- a/packages/machine/src/protocol/utils/get-resolution-increments.ts
+++ b/packages/machine/src/protocol/utils/get-resolution-increments.ts
@@ -1,6 +1,7 @@
 import CounterfactualApp from "@counterfactual/contracts/build/CounterfactualApp.json";
 import { AssetType } from "@counterfactual/types";
 import { Contract } from "ethers";
+import { Zero } from "ethers/constants";
 import { BaseProvider } from "ethers/providers";
 import { BigNumber } from "ethers/utils";
 
@@ -27,10 +28,31 @@ export async function computeFreeBalanceIncrements(
     provider
   );
 
-  const resolution: TransferTransaction = await appContract.functions.resolve(
+  let attempts = 1;
+  let resolution: TransferTransaction = await appContract.functions.resolve(
     appInstance.encodedLatestState,
     appInstance.terms
   );
+
+  // FIXME: This retry logic should apply to all view functions _and_ works for
+  //        arbitrary asset types. Presently it only works for ETH resolutions.
+  //        This was added to get the Playground demo launched sooner.
+  const wait = (ms: number) => new Promise(r => setTimeout(r, ms));
+  while (resolution.value.every(v => v.eq(Zero)) && attempts < 10) {
+    console.log(
+      `Found empty resolution. Querying blockchain again. Attempt #${attempts}`
+    );
+
+    resolution = await appContract.functions.resolve(
+      appInstance.encodedLatestState,
+      appInstance.terms
+    );
+
+    attempts += 1;
+
+    await wait(1000 * attempts);
+  }
+  // END FIXME
 
   if (resolution.assetType !== AssetType.ETH) {
     return Promise.reject("Node only supports ETH resolutions at the moment.");

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@counterfactual/node",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "main": "dist/index.js",
   "iife": "dist/index.iife.js",
   "types": "dist/src/index.d.ts",
@@ -34,7 +34,7 @@
   "dependencies": {
     "@counterfactual/cf.js": "0.1.1",
     "@counterfactual/contracts": "0.1.0",
-    "@counterfactual/machine": "0.1.2",
+    "@counterfactual/machine": "0.1.3",
     "@counterfactual/types": "0.0.9",
     "@firebase/util": "0.*",
     "@firebase/app-types": "0.*",

--- a/packages/node/src/methods/state-channel/deposit/controller.ts
+++ b/packages/node/src/methods/state-channel/deposit/controller.ts
@@ -40,12 +40,12 @@ export default class DepositController extends NodeController {
       return Promise.reject(ERRORS.CANNOT_DEPOSIT);
     }
 
-    const balanceOfSigner = await provider.getBalance(
-      await (await requestHandler.getSigner()).getAddress()
-    );
+    const address = await requestHandler.getSignerAddress();
+
+    const balanceOfSigner = await provider.getBalance(address);
 
     if (balanceOfSigner.lt(amount)) {
-      return Promise.reject(ERRORS.INSUFFICIENT_FUNDS);
+      return Promise.reject(`${ERRORS.INSUFFICIENT_FUNDS}: ${address}`);
     }
   }
 

--- a/packages/playground-server/package.json
+++ b/packages/playground-server/package.json
@@ -31,7 +31,7 @@
     "url": "https://github.com/counterfactual/monorepo/issues"
   },
   "dependencies": {
-    "@counterfactual/node": "0.1.2",
+    "@counterfactual/node": "0.1.3",
     "@counterfactual/types": "0.0.9",
     "@counterfactual/typescript-typings": "0.1.0",
     "@ebryn/jsonapi-ts": "^0.0.4",

--- a/packages/playground-server/src/node.ts
+++ b/packages/playground-server/src/node.ts
@@ -145,7 +145,10 @@ export default class NodeWrapper {
       {
         STORE_KEY_PREFIX: "store"
       },
-      provider || new JsonRpcProvider("https://ropsten.infura.io/metamask"),
+      provider ||
+        new JsonRpcProvider(
+          `https://${networkOrNetworkContext}.infura.io/metamask`
+        ),
       networkOrNetworkContext
     );
 

--- a/packages/playground-server/src/node.ts
+++ b/packages/playground-server/src/node.ts
@@ -7,7 +7,6 @@ import {
   Node
 } from "@counterfactual/node";
 import { NetworkContext, Node as NodeTypes } from "@counterfactual/types";
-import { ethers } from "ethers";
 import { JsonRpcProvider } from "ethers/providers";
 import FirebaseServer from "firebase-server";
 import { Log } from "logepi";
@@ -146,7 +145,7 @@ export default class NodeWrapper {
       {
         STORE_KEY_PREFIX: "store"
       },
-      provider || ethers.getDefaultProvider(networkOrNetworkContext as string),
+      provider || new JsonRpcProvider("https://ropsten.infura.io/metamask"),
       networkOrNetworkContext
     );
 

--- a/packages/playground/package.json
+++ b/packages/playground/package.json
@@ -13,7 +13,7 @@
     "test:watch": "stencil test --spec --e2e --watchAll"
   },
   "dependencies": {
-    "@counterfactual/node": "0.1.2",
+    "@counterfactual/node": "0.1.3",
     "@counterfactual/types": "0.0.9",
     "@stencil/core": "^0.18.0",
     "@stencil/router": "^0.3.0",

--- a/packages/tic-tac-toe-bot/package.json
+++ b/packages/tic-tac-toe-bot/package.json
@@ -30,7 +30,7 @@
     "url": "https://github.com/counterfactual/monorepo/issues"
   },
   "dependencies": {
-    "@counterfactual/node": "0.1.2",
+    "@counterfactual/node": "0.1.3",
     "@counterfactual/dapp-tic-tac-toe": "0.1.1",
     "@counterfactual/types": "^0.0.9",
     "eventemitter3": "^3.1.0"

--- a/packages/tic-tac-toe-bot/src/index.ts
+++ b/packages/tic-tac-toe-bot/src/index.ts
@@ -15,7 +15,9 @@ import {
   UserSession
 } from "./utils";
 
-const provider = ethers.getDefaultProvider("ropsten");
+const provider = new ethers.providers.JsonRpcProvider(
+  "https://ropsten.infura.io/metamask"
+);
 
 const BASE_URL = process.env.BASE_URL!;
 const TOKEN_PATH = "TTT_USER_TOKEN";


### PR DESCRIPTION
- Added retry logic of 15 attempts, waits 1 second * numAttempts per attempt
- Uses Infura ONLY as the backend versus Infura OR Etherscan
- Confirmations needed is now 1 block not 4 (since we were using confirmations as a proxy of waiting time anyway)