### PR TITLE
[machine] sort userNeuteredExtendedKeys in getChannelFromCounterparty

### DIFF
--- a/packages/machine/src/protocol/utils/get-channel-from-counterparty.ts
+++ b/packages/machine/src/protocol/utils/get-channel-from-counterparty.ts
@@ -16,7 +16,7 @@ export function getChannelFromCounterparty(
   const expectedExtendedKeys = [me, counterparty].sort();
   return [...stateChannelsMap.values()].find(
     sc =>
-      JSON.stringify(sc.userNeuteredExtendedKeys) ===
+      JSON.stringify(sc.userNeuteredExtendedKeys.concat().sort()) ===
       JSON.stringify(expectedExtendedKeys)
   );
 }


### PR DESCRIPTION
AFAICT `userNeuteredExtendedKeys` is not sorted, so the previous code should not have worked