### PR TITLE
[machine] use tdr in integration test

### DIFF
--- a/packages/machine/test/integration/eth-virtual-app-agreement-commitment.spec.ts
+++ b/packages/machine/test/integration/eth-virtual-app-agreement-commitment.spec.ts
@@ -1,12 +1,7 @@
 import AppRegistry from "@counterfactual/contracts/build/AppRegistry.json";
-import ETHBucket from "@counterfactual/contracts/build/ETHBucket.json";
-import ETHVirtualAppAgreement from "@counterfactual/contracts/build/ETHVirtualAppAgreement.json";
 import MinimumViableMultisig from "@counterfactual/contracts/build/MinimumViableMultisig.json";
-import MultiSend from "@counterfactual/contracts/build/MultiSend.json";
-import NonceRegistry from "@counterfactual/contracts/build/NonceRegistry.json";
 import ProxyFactory from "@counterfactual/contracts/build/ProxyFactory.json";
 import ResolveToPay5WeiApp from "@counterfactual/contracts/build/ResolveToPay5WeiApp.json";
-import StateChannelTransaction from "@counterfactual/contracts/build/StateChannelTransaction.json";
 import { AssetType, NetworkContext } from "@counterfactual/types";
 import { Contract, ContractFactory, Wallet } from "ethers";
 import { AddressZero, HashZero } from "ethers/constants";
@@ -20,8 +15,8 @@ import { xkeysToSortedKthSigningKeys } from "../../src/xkeys";
 
 import { toBeEq } from "./bignumber-jest-matcher";
 import { connectToGanache } from "./connect-ganache";
+import { makeNetworkContext } from "./make-network-context";
 import { getRandomHDNodes } from "./random-signing-keys";
-import { WaffleLegacyOutput } from "./waffle-type";
 
 // To be honest, 30000 is an arbitrary large number that has never failed
 // to reach the done() call in the test case, not intelligently chosen
