### PR TITLE
modify .yarnrc to force frozen-lockfile for yarn install

### DIFF
--- a/.yarnrc
+++ b/.yarnrc
@@ -1,1 +1,2 @@
 workspaces-experimental true
+--frozen-lockfile true


### PR DESCRIPTION
As I keep `git checkout yarn.lock`, I realize maybe we should follow this [issue](https://github.com/yarnpkg/yarn/issues/4147#issuecomment-321792657)
