### PR TITLE
[pg-server, pg] Adds a corrupt waller state UI and delete account button

### DIFF
--- a/packages/playground-server/src/db.ts
+++ b/packages/playground-server/src/db.ts
@@ -241,6 +241,19 @@ export async function getUser(userToFind: Partial<User>): Promise<User> {
   });
 }
 
+export async function deleteAccount(userId: string) {
+  const db = getDatabase();
+
+  const query = db("users")
+    .select()
+    .where("id", "=", userId)
+    .del();
+
+  await query;
+
+  await db.destroy();
+}
+
 export async function getUsernameFromMultisigAddress(
   multisigAddress: string
 ): Promise<string> {

--- a/packages/playground-server/src/resources/user/processor.ts
+++ b/packages/playground-server/src/resources/user/processor.ts
@@ -4,6 +4,7 @@ import { Log } from "logepi";
 
 import {
   createUser,
+  deleteAccount,
   ethAddressAlreadyRegistered,
   getUsers,
   updateUser,
@@ -107,5 +108,10 @@ export default class UserProcessor extends OperationProcessor<User> {
     });
 
     return updatedUser;
+  }
+
+  public async remove(op: Operation): Promise<void> {
+    const userId = op.ref.id as string;
+    await deleteAccount(userId);
   }
 }

