### PR TITLE
[monorepo] add Math to extraGlobals

### DIFF
--- a/packages/cf.js/jest.config.js
+++ b/packages/cf.js/jest.config.js
@@ -17,5 +17,6 @@ module.exports = {
     "js",
     "json"
   ],
-  "testURL": "http://localhost/"
+  "testURL": "http://localhost/",
+  "extraGlobals": ["Math"]
 };

--- a/packages/machine/jest.config.js
+++ b/packages/machine/jest.config.js
@@ -23,5 +23,6 @@ module.exports = {
     "js",
     "json"
   ],
-  "testURL": "http://localhost/"
+  "testURL": "http://localhost/",
+  "extraGlobals": ["Math"]
 }

--- a/packages/tic-tac-toe-bot/jest.config.js
+++ b/packages/tic-tac-toe-bot/jest.config.js
@@ -33,5 +33,6 @@ module.exports = {
   "transform": {
     "^.+\\.tsx?$": "ts-jest"
   },
-  "verbose": false
+  "verbose": false,
+  "extraGlobals": ["Math"]
 }


### PR DESCRIPTION
Due to jest using the vm module (https://github.com/facebook/jest/issues/5163#issuecomment-355509597), certain functions in the BN.js library used by ethers run really slowly under jest without this flag.