### PR TITLE
[circleci] Update circleci config with 2 more heroku apps

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -133,6 +133,29 @@ workflows:
             - build
 
       - heroku/deploy-via-git:
+          app-name: playground-server-staging
+          requires:
+            - build
+            - run-tests
+            - run-playground-tests
+            - run-tslint
+          filters:
+            branches:
+              only: master
+
+      - heroku/deploy-via-git:
+          app-name: hr-bot-staging
+          requires:
+            - build
+            - run-tests
+            - run-playground-tests
+            - run-tslint
+          filters:
+            branches:
+              only: master
+
+      - heroku/deploy-via-git:
+          app-name: ttt-bot-staging
           requires:
             - build
             - run-tests


### PR DESCRIPTION
If `app-name` is not specified it was using `HEROKU_APP_NAME` in env which we set on circleci UI

doc: https://circleci.com/orbs/registry/orb/circleci/heroku