### PR TITLE
[playground-server] Removes logs for /apps and /heartbeats

### DIFF
--- a/packages/playground-server/src/api.ts
+++ b/packages/playground-server/src/api.ts
@@ -43,10 +43,21 @@ export default function mountApi() {
 
   const api = new Koa();
 
+  // @joel: Move this to logepi.
+  const isUrlExcluded = (url: string, excludeList: string[]) =>
+    excludeList.some(endpoint => url.endsWith(endpoint));
+
+  const conditionalLogs = ({ exclude }) => (ctx, next) =>
+    isUrlExcluded(ctx.req.url as string, exclude) ? next() : logs()(ctx, next);
+
   api
     .use(cors({ keepHeadersOnError: false }))
     .use(jsonApiKoa(app, validateSignature(app)))
-    .use(logs());
+    .use(
+      conditionalLogs({
+        exclude: ["/heartbeats", "/apps"]
+      })
+    );
 
   return api;
 }

--- a/packages/playground-server/src/resources/app/processor.ts
+++ b/packages/playground-server/src/resources/app/processor.ts
@@ -23,7 +23,7 @@ export default class AppProcessor extends OperationProcessor<App> {
           .toString()
       );
 
-      Log.info("Loaded App registry", {
+      Log.debug("Loaded App registry", {
         tags: { totalApps: registry.data.length, endpoint: "apps" }
       });
 


### PR DESCRIPTION
This PR removes the logs for `/heartbeats` and `/apps`, since they're pretty much noise and constantly repeating themselves.