--- a/packages/playground/src/components/app-home/app-home/app-home.tsx
+++ b/packages/playground/src/components/app-home/app-home/app-home.tsx
@@ -28,7 +28,10 @@ export class AppHome {
   @Prop() ethPendingDepositTxHash: string = "";
 
   @Prop() hasLocalStorage: boolean = false;
+  @Prop() hasCorruptStateChannelState: boolean = false;
   @State() runningApps: AppDefinition[] = [];
+
+  @Prop() deleteAccount?: () => Promise<void>;
 
   appClickedHandler(e) {
     this.history.push(e.detail.dappContainerUrl, e.detail);
@@ -189,6 +192,22 @@ export class AppHome {
     );
   }
 
+  checkCorruptState() {
+    if (!this.hasCorruptStateChannelState) {
+      return;
+    }
+
+    return (
+      <div class="error-message">
+        <h1>☠️ Corrupt Wallet State</h1>
+        <h2>
+          Unfortunately, your state channel state has become corrupted or lost.
+          Please <a onClick={this.deleteAccount}>click here</a> to start over.
+        </h2>
+      </div>
+    );
+  }
+
   showApps() {
     return (
       <div class="container">
@@ -339,6 +358,7 @@ export class AppHome {
       this.checkNetworkPermitted() ||
       this.checkUserNotLoggedIn() ||
       this.checkInsufficientBalance() ||
+      this.checkCorruptState() ||
       this.showApps();
 
     return this.hasLocalStorage ? (
@@ -371,8 +391,10 @@ WalletTunnel.injectProps(AppHome, [
 
 AccountTunnel.injectProps(AppHome, [
   "user",
+  "hasCorruptStateChannelState",
   "enoughCounterpartyBalance",
   "enoughLocalBalance",
   "ethPendingDepositAmountWei",
-  "ethPendingDepositTxHash"
+  "ethPendingDepositTxHash",
+  "deleteAccount"
 ]);

--- a/packages/playground/src/components/app-root/app-root.tsx
+++ b/packages/playground/src/components/app-root/app-root.tsx
@@ -277,6 +277,7 @@ export class AppRoot {
     ) as string;
 
     if (!token) {
+      console.error("Couldn't delete account; no token was provided");
       return;
     }
 
@@ -284,8 +285,8 @@ export class AppRoot {
 
     try {
       await PlaygroundAPIClient.deleteAccount(user);
-    } finally {
       this.updateAccount({ hasCorruptStateChannelState: false });
+    } finally {
       this.logout();
       return;
     }

--- a/packages/playground/src/components/app-root/app-root.tsx
+++ b/packages/playground/src/components/app-root/app-root.tsx
@@ -271,6 +271,26 @@ export class AppRoot {
     return loggedUser;
   }
 
+  async deleteAccount(): Promise<void> {
+    const token = window.localStorage.getItem(
+      "playground:user:token"
+    ) as string;
+
+    if (!token) {
+      return;
+    }
+
+    const user = await PlaygroundAPIClient.getUser(token);
+
+    try {
+      await PlaygroundAPIClient.deleteAccount(user);
+    } finally {
+      this.updateAccount({ hasCorruptStateChannelState: false });
+      this.logout();
+      return;
+    }
+  }
+
   async getBalances({ poll = false } = {}): Promise<{
     ethFreeBalanceWei: BigNumber;
     ethMultisigBalance: BigNumber;
@@ -296,7 +316,20 @@ export class AppRoot {
       params: { multisigAddress } as Node.GetFreeBalanceStateParams
     };
 
-    const { result } = await node.call(query.type, query);
+    let result;
+
+    try {
+      result = await node.call(query.type, query);
+    } catch (e) {
+      // TODO: Use better typed error messages with error codes
+      if (e.includes("Call to getStateChannel failed")) {
+        await this.updateAccount({ hasCorruptStateChannelState: true });
+        return {
+          ethFreeBalanceWei: ethers.constants.Zero,
+          ethMultisigBalance: ethers.constants.Zero
+        };
+      }
+    }
 
     const { state } = result as Node.GetFreeBalanceStateResult;
 
@@ -571,6 +604,7 @@ export class AppRoot {
       waitForMultisig: this.waitForMultisig.bind(this),
       login: this.login.bind(this),
       logout: this.logout.bind(this),
+      deleteAccount: this.deleteAccount.bind(this),
       getBalances: this.getBalances.bind(this),
       autoLogin: this.autoLogin.bind(this),
       deposit: this.deposit.bind(this),

--- a/packages/playground/src/components/layout/layout-header/header-account/header-account.tsx
+++ b/packages/playground/src/components/layout/layout-header/header-account/header-account.tsx
@@ -33,6 +33,7 @@ export class HeaderAccount {
   @Prop() updateAccount: (e) => void = e => {};
   @Prop() login: () => Promise<UserSession> = async () => ({} as UserSession);
   @Prop() autoLogin: () => Promise<void> = async () => {};
+  @Prop() hasCorruptStateChannelState: boolean = false;
 
   @Event() authenticationChanged: EventEmitter = {} as EventEmitter;
 
@@ -178,6 +179,15 @@ export class HeaderAccount {
       );
     }
 
+    if (this.hasCorruptStateChannelState) {
+      return (
+        <div class="account-container">
+          <widget-error-message />
+          <div class="message-container">Corrupt State</div>
+        </div>
+      );
+    }
+
     if (!this.authenticated) {
       return (
         <div class="account-container">
@@ -250,7 +260,8 @@ AccountTunnel.injectProps(HeaderAccount, [
   "error",
   "updateAccount",
   "login",
-  "autoLogin"
+  "autoLogin",
+  "hasCorruptStateChannelState"
 ]);
 
 WalletTunnel.injectProps(HeaderAccount, [

--- a/packages/playground/src/data/account.tsx
+++ b/packages/playground/src/data/account.tsx
@@ -7,6 +7,8 @@ export type AccountState = {
   user: UserSession;
   error?: ErrorMessage;
 
+  hasCorruptStateChannelState?: boolean;
+
   precommitedDepositAmountWei?: BigNumber;
 
   ethMultisigBalance: BigNumber;
@@ -25,6 +27,7 @@ export type AccountState = {
   updateAccount?(data: Partial<AccountState>): Promise<void>;
   login?(): Promise<UserSession>;
   logout?(): void;
+  deleteAccount?(): Promise<void>;
   getBalances?(): Promise<
     { ethMultisigBalance: BigNumber; ethFreeBalanceWei: BigNumber } | undefined
   >;


### PR DESCRIPTION
Fixed the error where your account no longer has a valid state channel in the playground DB

<img width="866" alt="Capture d’écran 2019-03-18 à 17 26 28" src="https://user-images.githubusercontent.com/1933029/54564762-fc6c5b00-49a2-11e9-8d25-865a6e436c49.png">
