### PR TITLE
[node] pass --verbose to jest test

### DIFF
--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -7,7 +7,7 @@
   "license": "MIT",
   "scripts": {
     "build": "rollup -c",
-    "test": "jest --setupFiles dotenv-extended/config --runInBand --bail --forceExit",
+    "test": "jest --setupFiles dotenv-extended/config --runInBand --bail --forceExit --verbose",
     "test:coverage": "jest --runInBand --detectOpenHandles --bail --coverage",
     "lint:fix": "tslint -c tslint.json -p . --fix",
     "lint": "tslint -c tslint.json -p ."


### PR DESCRIPTION
Without these it seems that console.logs are not being printed (e.g. on master)