### PR TITLE
[contracts] Deploy updated ProxyFactory contract

### DIFF
--- a/packages/contracts/README.md
+++ b/packages/contracts/README.md
@@ -36,8 +36,7 @@ yarn test [test/<filename of specific test>.spec.ts ...]
 
 # Migrations
 
-The `networks` folder contains the migration files for the different Ethereum networks the contracts have been migrated to. The ID of the respective networks are used as file names.
-The mapping of some of the major Ethereum network IDs to network names is:
+The `networks` folder contains the migration files for the different Ethereum networks the contracts have been migrated to. The ID of the respective networks are used as file names. The mapping of some of the major Ethereum network IDs to network names is:
 
 | Network ID | Network Name    |
 | ---------- | --------------- |
@@ -46,10 +45,9 @@ The mapping of some of the major Ethereum network IDs to network names is:
 | 4          | Rinkeby testnet |
 | 42         | Kovan testnet   |
 
-Not all of the networks will be used for the Counterfactual contracts, but you can find a more comprehensive list [here](https://ethereum.stackexchange.com/a/17101).
-To run a migration against a target network:
+Not all of the networks will be used for the Counterfactual contracts, but you can find a more comprehensive list [here](https://ethereum.stackexchange.com/a/17101). To run a migration against a target network:
 
-- make sure the target network configuration exists in `truffle.js`
+- make sure the target network configuration exists in `truffle-config.js`
 - the right env vars are set in `.env`
 - the network account you're using to send transactions from is funded (eg. for Rinkeby: https://faucet.rinkeby.io/)
 - run: `yarn migrate --network <network name>`

--- a/packages/contracts/networks/42.json
+++ b/packages/contracts/networks/42.json
@@ -51,8 +51,8 @@
   },
   {
     "contractName": "ProxyFactory",
-    "address": "0xF8ABB72e48B0E0F0fDf9A892109F24ffAE14705c",
-    "transactionHash": "0x697f63adff2c1725737cc5de33ff7e0281583989ab628d3415b19353eec3a2ca"
+    "address": "0xa597600118dbd039ca8dc43a9af710a316de974d",
+    "transactionHash": "0x600c57dc6ef58c20793ceb671caf83dd6dcad09239f60ed01c07cdb48a8adbae"
   },
   {
     "contractName": "StateChannelTransaction",

--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -37,7 +37,6 @@
     "ethereum-waffle": "2.0.9",
     "ethers": "4.0.27",
     "ethlint": "1.2.4",
-    "ganache-cli": "6.4.1",
     "ganache-cli": "6.4.3",
     "openzeppelin-solidity": "2.2.0",
     "shx": "0.3.2",


### PR DESCRIPTION
This deploys the updated ProxyFactory contract as needed by https://github.com/counterfactual/monorepo/pull/1265