### PR TITLE
[playground-server] Updates jsonapi-ts to 0.1.17

### DIFF
--- a/packages/playground-server/package.json
+++ b/packages/playground-server/package.json
@@ -34,7 +34,7 @@
     "@counterfactual/node": "0.1.15",
     "@counterfactual/types": "0.0.9",
     "@counterfactual/typescript-typings": "0.1.0",
-    "@ebryn/jsonapi-ts": "0.1.5",
+    "@ebryn/jsonapi-ts": "0.1.17",
     "@koa/cors": "^3.0.0",
     "axios": "^0.18.0",
     "escape-string-regexp": "^1.0.5",

--- a/packages/playground-server/src/resources/app/resource.ts
+++ b/packages/playground-server/src/resources/app/resource.ts
@@ -1,10 +1,14 @@
 import { Resource } from "@ebryn/jsonapi-ts";
 
 export default class App extends Resource {
-  // attributes: {
-  //   name: string;
-  //   slug: string;
-  //   icon: string;
-  //   url: string;
-  // };
+  static get type() {
+    return "app";
+  }
+
+  static attributes = {
+    name: "",
+    slug: "",
+    icon: "",
+    url: ""
+  };
 }

--- a/packages/playground-server/src/resources/heartbeat/resource.ts
+++ b/packages/playground-server/src/resources/heartbeat/resource.ts
@@ -1,8 +1,12 @@
 import { Resource } from "@ebryn/jsonapi-ts";
 
 export default class Heartbeat extends Resource {
-  attributes: {
-    schemaVersion: string;
-    maintenanceMode: boolean;
+  static get type() {
+    return "heartbeat";
+  }
+
+  static attributes = {
+    schemaVersion: "",
+    maintenanceMode: false
   };
 }

--- a/packages/playground-server/src/resources/matchmaking-request/resource.ts
+++ b/packages/playground-server/src/resources/matchmaking-request/resource.ts
@@ -1,6 +1,16 @@
 import { Resource } from "@ebryn/jsonapi-ts";
 
 export default class MatchmakingRequest extends Resource {
+  static get type() {
+    return "matchmakingRequest";
+  }
+
+  static attributes = {
+    intermediary: "",
+    username: "",
+    ethAddress: "",
+    nodeAddress: ""
+  };
   // attributes: {
   //   intermediary: string;
   // };

--- a/packages/playground-server/src/resources/multisig-deploy/processor.ts
+++ b/packages/playground-server/src/resources/multisig-deploy/processor.ts
@@ -17,8 +17,9 @@ export default class MultisigDeployProcessor extends OperationProcessor<
       User
     >);
 
+    const { nodeAddress } = user.attributes;
     const { transactionHash } = await NodeWrapper.createStateChannelFor(
-      user.attributes.nodeAddress
+      nodeAddress as string
     );
 
     informSlack(

--- a/packages/playground-server/src/resources/multisig-deploy/resource.ts
+++ b/packages/playground-server/src/resources/multisig-deploy/resource.ts
@@ -1,9 +1,12 @@
 import { Resource } from "@ebryn/jsonapi-ts";
 
 export default class MultisigDeploy extends Resource {
-  // @ts-ignore
-  public attributes: {
-    ethAddress: string;
-    transactionHash: string;
+  static get type() {
+    return "multisigDeploy";
+  }
+
+  static attributes = {
+    ethAddress: "",
+    transactionHash: ""
   };
 }

--- a/packages/playground-server/src/resources/session-request/resource.ts
+++ b/packages/playground-server/src/resources/session-request/resource.ts
@@ -1,7 +1,16 @@
 import { Resource } from "@ebryn/jsonapi-ts";
 
 export default class SessionRequest extends Resource {
-  // attributes: {
-  //   ethAddress: string;
-  // };
+  static get type() {
+    return "sessionRequest";
+  }
+
+  static attributes = {
+    username: "",
+    email: "",
+    ethAddress: "",
+    multisigAddress: "",
+    nodeAddress: "",
+    token: ""
+  };
 }

--- a/packages/playground-server/src/resources/user/resource.ts
+++ b/packages/playground-server/src/resources/user/resource.ts
@@ -1,22 +1,29 @@
 import { Resource } from "@ebryn/jsonapi-ts";
 
 export default class User extends Resource {
-  // @ts-ignore
-  public attributes: {
-    username: string;
-    ethAddress: string;
-    nodeAddress: string;
-    email: string;
-    multisigAddress: string;
-    transactionHash: string;
-    token: string;
+  static get type() {
+    return "type";
+  }
+
+  static attributes = {
+    username: "",
+    ethAddress: "",
+    nodeAddress: "",
+    email: "",
+    multisigAddress: "",
+    transactionHash: "",
+    token: ""
   };
 }
 
 export class MatchedUser extends Resource {
-  // attributes: {
-  //   username: string;
-  //   ethAddress: string;
-  //   nodeAddress: string;
-  // };
+  static get type() {
+    return "matchedUser";
+  }
+
+  static attributes = {
+    username: "",
+    ethAddress: "",
+    nodeAddress: ""
+  }
 }

--- a/packages/playground-server/src/resources/user/resource.ts
+++ b/packages/playground-server/src/resources/user/resource.ts
@@ -2,7 +2,7 @@ import { Resource } from "@ebryn/jsonapi-ts";
 
 export default class User extends Resource {
   static get type() {
-    return "type";
+    return "user";
   }
 
   static attributes = {

--- a/packages/playground-server/src/resources/user/resource.ts
+++ b/packages/playground-server/src/resources/user/resource.ts
@@ -25,5 +25,5 @@ export class MatchedUser extends Resource {
     username: "",
     ethAddress: "",
     nodeAddress: ""
-  }
+  };
 }

--- a/packages/playground-server/test/api.spec.ts
+++ b/packages/playground-server/test/api.spec.ts
@@ -350,7 +350,7 @@ describe("playground-server", () => {
           errors: [
             {
               status: HttpStatusCode.Unauthorized,
-              code: "access_denied"
+              code: "unauthorized"
             }
           ]
         });

--- a/yarn.lock
+++ b/yarn.lock
@@ -884,10 +884,10 @@
   resolved "https://registry.yarnpkg.com/@csstools/convert-colors/-/convert-colors-1.4.0.tgz#ad495dc41b12e75d588c6db8b9834f08fa131eb7"
   integrity sha512-5a6wqoJV/xEdbRNKVo6I4hO3VjyDq//8q2f9I6PBAvMesJHFauXDorcNCsr9RzvsZnaWi5NYCcfyqP1QeFHFbw==
 
-"@ebryn/jsonapi-ts@0.1.5":
-  version "0.1.5"
-  resolved "https://registry.yarnpkg.com/@ebryn/jsonapi-ts/-/jsonapi-ts-0.1.5.tgz#8f7713f11d88883207999529bce7feac3862aa22"
-  integrity sha512-9QwNuo3Mzow6aoSCa0M8uGEPp+ZLmDPITv/wKDaKjEKTYSa/KBJEHg74TKYVFiW0u6h+LvcZztZvinl+umMoRw==
+"@ebryn/jsonapi-ts@0.1.17":
+  version "0.1.17"
+  resolved "https://registry.yarnpkg.com/@ebryn/jsonapi-ts/-/jsonapi-ts-0.1.17.tgz#8258e3bf58875b4ff6c237f6c2d73fe73f35fd68"
+  integrity sha512-CVpzxJhuRrCS1SLgfoqbH6kuftWhkSrrtTSFZVIan+PJO+GcDm4qRpFy/TuWdjGO7+1BE1Lo+fve0zXMp0K1nA==
   dependencies:
     ember-cli-string-utils "^1.1.0"
     escape-string-regexp "^1.0.5"


### PR DESCRIPTION
This PR introduces the following changes required by jsonapi-ts@0.1.17:

- All resources now have a defined schema.
- The UserProcessor now implements an `identify` operation, which is private and non-HTTP mapped, to fetch data for an user who's trying to login. That way, the `get` operation needs no further authorization checks and cannot be spoofed to leak user data.

### Related issues

Resolves #1230.