### PR TITLE
[playground] link to kovan faucet

### DIFF
--- a/packages/playground/src/components/account/account-eth-form/account-eth-form.tsx
+++ b/packages/playground/src/components/account/account-eth-form/account-eth-form.tsx
@@ -26,7 +26,7 @@ export class AccountEthForm {
   }
 
   openFaucet() {
-    window.open("https://faucet.metamask.io/", "_blank");
+    window.open("https://faucet.kovan.network/", "_blank");
   }
 
   handleSubmit(event) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2147,6 +2147,11 @@
   resolved "https://registry.yarnpkg.com/@types/jest-diff/-/jest-diff-20.0.1.tgz#35cc15b9c4f30a18ef21852e255fdb02f6d59b89"
   integrity sha512-yALhelO3i0hqZwhjtcr6dYyaLoCHbAMshwtj6cGxTvHZAKXHsYGdff6E8EPw3xLKY0ELUTQ69Q1rQiJENnccMA==
 
+"@types/jest@23.3.14":
+  version "23.3.14"
+  resolved "https://registry.yarnpkg.com/@types/jest/-/jest-23.3.14.tgz#37daaf78069e7948520474c87b80092ea912520a"
+  integrity sha512-Q5hTcfdudEL2yOmluA1zaSyPbzWPmJ3XfSWeP3RyoYvS9hnje1ZyagrZOuQ6+1nQC1Gw+7gap3pLNL3xL6UBug==
+
 "@types/jest@24.0.10":
   version "24.0.10"
   resolved "https://registry.yarnpkg.com/@types/jest/-/jest-24.0.10.tgz#a7b49ed1c23e518b1381596eb0ad9736eb6f2f64"


### PR DESCRIPTION
The deposit form has a link to the test network faucet. This changes the link from ropsten to kovan.