### PR TITLE
Move arguments to Context

### DIFF
--- a/packages/machine/src/instruction-executor.ts
+++ b/packages/machine/src/instruction-executor.ts
@@ -158,20 +158,18 @@ export class InstructionExecutor {
 
   private async runProtocol(
     stateChannelsMap: Map<string, StateChannel>,
-    instruction: (
-      message: ProtocolMessage,
-      context: Context,
-      provider: BaseProvider
-    ) => AsyncIterableIterator<any>,
-    msg: ProtocolMessage
+    instruction: (context: Context) => AsyncIterableIterator<any>,
+    message: ProtocolMessage
   ): Promise<Map<string, StateChannel>> {
     const context: Context = {
+      message,
       stateChannelsMap,
-      network: this.network
+      network: this.network,
+      provider: this.provider
     };
 
     let lastMiddlewareRet: any = undefined;
-    const it = instruction(msg, context, this.provider);
+    const it = instruction(context);
     while (true) {
       const ret = await it.next(lastMiddlewareRet);
       if (ret.done) {

--- a/packages/machine/src/protocol/withdraw-eth.ts
+++ b/packages/machine/src/protocol/withdraw-eth.ts
@@ -28,20 +28,18 @@ import { validateSignature } from "./utils/signature-validator";
  * https://specs.counterfactual.com/11-withdraw-protocol *
  */
 export const WITHDRAW_ETH_PROTOCOL: ProtocolExecutionFlow = {
-  0: async function*(message: ProtocolMessage, context: Context) {
-    const {
-      respondingXpub,
-      multisigAddress
-    } = message.params as WithdrawParams;
+  0: async function*(context: Context) {
+    const { respondingXpub, multisigAddress } = context.message
+      .params as WithdrawParams;
     const respondingAddress = xkeyKthAddress(respondingXpub, 0);
 
     const [
       installRefundCommitment,
       refundAppIdentityHash
-    ] = addInstallRefundAppCommitmentToContext(message.params, context);
+    ] = addInstallRefundAppCommitmentToContext(context.message.params, context);
 
     const withdrawETHCommitment = addMultisigSendCommitmentToContext(
-      message,
+      context.message,
       context
     );
 
@@ -51,7 +49,7 @@ export const WITHDRAW_ETH_PROTOCOL: ProtocolExecutionFlow = {
     const m2 = yield [
       Opcode.IO_SEND_AND_WAIT,
       {
-        ...message,
+        ...context.message,
         toXpub: respondingXpub,
         signature: s1,
         signature2: s3,
@@ -62,7 +60,7 @@ export const WITHDRAW_ETH_PROTOCOL: ProtocolExecutionFlow = {
     const { signature: s2, signature2: s4, signature3: s6 } = m2;
 
     const uninstallRefundCommitment = addUninstallRefundAppCommitmentToContext(
-      message,
+      context.message,
       context,
       refundAppIdentityHash
     );
@@ -76,7 +74,7 @@ export const WITHDRAW_ETH_PROTOCOL: ProtocolExecutionFlow = {
     yield [
       Opcode.IO_SEND,
       {
-        ...message,
+        ...context.message,
         toXpub: respondingXpub,
         signature: s5,
         seq: -1
@@ -93,29 +91,27 @@ export const WITHDRAW_ETH_PROTOCOL: ProtocolExecutionFlow = {
     ];
   },
 
-  1: async function*(message: ProtocolMessage, context: Context) {
-    const {
-      initiatingXpub,
-      multisigAddress
-    } = message.params as WithdrawParams;
+  1: async function*(context: Context) {
+    const { initiatingXpub, multisigAddress } = context.message
+      .params as WithdrawParams;
     const initiatingAddress = xkeyKthAddress(initiatingXpub, 0);
 
     const [
       installRefundCommitment,
       refundAppIdentityHash
-    ] = addInstallRefundAppCommitmentToContext(message.params, context);
+    ] = addInstallRefundAppCommitmentToContext(context.message.params, context);
 
     const withdrawETHCommitment = addMultisigSendCommitmentToContext(
-      message,
+      context.message,
       context
     );
     const uninstallRefundCommitment = addUninstallRefundAppCommitmentToContext(
-      message,
+      context.message,
       context,
       refundAppIdentityHash
     );
 
-    const { signature: s1, signature2: s3 } = message;
+    const { signature: s1, signature2: s3 } = context.message;
 
     validateSignature(initiatingAddress, installRefundCommitment, s1);
 
@@ -136,7 +132,7 @@ export const WITHDRAW_ETH_PROTOCOL: ProtocolExecutionFlow = {
     const m3 = yield [
       Opcode.IO_SEND_AND_WAIT,
       {
-        ...message,
+        ...context.message,
         toXpub: initiatingXpub,
         signature: s2,
         signature2: s4,

--- a/packages/machine/src/types.ts
+++ b/packages/machine/src/types.ts
@@ -12,11 +12,7 @@ import { Transaction } from "./ethereum/types";
 import { StateChannel } from "./models";
 
 export type ProtocolExecutionFlow = {
-  [x: number]: (
-    message: ProtocolMessage,
-    context: Context,
-    provider: BaseProvider
-  ) => AsyncIterableIterator<any[]>;
+  [x: number]: (context: Context) => AsyncIterableIterator<any[]>;
 };
 
 export type Middleware = {
@@ -25,9 +21,12 @@ export type Middleware = {
 
 export type Instruction = Function | Opcode;
 
+/// Arguments passed to a protocol execulion flow
 export interface Context {
   network: NetworkContext;
   stateChannelsMap: Map<string, StateChannel>;
+  message: ProtocolMessage;
+  provider: BaseProvider;
 }
 
 export type ProtocolMessage = {


### PR DESCRIPTION
Long ago, `Context` was used to store intermediate results, the state channel map that is to be mutated, the read-only networkContext, etc. The provider and first message were passed in directly. Since there is no real distinction between the arguments in `Context` and those not, this PR moves the provider and first message into `Context`.