### PR TITLE
[playground] Fix hash links for dApps if they're not yet available

### DIFF
--- a/packages/playground/src/components/app-home/app-home/app-home.tsx
+++ b/packages/playground/src/components/app-home/app-home/app-home.tsx
@@ -189,7 +189,6 @@ export class AppHome {
       <div class="container">
         <apps-list
           apps={this.apps}
-          canUseApps={this.canUseApps}
           onAppClicked={e => this.appClickedHandler(e)}
           name="Available Apps"
         />

--- a/packages/playground/src/components/app-home/apps-list-item/apps-list-item.tsx
+++ b/packages/playground/src/components/app-home/apps-list-item/apps-list-item.tsx
@@ -1,4 +1,13 @@
-import { Component, Event, EventEmitter, Prop } from "@stencil/core";
+import {
+  Component,
+  Element,
+  Event,
+  EventEmitter,
+  Prop,
+  State
+} from "@stencil/core";
+
+import AppRegistryTunnel from "../../../data/app-registry";
 
 @Component({
   tag: "apps-list-item",
@@ -6,12 +15,16 @@ import { Component, Event, EventEmitter, Prop } from "@stencil/core";
   shadow: true
 })
 export class AppsListItem {
+  @Element() el: HTMLStencilElement = {} as HTMLStencilElement;
+
   @Event() appClicked: EventEmitter = {} as EventEmitter;
   @Prop() icon: string = "";
   @Prop() name: string = "";
   @Prop() notifications: number | null = null;
   @Prop() url: string = "";
-  @Prop() canUse: boolean = false;
+  @Prop() canUseApps: boolean = false;
+
+  @State() modalVisible: boolean = false;
 
   private getAppSlug() {
     return this.name.toLowerCase().replace(/ /g, "-");
@@ -22,12 +35,23 @@ export class AppsListItem {
     this.appClicked.emit(event);
   }
 
+  showModal() {
+    this.modalVisible = true;
+  }
+
+  hideModal() {
+    this.modalVisible = false;
+  }
+
   private openApp(event: MouseEvent) {
     event.preventDefault();
 
-    if (!this.canUse) {
+    if (!this.canUseApps) {
+      this.showModal();
       return;
     }
+
+    this.hideModal();
 
     this.appClicked.emit({
       name: this.name,
@@ -40,7 +64,7 @@ export class AppsListItem {
     return (
       <li class="item">
         <a
-          href={this.canUse ? `/dapp/${this.getAppSlug()}` : "#"}
+          href={this.canUseApps ? `/dapp/${this.getAppSlug()}` : "#"}
           onClick={e => this.openApp(e)}
         >
           <div class="icon">
@@ -51,7 +75,16 @@ export class AppsListItem {
           </div>
           <span class="name">{this.name}</span>
         </a>
+        <widget-dialog
+          visible={this.modalVisible}
+          dialogTitle="One moment, please!"
+          content="Your state channel is still collateralizing. Try again in 10-15 seconds."
+          primaryButtonText="OK, I'll wait"
+          onPrimaryButtonClicked={this.hideModal.bind(this)}
+        />
       </li>
     );
   }
 }
+
+AppRegistryTunnel.injectProps(AppsListItem, ["canUseApps"]);

--- a/packages/playground/src/components/app-home/apps-list/apps-list.tsx
+++ b/packages/playground/src/components/app-home/apps-list/apps-list.tsx
@@ -1,7 +1,6 @@
 import { Component, Element, Event, EventEmitter, Prop } from "@stencil/core";
 
 import AccountTunnel from "../../../data/account";
-import AppRegistryTunnel from "../../../data/app-registry";
 import { AppDefinition, UserSession } from "../../../types";
 
 @Component({
@@ -13,7 +12,6 @@ export class AppsList {
   @Element() el: HTMLStencilElement = {} as HTMLStencilElement;
   @Event() appClicked: EventEmitter = {} as EventEmitter;
   @Prop() apps: AppDefinition[] = [];
-  @Prop() canUseApps: boolean = false;
   @Prop() name: string = "";
   @Prop() user: UserSession = {} as UserSession;
 
@@ -31,7 +29,6 @@ export class AppsList {
             <apps-list-item
               onAppClicked={e => this.appClickedHandler(e)}
               icon={app.icon}
-              canUse={this.canUseApps}
               name={app.name}
               notifications={app.notifications}
               url={app.url}
@@ -44,4 +41,3 @@ export class AppsList {
 }
 
 AccountTunnel.injectProps(AppsList, ["user"]);
-AppRegistryTunnel.injectProps(AppsList, ["canUseApps"]);

--- a/packages/playground/src/components/app-root/app-root.tsx
+++ b/packages/playground/src/components/app-root/app-root.tsx
@@ -180,7 +180,7 @@ export class AppRoot {
   async loadApps() {
     const apps = await PlaygroundAPIClient.getApps();
 
-    this.updateAppRegistry({ apps });
+    await this.updateAppRegistry({ apps });
   }
 
   bindProviderEvents() {
@@ -303,7 +303,7 @@ export class AppRoot {
       .sub(this.lastCounterpartyBalance)
       .eq(this.lastDeposit);
 
-    this.updateAppRegistry({
+    await this.updateAppRegistry({
       canUseApps
     });
 


### PR DESCRIPTION
This should solve the following issues:

- The apps are not blocked on the UI when the channel is not fully collateralized
- fix the dapps on home screen having a `/#` link instead of correct links after the registration & deposit flow is complete