### PR TITLE
[dapp-high-roller] Fixes randomness logic in high roller for contract

### DIFF
--- a/packages/dapp-high-roller/src/components/app-root/app-root.tsx
+++ b/packages/dapp-high-roller/src/components/app-root/app-root.tsx
@@ -189,7 +189,7 @@ export class AppRoot {
     num1: number,
     num2: number
   ): Promise<{ myRoll: number[]; opponentRoll: number[] }> {
-    const randomness = solidityKeccak256(["uint256", "uint256"], [num1, num2]);
+    const randomness = solidityKeccak256(["uint256"], [num1 * num2]);
 
     // The Contract interface
     const abi = [


### PR DESCRIPTION
### Description

Fixes randomness logic in high roller for contract.
Logic for determining randomness in the Solidity contract was this:
`randomness = keccak256(abi.encodePacked(num1 * num2));`
In the dApp code was this:
`const randomness = solidityKeccak256(["uint256", "uint256"], [num1, num2]);`

This caused different randomness values which caused the UI to show different states than what the contract was actually resolving.
You thought you won but you actually lost 😅 

### Related issues

[Link here any issues relevant to this PR, using the GitHub `fixes/resolves/closes` keywords to close related issues automatically.]

- [ ] Deploy preview is functional
