### PR TITLE
[node][playground-server] Update error message & expose public identifier

### DIFF
--- a/packages/node/src/node.ts
+++ b/packages/node/src/node.ts
@@ -111,6 +111,7 @@ export class Node {
   private async asynchronouslySetupUsingRemoteServices(): Promise<Node> {
     this.signer = await getHDNode(this.storeService);
     console.log(`Node signer address: ${this.signer.address}`);
+    console.log(`Node public identifier: ${this.publicIdentifier}`);
     this.requestHandler = new RequestHandler(
       this.publicIdentifier,
       this.incoming,

--- a/packages/playground-server/README.md
+++ b/packages/playground-server/README.md
@@ -71,7 +71,7 @@ $ node
 'camera enter drive paper elegant camp above attend board thought inch crash'
 ```
 
-And save it in `.env`.
+And save it in `.env` in the format specified in `.env.schema`.
 
 **Option 1** Compute the address:
 

--- a/packages/playground-server/src/index.ts
+++ b/packages/playground-server/src/index.ts
@@ -9,6 +9,11 @@ const BANNED_MNEMONICS = new Set([
   "impulse exile artwork when toss canal entire electric protect custom adult erupt"
 ]);
 
+const NO_MNEMONIC_MESSAGE =
+  'Error: No mnemonic specified in the NODE_MNEMONIC env var.\n\
+Please set one by following the instructions in the README, \
+section "Funding the Hub Account for Playground Testing".\n';
+
 Log.setOutputLevel((process.env.API_LOG_LEVEL as LogLevel) || LogLevel.INFO);
 
 const API_TIMEOUT = 5 * 60 * 1000;
@@ -16,9 +21,7 @@ const API_TIMEOUT = 5 * 60 * 1000;
 (async () => {
   const nodeMnemonic = process.env.NODE_MNEMONIC;
   if (!nodeMnemonic) {
-    console.error(
-      "\nError: No mnemonic specified in the NODE_MNEMONIC env var. Please set one.\n"
-    );
+    console.error(NO_MNEMONIC_MESSAGE);
     process.exit(1);
   }
 


### PR DESCRIPTION
This updates the error message for not having a mnemonic set for the playground server to direct the user to be able to set it up.

It also exposes a node's public identifier for easier accessibility to the node's "address".