### PR TITLE
[dapp-high-roller] [playground] Pre-launch fixes

### DIFF
--- a/packages/dapp-high-roller/src/components/app-root/app-root.tsx
+++ b/packages/dapp-high-roller/src/components/app-root/app-root.tsx
@@ -73,7 +73,11 @@ export class AppRoot {
 
     window.addEventListener("popstate", () => {
       window.parent.postMessage(
-        `playground:send:dappRoute|${location.hash}`,
+        `playground:send:dappRoute|${location.hash}${
+          this.state.appInstance
+            ? `?appInstanceId=${this.state.appInstance.id}`
+            : ""
+        }`,
         "*"
       );
     });

--- a/packages/dapp-high-roller/src/data/game-types.ts
+++ b/packages/dapp-high-roller/src/data/game-types.ts
@@ -13,7 +13,6 @@ export type HighRollerAppState = {
   commitHash: string;
   playerFirstNumber: number;
   playerSecondNumber: number;
-  playerNames?: string[];
 };
 
 export enum ActionType {


### PR DESCRIPTION
This should take care of:

- The rematch button does not work on HR
- The exit button does not work. After clicking exit and then play on HR the UI is from the old game
- The appInstanceId is not inside the URL of the HR game
- The "waiting for collateralization modal" is incorrectly popping up instead of the `/#` url bug from before