### PR TITLE
[playground] For post-deposit, converts pending flags @State(), so they trigger rendering

### DIFF
--- a/packages/playground/src/components/account/account-exchange/account-exchange.tsx
+++ b/packages/playground/src/components/account/account-exchange/account-exchange.tsx
@@ -49,17 +49,42 @@ export class AccountExchange {
     });
   }
 
+  @Watch("ethPendingDepositTxHash")
+  onEthPendingDepositTxHashChanged() {
+    this.updateDepositPendingState();
+  }
+
+  @Watch("ethPendingDepositAmountWei")
+  onEthPendingDepositAmountWeiChanged() {
+    this.updateDepositPendingState();
+  }
+
+  @Watch("ethPendingWithdrawalTxHash")
+  onEthPendingWithdrawalTxHashChanged() {
+    this.updateWithdrawalPendingState();
+  }
+
+  @Watch("ethPendingWithdrawalAmountWei")
+  onEthPendingWithdrawalAmountWeiChanged() {
+    this.updateDepositPendingState();
+  }
+
   @State() depositError: string = "";
   @State() withdrawalError: string = "";
 
-  get isDepositPending() {
-    return this.ethPendingDepositTxHash && this.ethPendingDepositAmountWei;
+  @State() isDepositPending: Boolean = false;
+  @State() isWithdrawalPending: Boolean = false;
+
+  updateDepositPendingState() {
+    this.isDepositPending =
+      Boolean(this.ethPendingDepositTxHash) &&
+      Boolean(this.ethPendingDepositAmountWei);
   }
 
-  get isWithdrawalPending() {
-    return (
-      this.ethPendingWithdrawalTxHash && this.ethPendingWithdrawalAmountWei
-    );
+  updateWithdrawalPendingState() {
+    this.isWithdrawalPending =
+      Boolean(this.ethPendingWithdrawalTxHash) &&
+      Boolean(this.ethPendingWithdrawalAmountWei);
   }
 
   @Watch("user")


### PR DESCRIPTION
__Previously on "The Playground"...__

The `isDepositPending` and `isWithdrawalPending` flags were private getters (which can't use the `@State` decorator), so they wouldn't be able to trigger changes to the render if the tunneled properties used to compute its value didn't change.

This PR explicitly uses a combination of `@Watch` + `@State` to make sure we're listening for the changes at the right moment.

*[cue opening theme]*