@@ -46,32 +41,9 @@ expect.extend({ toBeEq });
 beforeAll(async () => {
   [provider, wallet, networkId] = await connectToGanache();
 
-  const relevantArtifacts = [
-    { contractName: "AppRegistry", ...AppRegistry },
-    { contractName: "NonceRegistry", ...NonceRegistry },
-    { contractName: "ETHBucket", ...ETHBucket },
-    { contractName: "MultiSend", ...MultiSend },
-    { contractName: "StateChannelTransaction", ...StateChannelTransaction },
-    { contractName: "ETHVirtualAppAgreement", ...ETHVirtualAppAgreement }
-  ];
+  network = makeNetworkContext(networkId);
 
-  network = {
-    // Fetches the values from build artifacts of the contracts needed
-    // for this test and sets the ones we don't care about to 0x0
-    ...relevantArtifacts.reduce(
-      (accumulator: { [x: string]: string }, artifact: WaffleLegacyOutput) => ({
-        ...accumulator,
-        [artifact.contractName as string]: artifact.networks![networkId].address
-      }),
-      {}
-    )
-  } as NetworkContext;
-
-  appRegistry = new Contract(
-    (AppRegistry as WaffleLegacyOutput).networks![networkId].address,
-    AppRegistry.abi,
-    wallet
-  );
+  appRegistry = new Contract(network.AppRegistry, AppRegistry.abi, wallet);
 });
 
 describe("Scenario: install virtual AppInstance, put on-chain", () => {
@@ -92,7 +64,7 @@ describe("Scenario: install virtual AppInstance, put on-chain", () => {
     ).deploy();
 
     const proxyFactory = new Contract(
-      (ProxyFactory as WaffleLegacyOutput).networks![networkId].address,
+      network.ProxyFactory,
       ProxyFactory.abi,
       wallet
     );
@@ -203,8 +175,7 @@ describe("Scenario: install virtual AppInstance, put on-chain", () => {
     });
 
     await proxyFactory.functions.createProxy(
-      (MinimumViableMultisig as WaffleLegacyOutput).networks![networkId]
-        .address,
+      network.MinimumViableMultisig,
       new Interface(MinimumViableMultisig.abi).functions.setup.encode([
         multisigOwnerKeys.map(x => x.address)
       ]),

--- a/packages/machine/test/integration/make-network-context.ts
+++ b/packages/machine/test/integration/make-network-context.ts
@@ -1,0 +1,24 @@
+import { NetworkContext, networkContextProps } from "@counterfactual/types";
+
+export function makeNetworkContext(networkId: number): NetworkContext {
+  const preNetworkContext = {} as any;
+
+  const deployedContracts = require(`../../networks/${networkId}.json`);
+
+  deployedContracts.forEach((val: any) => {
+    const { contractName, address } = val;
+    if (networkContextProps.includes(contractName)) {
+      preNetworkContext[contractName] = address;
+    }
+  });
+
+  for (const contractName of networkContextProps) {
+    if (!preNetworkContext[contractName]) {
+      throw Error(
+        `Could not construct network context, ${contractName} not found`
+      );
+    }
+  }
+
+  return preNetworkContext as NetworkContext;
+}

--- a/packages/machine/test/integration/message-router.ts
+++ b/packages/machine/test/integration/message-router.ts
@@ -1,4 +1,4 @@
-import { Opcode } from "@counterfactual/machine/src";
+import { Opcode } from "../../src";
 
 import { MiniNode } from "./mininode";
 

--- a/packages/machine/test/integration/mininode.ts
+++ b/packages/machine/test/integration/mininode.ts
@@ -1,13 +1,10 @@
-import {
-  InstructionExecutor,
-  Opcode,
-  StateChannel
-} from "@counterfactual/machine/src";
-import { EthereumCommitment } from "@counterfactual/machine/src/ethereum/types";
 import { NetworkContext } from "@counterfactual/types";
 import { JsonRpcProvider } from "ethers/providers";
 import { SigningKey } from "ethers/utils";
 import { HDNode } from "ethers/utils/hdnode";
+
+import { InstructionExecutor, Opcode, StateChannel } from "../../src";
+import { EthereumCommitment } from "../../src/ethereum/types";
 
 import { getRandomHDNodes } from "./random-signing-keys";
 

--- a/packages/machine/test/integration/protocols.spec.ts
+++ b/packages/machine/test/integration/protocols.spec.ts
@@ -1,23 +1,18 @@
-import AppRegistry from "@counterfactual/contracts/build/AppRegistry.json";
-import ETHBucket from "@counterfactual/contracts/build/ETHBucket.json";
-import ETHVirtualAppAgreement from "@counterfactual/contracts/build/ETHVirtualAppAgreement.json";
-import MultiSend from "@counterfactual/contracts/build/MultiSend.json";
-import NonceRegistry from "@counterfactual/contracts/build/NonceRegistry.json";
 import ResolveToPay5WeiApp from "@counterfactual/contracts/build/ResolveToPay5WeiApp.json";
-import StateChannelTransaction from "@counterfactual/contracts/build/StateChannelTransaction.json";
-import { xkeyKthAddress } from "@counterfactual/machine/src";
-import { sortAddresses } from "@counterfactual/machine/src/xkeys";
 import { AssetType, NetworkContext } from "@counterfactual/types";
 import { Contract, ContractFactory, Wallet } from "ethers";
 import { AddressZero } from "ethers/constants";
 import { JsonRpcProvider } from "ethers/providers";
 import { bigNumberify } from "ethers/utils";
 
+import { xkeyKthAddress } from "../../src";
+import { sortAddresses } from "../../src/xkeys";
+
 import { toBeEq } from "./bignumber-jest-matcher";
 import { connectToGanache } from "./connect-ganache";
+import { makeNetworkContext } from "./make-network-context";
 import { MessageRouter } from "./message-router";
 import { MiniNode } from "./mininode";
-import { WaffleLegacyOutput } from "./waffle-type";
 
 const JEST_TEST_WAIT_TIME = 50000;
 
@@ -32,26 +27,7 @@ expect.extend({ toBeEq });
 beforeAll(async () => {
   [provider, wallet, networkId] = await connectToGanache();
 
-  const relevantArtifacts = [
-    { contractName: "AppRegistry", ...AppRegistry },
-    { contractName: "ETHBucket", ...ETHBucket },
-    { contractName: "StateChannelTransaction", ...StateChannelTransaction },
-    { contractName: "NonceRegistry", ...NonceRegistry },
-    { contractName: "MultiSend", ...MultiSend },
-    { contractName: "ETHVirtualAppAgreement", ...ETHVirtualAppAgreement }
-    // todo: add more
-  ];
-
-  network = {
-    ETHBalanceRefundApp: AddressZero,
-    ...relevantArtifacts.reduce(
-      (accumulator: { [x: string]: string }, artifact: WaffleLegacyOutput) => ({
-        ...accumulator,
-        [artifact.contractName as string]: artifact.networks![networkId].address
-      }),
-      {}
-    )
-  } as NetworkContext;
+  network = makeNetworkContext(networkId);
 
   appDefinition = await new ContractFactory(
     ResolveToPay5WeiApp.abi,

--- a/packages/machine/test/integration/set-state.spec.ts
+++ b/packages/machine/test/integration/set-state.spec.ts
@@ -1,6 +1,4 @@
 import AppRegistry from "@counterfactual/contracts/build/AppRegistry.json";
-import ETHBucket from "@counterfactual/contracts/build/ETHBucket.json";
-import StateChannelTransaction from "@counterfactual/contracts/build/StateChannelTransaction.json";
 import { AssetType, NetworkContext } from "@counterfactual/types";
 import { Contract, Wallet } from "ethers";
 import { AddressZero, WeiPerEther } from "ethers/constants";
@@ -11,8 +9,8 @@ import { StateChannel } from "../../src/models";
 
 import { toBeEq } from "./bignumber-jest-matcher";
 import { connectToGanache } from "./connect-ganache";
+import { makeNetworkContext } from "./make-network-context";
 import { getRandomHDNodes } from "./random-signing-keys";
-import { WaffleLegacyOutput } from "./waffle-type";
 
 // To be honest, 30000 is an arbitrary large number that has never failed
 // to reach the done() call in the test case, not intelligently chosen
@@ -32,30 +30,9 @@ expect.extend({ toBeEq });
 beforeAll(async () => {
   [{}, wallet, networkId] = await connectToGanache();
 
-  const relevantArtifacts = [
-    { contractName: "AppRegistry", ...AppRegistry },
-    { contractName: "ETHBucket", ...ETHBucket },
-    { contractName: "StateChannelTransaction", ...StateChannelTransaction }
-  ];
+  network = makeNetworkContext(networkId);
 
-  network = {
-    // Fetches the values from build artifacts of the contracts needed
-    // for this test and sets the ones we don't care about to 0x0
-    ETHBalanceRefundApp: AddressZero,
-    ...relevantArtifacts.reduce(
-      (accumulator: { [x: string]: string }, artifact: WaffleLegacyOutput) => ({
-        ...accumulator,
-        [artifact.contractName as string]: artifact.networks![networkId].address
-      }),
-      {}
-    )
-  } as NetworkContext;
-
-  appRegistry = new Contract(
-    (AppRegistry as WaffleLegacyOutput).networks![networkId].address,
-    AppRegistry.abi,
-    wallet
-  );
+  appRegistry = new Contract(network.AppRegistry, AppRegistry.abi, wallet);
 });
 
 /**

--- a/packages/machine/test/integration/setup-then-set-state.spec.ts
+++ b/packages/machine/test/integration/setup-then-set-state.spec.ts
@@ -1,12 +1,9 @@
 import AppRegistry from "@counterfactual/contracts/build/AppRegistry.json";
-import ETHBucket from "@counterfactual/contracts/build/ETHBucket.json";
 import MinimumViableMultisig from "@counterfactual/contracts/build/MinimumViableMultisig.json";
-import NonceRegistry from "@counterfactual/contracts/build/NonceRegistry.json";
 import ProxyFactory from "@counterfactual/contracts/build/ProxyFactory.json";
-import StateChannelTransaction from "@counterfactual/contracts/build/StateChannelTransaction.json";
 import { AssetType, NetworkContext } from "@counterfactual/types";
 import { Contract, Wallet } from "ethers";
-import { AddressZero, WeiPerEther, Zero } from "ethers/constants";
+import { WeiPerEther, Zero } from "ethers/constants";
 import { JsonRpcProvider } from "ethers/providers";
 import { Interface, keccak256 } from "ethers/utils";
 
@@ -16,8 +13,8 @@ import { StateChannel } from "../../src/models";
 
 import { toBeEq } from "./bignumber-jest-matcher";
 import { connectToGanache } from "./connect-ganache";
+import { makeNetworkContext } from "./make-network-context";
 import { getRandomHDNodes } from "./random-signing-keys";
-import { WaffleLegacyOutput } from "./waffle-type";
 
 // To be honest, 30000 is an arbitrary large number that has never failed
 // to reach the done() call in the test case, not intelligently chosen
@@ -45,31 +42,9 @@ expect.extend({ toBeEq });
 beforeAll(async () => {
   [provider, wallet, networkId] = await connectToGanache();
 
-  const relevantArtifacts = [
-    { contractName: "AppRegistry", ...AppRegistry },
-    { contractName: "ETHBucket", ...ETHBucket },
-    { contractName: "NonceRegistry", ...NonceRegistry },
-    { contractName: "StateChannelTransaction", ...StateChannelTransaction }
-  ];
+  network = makeNetworkContext(networkId);
 
-  network = {
-    // Fetches the values from build artifacts of the contracts needed
-    // for this test and sets the ones we don't care about to 0x0
-    ETHBalanceRefundApp: AddressZero,
-    ...relevantArtifacts.reduce(
-      (accumulator: { [x: string]: string }, artifact: WaffleLegacyOutput) => ({
-        ...accumulator,
-        [artifact.contractName as string]: artifact.networks![networkId].address
-      }),
-      {}
-    )
-  } as NetworkContext;
-
-  appRegistry = new Contract(
-    (AppRegistry as WaffleLegacyOutput).networks![networkId].address,
-    AppRegistry.abi,
-    wallet
-  );
+  appRegistry = new Contract(network.AppRegistry, AppRegistry.abi, wallet);
 });
 
 /**
@@ -87,7 +62,7 @@ describe("Scenario: Setup, set state on free balance, go on chain", () => {
     );
 
     const proxyFactory = new Contract(
-      (ProxyFactory as WaffleLegacyOutput).networks![networkId].address,
+      network.ProxyFactory,
       ProxyFactory.abi,
       wallet
     );
@@ -164,8 +139,7 @@ describe("Scenario: Setup, set state on free balance, go on chain", () => {
     });
 
     await proxyFactory.functions.createProxy(
-      (MinimumViableMultisig as WaffleLegacyOutput).networks![networkId]
-        .address,
+      network.MinimumViableMultisig,
       new Interface(MinimumViableMultisig.abi).functions.setup.encode([
         multisigOwnerKeys.map(x => x.address)
       ]),

--- a/packages/machine/test/integration/virtual-app-set-state-commitment.spec.ts
+++ b/packages/machine/test/integration/virtual-app-set-state-commitment.spec.ts
@@ -1,6 +1,4 @@
 import AppRegistry from "@counterfactual/contracts/build/AppRegistry.json";
-import ETHBucket from "@counterfactual/contracts/build/ETHBucket.json";
-import StateChannelTransaction from "@counterfactual/contracts/build/StateChannelTransaction.json";
 import { AssetType, NetworkContext } from "@counterfactual/types";
 import * as chai from "chai";
 import * as matchers from "ethereum-waffle/dist/matchers/matchers";
@@ -14,8 +12,8 @@ import { AppInstance, StateChannel } from "../../src/models";
 
 import { toBeEq } from "./bignumber-jest-matcher";
 import { connectToGanache } from "./connect-ganache";
+import { makeNetworkContext } from "./make-network-context";
 import { getRandomHDNodes } from "./random-signing-keys";
-import { WaffleLegacyOutput } from "./waffle-type";
 
 // To be honest, 30000 is an arbitrary large number that has never failed
 // to reach the done() call in the test case, not intelligently chosen
@@ -45,30 +43,9 @@ const expect2 = chai.use(matchers.default).expect;
 beforeAll(async () => {
   [{}, wallet, networkId] = await connectToGanache();
 
-  const relevantArtifacts = [
-    { contractName: "AppRegistry", ...AppRegistry },
-    { contractName: "ETHBucket", ...ETHBucket },
-    { contractName: "StateChannelTransaction", ...StateChannelTransaction }
-  ];
+  network = makeNetworkContext(networkId);
 
-  network = {
-    // Fetches the values from build artifacts of the contracts needed
-    // for this test and sets the ones we don't care about to 0x0
-    ETHBalanceRefundApp: AddressZero,
-    ...relevantArtifacts.reduce(
-      (accumulator: { [x: string]: string }, artifact: WaffleLegacyOutput) => ({
-        ...accumulator,
-        [artifact.contractName as string]: artifact.networks![networkId].address
-      }),
-      {}
-    )
-  } as NetworkContext;
-
-  appRegistry = new Contract(
-    (AppRegistry as WaffleLegacyOutput).networks![networkId].address,
-    AppRegistry.abi,
-    wallet
-  );
+  appRegistry = new Contract(network.AppRegistry, AppRegistry.abi, wallet);
 });
 
 beforeEach(() => {

--- a/packages/node/test/integration/utils.ts
+++ b/packages/node/test/integration/utils.ts
@@ -7,6 +7,7 @@ import {
   BlockchainAsset,
   ETHBucketAppState,
   NetworkContext,
+  networkContextProps,
   Node as NodeTypes,
   SolidityABIEncoderV2Struct
 } from "@counterfactual/types";
@@ -317,17 +318,13 @@ export function confirmProposedVirtualAppInstanceOnNode(
   );
 }
 
-export const EMPTY_NETWORK: NetworkContext = {
-  AppRegistry: AddressZero,
-  ETHBalanceRefundApp: AddressZero,
-  ETHBucket: AddressZero,
-  MultiSend: AddressZero,
-  NonceRegistry: AddressZero,
-  StateChannelTransaction: AddressZero,
-  ETHVirtualAppAgreement: AddressZero,
-  MinimumViableMultisig: AddressZero,
-  ProxyFactory: AddressZero
-};
+const emptyNetworkMap = new Map(
+  networkContextProps.map((i): [string, string] => [i, AddressZero])
+);
+export const EMPTY_NETWORK = Array.from(emptyNetworkMap.entries()).reduce(
+  (main, [key, value]) => ({ ...main, [key]: value }),
+  {}
+) as NetworkContext;
 
 export function generateGetStateRequest(
   appInstanceId: AppInstanceID

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -33,6 +33,19 @@ export interface NetworkContext {
   ProxyFactory: string;
 }
 
+// Keep in sync with above
+export const networkContextProps = [
+  "AppRegistry",
+  "ETHBalanceRefundApp",
+  "ETHBucket",
+  "MultiSend",
+  "NonceRegistry",
+  "StateChannelTransaction",
+  "ETHVirtualAppAgreement",
+  "MinimumViableMultisig",
+  "ProxyFactory"
+];
+
 export {
   ABIEncoding,
   Address,


### PR DESCRIPTION
Use the tdr-generated file for deployed addresses instead of reading the artifact's network field