### PR TITLE
[node] Add error message on attempt to uninstall already uninstalled app

### DIFF
--- a/packages/node/src/methods/app-instance/uninstall-virtual/controller.ts
+++ b/packages/node/src/methods/app-instance/uninstall-virtual/controller.ts
@@ -27,6 +27,20 @@ export default class UninstallVirtualController extends NodeController {
     return requestHandler.getShardedQueue(metachannel.multisigAddress);
   }
 
+  protected async beforeExecution(
+    requestHandler: RequestHandler,
+    params: Node.UninstallVirtualParams
+  ) {
+    const { store } = requestHandler;
+    const { appInstanceId } = params;
+
+    const stateChannel = await store.getChannelFromAppInstanceID(appInstanceId);
+
+    if (!stateChannel.hasAppInstance(appInstanceId)) {
+      throw new Error(ERRORS.APP_ALREADY_UNINSTALLED(appInstanceId));
+    }
+  }
+
   protected async executeMethodImplementation(
     requestHandler: RequestHandler,
     params: Node.UninstallVirtualParams
@@ -39,6 +53,10 @@ export default class UninstallVirtualController extends NodeController {
     }
 
     const stateChannel = await store.getChannelFromAppInstanceID(appInstanceId);
+
+    if (!stateChannel.hasAppInstance(appInstanceId)) {
+      throw new Error(ERRORS.APP_ALREADY_UNINSTALLED(appInstanceId));
+    }
 
     const to = getCounterpartyAddress(
       publicIdentifier,

--- a/packages/node/src/methods/app-instance/uninstall/controller.ts
+++ b/packages/node/src/methods/app-instance/uninstall/controller.ts
@@ -23,6 +23,20 @@ export default class UninstallController extends NodeController {
     );
   }
 
+  protected async beforeExecution(
+    requestHandler: RequestHandler,
+    params: Node.UninstallParams
+  ) {
+    const { store } = requestHandler;
+    const { appInstanceId } = params;
+
+    const stateChannel = await store.getChannelFromAppInstanceID(appInstanceId);
+
+    if (!stateChannel.hasAppInstance(appInstanceId)) {
+      throw new Error(ERRORS.APP_ALREADY_UNINSTALLED(appInstanceId));
+    }
+  }
+
   protected async executeMethodImplementation(
     requestHandler: RequestHandler,
     params: Node.UninstallParams
@@ -40,6 +54,10 @@ export default class UninstallController extends NodeController {
     }
 
     const stateChannel = await store.getChannelFromAppInstanceID(appInstanceId);
+
+    if (!stateChannel.hasAppInstance(appInstanceId)) {
+      throw new Error(ERRORS.APP_ALREADY_UNINSTALLED(appInstanceId));
+    }
 
     const to = getCounterpartyAddress(
       publicIdentifier,

--- a/packages/node/src/methods/errors.ts
+++ b/packages/node/src/methods/errors.ts
@@ -1,4 +1,6 @@
 export const ERRORS = {
+  APP_ALREADY_UNINSTALLED: id =>
+    `Cannot uninstall app ${id}, it has already been uninstalled`,
   NO_APP_INSTANCE_ID_FOR_GET_STATE:
     "No AppInstanceID specified to get state for",
   NO_APP_INSTANCE_ID_TO_GET_DETAILS:


### PR DESCRIPTION
Added it twice because you might call the method while another uninstall request is currently pending in the queue or being executed and have the `beforeExecution` method not catch this.