### PR TITLE
[contracts] add FreeBalanceApp, extending ETHBucket to n-party

### DIFF
--- a/packages/contracts/contracts/default-apps/FreeBalanceApp.sol
+++ b/packages/contracts/contracts/default-apps/FreeBalanceApp.sol
@@ -1,0 +1,56 @@
+pragma solidity 0.5.7;
+pragma experimental "ABIEncoderV2";
+
+import "../libs/Transfer.sol";
+import "../CounterfactualApp.sol";
+
+contract FreeBalanceApp is CounterfactualApp {
+
+  struct AppState {
+    address[] peers;
+    uint256[] balances;
+  }
+
+  function resolve(bytes memory encodedState, Transfer.Terms memory terms)
+    public
+    pure
+    returns (Transfer.Transaction memory)
+  {
+    AppState memory state = abi.decode(encodedState, (AppState));
+
+    bytes[] memory data = new bytes[](2);
+
+    return Transfer.Transaction(
+      terms.assetType,
+      terms.token,
+      state.peers,
+      state.balances,
+      data
+    );
+  }
+
+  function isStateTerminal(bytes memory)
+    public
+    pure
+    returns (bool)
+  {
+    revert("Not implemented");
+  }
+
+  function getTurnTaker(bytes memory, address[] memory)
+    public
+    pure
+    returns (address)
+  {
+    revert("Not implemented");
+  }
+
+  function applyAction(bytes memory, bytes memory)
+    public
+    pure
+    returns (bytes memory)
+  {
+    revert("Not implemented");
+  }
+
+}

--- a/packages/types/src/app-instance.ts
+++ b/packages/types/src/app-instance.ts
@@ -49,3 +49,8 @@ export type ETHBucketAppState = {
   aliceBalance: BigNumber;
   bobBalance: BigNumber;
 };
+
+export type FreeBalanceAppState = {
+  peers: string[];
+  balances: BigNumber[];
+};

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -25,7 +25,7 @@ import {
 export interface NetworkContext {
   AppRegistry: string;
   ETHBalanceRefund: string;
-  FreeBalanceAppState: string;
+  FreeBalanceAppState?: string;
   ETHBucket: string;
   MultiSend: string;
   NonceRegistry: string;

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -3,6 +3,7 @@ import {
   AppInterface,
   AssetType,
   ETHBucketAppState,
+  FreeBalanceAppState,
   SignedStateHashUpdate,
   Terms,
   Transaction
@@ -24,6 +25,7 @@ import {
 export interface NetworkContext {
   AppRegistry: string;
   ETHBalanceRefund: string;
+  FreeBalanceAppState: string;
   ETHBucket: string;
   MultiSend: string;
   NonceRegistry: string;
@@ -46,6 +48,7 @@ export {
   BlockchainAsset,
   Bytes32,
   ETHBucketAppState,
+  FreeBalanceAppState,
   INodeProvider,
   Node,
   SignedStateHashUpdate,


### PR DESCRIPTION
extending the ETHBucket contract to n-party, so that right now all contracts are n-party compatible. (for channelized coinshuffle and others)

To avoid breaking existing code base especially dependencies in machine and node, I name it `FreeBalanceApp`, 

minor update on the `types` as well.
