### PR TITLE
[monorepo] `CounterfactualApp` cleanup

### DIFF
--- a/packages/apps/contracts/CommitRevealApp.sol
+++ b/packages/apps/contracts/CommitRevealApp.sol
@@ -46,7 +46,9 @@ contract CommitRevealApp is CounterfactualApp {
     return state.stage == Stage.DONE;
   }
 
-  function getTurnTaker(bytes calldata encodedState, address[] calldata signingKeys)
+  function getTurnTaker(
+    bytes calldata encodedState, address[] calldata signingKeys
+  )
     external
     pure
     returns (address)
@@ -60,7 +62,9 @@ contract CommitRevealApp is CounterfactualApp {
     return signingKeys[uint8(Player.CHOOSING)];
   }
 
-  function applyAction(bytes calldata encodedState, bytes calldata encodedAction)
+  function applyAction(
+    bytes calldata encodedState, bytes calldata encodedAction
+  )
     external
     pure
     returns (bytes memory)

--- a/packages/apps/contracts/CommitRevealApp.sol
+++ b/packages/apps/contracts/CommitRevealApp.sol
@@ -37,8 +37,8 @@ contract CommitRevealApp is CounterfactualApp {
     bytes32 actionHash;
   }
 
-  function isStateTerminal(bytes memory encodedState)
-    public
+  function isStateTerminal(bytes calldata encodedState)
+    external
     pure
     returns (bool)
   {
@@ -46,8 +46,8 @@ contract CommitRevealApp is CounterfactualApp {
     return state.stage == Stage.DONE;
   }
 
-  function getTurnTaker(bytes memory encodedState, address[] memory signingKeys)
-    public
+  function getTurnTaker(bytes calldata encodedState, address[] calldata signingKeys)
+    external
     pure
     returns (address)
   {
@@ -60,8 +60,8 @@ contract CommitRevealApp is CounterfactualApp {
     return signingKeys[uint8(Player.CHOOSING)];
   }
 
-  function applyAction(bytes memory encodedState, bytes memory encodedAction)
-    public
+  function applyAction(bytes calldata encodedState, bytes calldata encodedAction)
+    external
     pure
     returns (bytes memory)
   {
@@ -102,8 +102,8 @@ contract CommitRevealApp is CounterfactualApp {
     return abi.encode(nextState);
   }
 
-  function resolve(bytes memory encodedState, Transfer.Terms memory terms)
-    public
+  function resolve(bytes calldata encodedState, Transfer.Terms calldata terms)
+    external
     pure
     returns (Transfer.Transaction memory)
   {

--- a/packages/apps/contracts/HighRollerApp.sol
+++ b/packages/apps/contracts/HighRollerApp.sol
@@ -47,8 +47,8 @@ contract HighRollerApp is CounterfactualApp {
     bytes32 actionHash;
   }
 
-  function isStateTerminal(bytes memory encodedState)
-    public
+  function isStateTerminal(bytes calldata encodedState)
+    external
     pure
     returns (bool)
   {
@@ -56,8 +56,8 @@ contract HighRollerApp is CounterfactualApp {
     return state.stage == Stage.DONE;
   }
 
-  function getTurnTaker(bytes memory encodedState, address[] memory signingKeys)
-    public
+  function getTurnTaker(bytes calldata encodedState, address[] calldata signingKeys)
+    external
     pure
     returns (address)
   {
@@ -68,8 +68,8 @@ contract HighRollerApp is CounterfactualApp {
       signingKeys[uint8(Player.FIRST)];
   }
 
-  function applyAction(bytes memory encodedState, bytes memory encodedAction)
-    public
+  function applyAction(bytes calldata encodedState, bytes calldata encodedAction)
+    external
     pure
     returns (bytes memory)
   {
@@ -116,8 +116,8 @@ contract HighRollerApp is CounterfactualApp {
     return abi.encode(nextState);
   }
 
-  function resolve(bytes memory encodedState, Transfer.Terms memory terms)
-    public
+  function resolve(bytes calldata encodedState, Transfer.Terms calldata terms)
+    external
     pure
     returns (Transfer.Transaction memory)
   {

--- a/packages/apps/contracts/HighRollerApp.sol
+++ b/packages/apps/contracts/HighRollerApp.sol
@@ -56,7 +56,9 @@ contract HighRollerApp is CounterfactualApp {
     return state.stage == Stage.DONE;
   }
 
-  function getTurnTaker(bytes calldata encodedState, address[] calldata signingKeys)
+  function getTurnTaker(
+    bytes calldata encodedState, address[] calldata signingKeys
+  )
     external
     pure
     returns (address)
@@ -68,7 +70,9 @@ contract HighRollerApp is CounterfactualApp {
       signingKeys[uint8(Player.FIRST)];
   }
 
-  function applyAction(bytes calldata encodedState, bytes calldata encodedAction)
+  function applyAction(
+    bytes calldata encodedState, bytes calldata encodedAction
+  )
     external
     pure
     returns (bytes memory)

--- a/packages/apps/contracts/NimApp.sol
+++ b/packages/apps/contracts/NimApp.sol
@@ -21,8 +21,8 @@ contract NimApp is CounterfactualApp {
     uint256[3] pileHeights;
   }
 
-  function isStateTerminal(bytes memory encodedState)
-    public
+  function isStateTerminal(bytes calldata encodedState)
+    external
     pure
     returns (bool)
   {
@@ -30,8 +30,8 @@ contract NimApp is CounterfactualApp {
     return isWin(state);
   }
 
-  function getTurnTaker(bytes memory encodedState, address[] memory signingKeys)
-    public
+  function getTurnTaker(bytes calldata encodedState, address[] calldata signingKeys)
+    external
     pure
     returns (address)
   {
@@ -39,8 +39,8 @@ contract NimApp is CounterfactualApp {
     return signingKeys[state.turnNum % 2];
   }
 
-  function applyAction(bytes memory encodedState, bytes memory encodedAction)
-    public
+  function applyAction(bytes calldata encodedState, bytes calldata encodedAction)
+    external
     pure
     returns (bytes memory)
   {
@@ -60,8 +60,8 @@ contract NimApp is CounterfactualApp {
     return abi.encode(ret);
   }
 
-  function resolve(bytes memory encodedState, Transfer.Terms memory terms)
-    public
+  function resolve(bytes calldata encodedState, Transfer.Terms calldata terms)
+    external
     pure
     returns (Transfer.Transaction memory)
   {

--- a/packages/apps/contracts/NimApp.sol
+++ b/packages/apps/contracts/NimApp.sol
@@ -30,7 +30,9 @@ contract NimApp is CounterfactualApp {
     return isWin(state);
   }
 
-  function getTurnTaker(bytes calldata encodedState, address[] calldata signingKeys)
+  function getTurnTaker(
+    bytes calldata encodedState, address[] calldata signingKeys
+  )
     external
     pure
     returns (address)
@@ -39,7 +41,9 @@ contract NimApp is CounterfactualApp {
     return signingKeys[state.turnNum % 2];
   }
 
-  function applyAction(bytes calldata encodedState, bytes calldata encodedAction)
+  function applyAction(
+    bytes calldata encodedState, bytes calldata encodedAction
+  )
     external
     pure
     returns (bytes memory)
@@ -60,7 +64,9 @@ contract NimApp is CounterfactualApp {
     return abi.encode(ret);
   }
 
-  function resolve(bytes calldata encodedState, Transfer.Terms calldata terms)
+  function resolve(
+    bytes calldata encodedState, Transfer.Terms calldata terms
+  )
     external
     pure
     returns (Transfer.Transaction memory)

--- a/packages/apps/contracts/TicTacToeApp.sol
+++ b/packages/apps/contracts/TicTacToeApp.sol
@@ -59,7 +59,9 @@ contract TicTacToeApp is CounterfactualApp {
     return state.winner != GAME_IN_PROGRESS;
   }
 
-  function getTurnTaker(bytes calldata encodedState, address[] calldata signingKeys)
+  function getTurnTaker(
+    bytes calldata encodedState, address[] calldata signingKeys
+  )
     external
     pure
     returns (address)
@@ -68,7 +70,9 @@ contract TicTacToeApp is CounterfactualApp {
     return signingKeys[state.turnNum % 2];
   }
 
-  function applyAction(bytes calldata encodedState, bytes calldata encodedAction)
+  function applyAction(
+    bytes calldata encodedState, bytes calldata encodedAction
+  )
     external
     pure
     returns (bytes memory)

--- a/packages/apps/contracts/TicTacToeApp.sol
+++ b/packages/apps/contracts/TicTacToeApp.sol
@@ -50,8 +50,8 @@ contract TicTacToeApp is CounterfactualApp {
     WinClaim winClaim;
   }
 
-  function isStateTerminal(bytes memory encodedState)
-    public
+  function isStateTerminal(bytes calldata encodedState)
+    external
     pure
     returns (bool)
   {
@@ -59,8 +59,8 @@ contract TicTacToeApp is CounterfactualApp {
     return state.winner != GAME_IN_PROGRESS;
   }
 
-  function getTurnTaker(bytes memory encodedState, address[] memory signingKeys)
-    public
+  function getTurnTaker(bytes calldata encodedState, address[] calldata signingKeys)
+    external
     pure
     returns (address)
   {
@@ -68,8 +68,8 @@ contract TicTacToeApp is CounterfactualApp {
     return signingKeys[state.turnNum % 2];
   }
 
-  function applyAction(bytes memory encodedState, bytes memory encodedAction)
-    public
+  function applyAction(bytes calldata encodedState, bytes calldata encodedAction)
+    external
     pure
     returns (bytes memory)
   {
@@ -98,8 +98,8 @@ contract TicTacToeApp is CounterfactualApp {
     return abi.encode(postState);
   }
 
-  function resolve(bytes memory encodedState, Transfer.Terms memory terms)
-    public
+  function resolve(bytes calldata encodedState, Transfer.Terms calldata terms)
+    external
     pure
     returns (Transfer.Transaction memory)
   {

--- a/packages/contracts/contracts/CounterfactualApp.sol
+++ b/packages/contracts/contracts/CounterfactualApp.sol
@@ -4,25 +4,25 @@ pragma experimental "ABIEncoderV2";
 import "./libs/Transfer.sol";
 
 
-contract CounterfactualApp {
+interface CounterfactualApp {
 
-  function isStateTerminal(bytes memory)
-    public
+  function isStateTerminal(bytes calldata)
+    external
     pure
     returns (bool);
 
-  function getTurnTaker(bytes memory, address[] memory)
-    public
+  function getTurnTaker(bytes calldata, address[] calldata)
+    external
     pure
     returns (address);
 
-  function applyAction(bytes memory, bytes memory)
-    public
+  function applyAction(bytes calldata, bytes calldata)
+    external
     pure
     returns (bytes memory);
 
-  function resolve(bytes memory, Transfer.Terms memory)
-    public
+  function resolve(bytes calldata, Transfer.Terms calldata)
+    external
     pure
     returns (Transfer.Transaction memory);
 

--- a/packages/contracts/contracts/default-apps/ETHBalanceRefundApp.sol
+++ b/packages/contracts/contracts/default-apps/ETHBalanceRefundApp.sol
@@ -36,28 +36,4 @@ contract ETHBalanceRefundApp {
       data
     );
   }
-
-  function isStateTerminal(bytes memory)
-    public
-    pure
-    returns (bool)
-  {
-    revert("Not implemented");
-  }
-
-  function getTurnTaker(bytes memory, address[] memory)
-    public
-    pure
-    returns (address)
-  {
-    revert("Not implemented");
-  }
-
-  function applyAction(bytes memory, bytes memory)
-    public
-    pure
-    returns (bytes memory)
-  {
-    revert("Not implemented");
-  }
 }

--- a/packages/contracts/contracts/default-apps/ETHBucket.sol
+++ b/packages/contracts/contracts/default-apps/ETHBucket.sol
@@ -14,8 +14,8 @@ contract ETHBucket is CounterfactualApp {
     uint256 bobBalance;
   }
 
-  function resolve(bytes memory encodedState, Transfer.Terms memory terms)
-    public
+  function resolve(bytes calldata encodedState, Transfer.Terms calldata terms)
+    external
     pure
     returns (Transfer.Transaction memory)
   {

--- a/packages/contracts/contracts/test-fixtures/ResolveToPay5WeiApp.sol
+++ b/packages/contracts/contracts/test-fixtures/ResolveToPay5WeiApp.sol
@@ -11,8 +11,8 @@ import "../CounterfactualApp.sol";
 /// `Transfer.Transaction` object when the channel is closed.
 contract ResolveToPay5WeiApp is CounterfactualApp {
 
-  function resolve(bytes memory encodedState, Transfer.Terms memory terms)
-    public
+  function resolve(bytes calldata encodedState, Transfer.Terms calldata terms)
+    external
     pure
     returns (Transfer.Transaction memory)
   {


### PR DESCRIPTION
- delete `revert("not implemented")`s in app definitions which only define a resolve function. It seems that solidity no longer complains if virtual functions are not implemented in the child function.
- change `CounterfactualApp` to be `interface`
- mark CounterfactualApp functions as `external` instead of `public`; required by interfaces and saves a tiny bit of gas