### PR TITLE
[contracts] remove truffle compiler version to avoid confusion

### DIFF
--- a/packages/contracts/truffle-config.js
+++ b/packages/contracts/truffle-config.js
@@ -6,7 +6,7 @@ require("dotenv").config();
 module.exports = {
   compilers: {
     solc: {
-      version: "0.5.3",
+      version: "0.5.5",
     },
   },
   networks: {


### PR DESCRIPTION
Since all contracts are upgraded by bot, and we are using waffle instead of truffle for contract build, it's better to remove the compiler version to avoid confusion. 