### PR TITLE
[dapp-high-roller] Fix High Roller Winner Player Logic

### DIFF
--- a/packages/dapp-high-roller/src/components/app-provider/app-provider.tsx
+++ b/packages/dapp-high-roller/src/components/app-provider/app-provider.tsx
@@ -35,7 +35,10 @@ export class AppProvider {
   @Prop() highRoller: (
     num1: number,
     num2: number
-  ) => Promise<{ playerFirstRoll: number[]; playerSecondRoll: number[] }> = async () => ({
+  ) => Promise<{
+    playerFirstRoll: number[];
+    playerSecondRoll: number[];
+  }> = async () => ({
     playerFirstRoll: [0, 0],
     playerSecondRoll: [0, 0]
   });
@@ -132,7 +135,9 @@ export class AppProvider {
 
     const isProposing = state.stage === HighRollerStage.DONE;
     const myRoll = isProposing ? rolls.playerFirstRoll : rolls.playerSecondRoll;
-    const opponentRoll = isProposing ? rolls.playerSecondRoll : rolls.playerFirstRoll;
+    const opponentRoll = isProposing
+      ? rolls.playerSecondRoll
+      : rolls.playerFirstRoll;
 
     const totalMyRoll = myRoll[0] + myRoll[1];
     const totalOpponentRoll = opponentRoll[0] + opponentRoll[1];

--- a/packages/dapp-high-roller/src/components/app-provider/app-provider.tsx
+++ b/packages/dapp-high-roller/src/components/app-provider/app-provider.tsx
@@ -35,9 +35,9 @@ export class AppProvider {
   @Prop() highRoller: (
     num1: number,
     num2: number
-  ) => Promise<{ myRoll: number[]; opponentRoll: number[] }> = async () => ({
-    myRoll: [0, 0],
-    opponentRoll: [0, 0]
+  ) => Promise<{ playerFirstRoll: number[]; playerSecondRoll: number[] }> = async () => ({
+    playerFirstRoll: [0, 0],
+    playerSecondRoll: [0, 0]
   });
   @Prop() generateRandomRoll: () => number[] = () => [0, 0];
   @Prop() highRollerState: HighRollerAppState = {} as HighRollerAppState;
@@ -130,10 +130,9 @@ export class AppProvider {
       state.playerSecondNumber
     );
 
-    const myRoll =
-      state.stage < HighRollerStage.DONE ? rolls.myRoll : rolls.opponentRoll;
-    const opponentRoll =
-      state.stage < HighRollerStage.DONE ? rolls.opponentRoll : rolls.myRoll;
+    const isProposing = state.stage === HighRollerStage.DONE;
+    const myRoll = isProposing ? rolls.playerFirstRoll : rolls.playerSecondRoll;
+    const opponentRoll = isProposing ? rolls.playerSecondRoll : rolls.playerFirstRoll;
 
     const totalMyRoll = myRoll[0] + myRoll[1];
     const totalOpponentRoll = opponentRoll[0] + opponentRoll[1];

--- a/packages/dapp-high-roller/src/components/app-root/app-root.tsx
+++ b/packages/dapp-high-roller/src/components/app-root/app-root.tsx
@@ -188,7 +188,7 @@ export class AppRoot {
   async highRoller(
     num1: any,
     num2: any
-  ): Promise<{ myRoll: number[]; opponentRoll: number[] }> {
+  ): Promise<{ playerFirstRoll: number[]; playerSecondRoll: number[] }> {
     const randomness = solidityKeccak256(["uint256"], [num1.mul(num2)]);
 
     // The Contract interface
@@ -208,8 +208,8 @@ export class AppRoot {
     const result = await contract.highRoller(randomness);
 
     return {
-      myRoll: this.getDieNumbers(result[0]),
-      opponentRoll: this.getDieNumbers(result[1])
+      playerFirstRoll: this.getDieNumbers(result[0]),
+      playerSecondRoll: this.getDieNumbers(result[1])
     };
   }
 


### PR DESCRIPTION
### Description

High Roller winner logic was reversed.
The contract was returning correct dice rolls but the UI was putting the winnerRollResult into the LoserRolls :trollface: 

This fixes that. There is also an `isProposing` prop that is passed around in the game. Maybe we should be using this?

### Related issues

[Link here any issues relevant to this PR, using the GitHub `fixes/resolves/closes` keywords to close related issues automatically.]

- [ ] Deploy preview is functional
