### PR TITLE
[tic-tac-toe-bot] fix bad import

### DIFF
--- a/packages/tic-tac-toe-bot/test/integration.spec.ts
+++ b/packages/tic-tac-toe-bot/test/integration.spec.ts
@@ -5,13 +5,13 @@ import {
   Node,
   NodeConfig
 } from "@counterfactual/node";
+import { LocalFirebaseServiceFactory } from "@counterfactual/node/test/services/firebase-server";
 import { Node as NodeTypes } from "@counterfactual/types";
 import { ethers } from "ethers";
 import { JsonRpcProvider } from "ethers/providers";
 import { Log, LogLevel } from "logepi";
 import { v4 as generateUUID } from "uuid";
 
-import { LocalFirebaseServiceFactory } from "../../node/test/services/firebase-server";
 import { connectNode } from "../src/bot";
 
 jest.setTimeout(50000);


### PR DESCRIPTION
This import was causing `yarn:lint` to lint the node package as well