### PR TITLE
[playground] fix: redirect home from register if mmLocked

### DIFF
--- a/packages/playground/src/components/account/account-register/account-register.tsx
+++ b/packages/playground/src/components/account/account-register/account-register.tsx
@@ -38,6 +38,7 @@ export class AccountRegister {
   @Prop() updateAccount: (e) => void = e => {};
   @Prop() signer: Signer = {} as Signer;
   @Prop() history: RouterHistory = {} as RouterHistory;
+  @Prop() metamaskUnlocked: boolean = false;
   @Prop() waitForMultisig: () => Promise<void> = async () => {};
 
   changeset: UserChangeset = {
@@ -59,6 +60,13 @@ export class AccountRegister {
     | "creatingAccount"
     | "deployingMultisig"
     | "finished" = "ready";
+
+  componentDidUpdate() {
+    if (!this.metamaskUnlocked) {
+      this.history.push("/");
+      return;
+    }
+  }
 
   async login(e: MouseEvent) {
     e.preventDefault();
@@ -281,4 +289,4 @@ AccountTunnel.injectProps(AccountRegister, [
   "waitForMultisig"
 ]);
 
-WalletTunnel.injectProps(AccountRegister, ["connected", "signer"]);
+WalletTunnel.injectProps(AccountRegister, ["connected", "signer", "metamaskUnlocked"]);

--- a/packages/playground/src/components/account/account-register/account-register.tsx
+++ b/packages/playground/src/components/account/account-register/account-register.tsx
@@ -289,4 +289,8 @@ AccountTunnel.injectProps(AccountRegister, [
   "waitForMultisig"
 ]);
 
-WalletTunnel.injectProps(AccountRegister, ["connected", "signer", "metamaskUnlocked"]);
+WalletTunnel.injectProps(AccountRegister, [
+  "connected",
+  "signer",
+  "metamaskUnlocked"
+]);


### PR DESCRIPTION
### Description

It was possible to visit the `/register` screen and trying to register resulted in, obviously, an error in MM.

This fixes the issue by redirecting to `/` if `walletState.metamaskUnlocked==false`

### Related issues

[Link here any issues relevant to this PR, using the GitHub `fixes/resolves/closes` keywords to close related issues automatically.]

- [ ] Deploy preview is functional
