### PR TITLE
[node] Propose State for AppInstance

### DIFF
--- a/packages/cf.js/API_REFERENCE.md
+++ b/packages/cf.js/API_REFERENCE.md
@@ -316,7 +316,13 @@ Errors: (TODO)
 
 ### Method: `proposeState`
 
-TODO
+Proposes a state update for the AppInstance with the specified ID.
+
+Params:
+- `appInstanceId: string`
+    - ID of the app instance the state proposal is being made for
+- `state:`[`AppState`](#data-type-appstate)
+    - The state to propose
 
 ### Method: `acceptState`
 

--- a/packages/node/src/methods/app-instance/propose-state/controller.ts
+++ b/packages/node/src/methods/app-instance/propose-state/controller.ts
@@ -1,0 +1,82 @@
+import { Node } from "@counterfactual/types";
+import { INVALID_ARGUMENT } from "ethers/errors";
+import Queue from "p-queue";
+
+import { RequestHandler } from "../../../request-handler";
+import { NODE_EVENTS, UpdateStateMessage } from "../../../types";
+import { getCounterpartyAddress } from "../../../utils";
+import { NodeController } from "../../controller";
+import { ERRORS } from "../../errors";
+
+export default class ProposeStateController extends NodeController {
+  public static readonly methodName = Node.MethodName.PROPOSE_STATE;
+
+  protected async enqueueByShard(
+    requestHandler: RequestHandler,
+    params: Node.StateProposalParams
+  ): Promise<Queue[]> {
+    const { store } = requestHandler;
+    const { appInstanceId } = params;
+
+    return [
+      requestHandler.getShardedQueue(
+        await store.getMultisigAddressFromAppInstanceID(appInstanceId)
+      )
+    ];
+  }
+
+  protected async beforeExecution(
+    requestHandler: RequestHandler,
+    params: Node.StateProposalParams
+  ): Promise<void> {
+    const { store } = requestHandler;
+    const { appInstanceId, newState } = params;
+
+    if (!appInstanceId) {
+      return Promise.reject(ERRORS.NO_APP_INSTANCE_FOR_STATE_PROPOSAL);
+    }
+
+    const appInstance = await store.getAppInstance(appInstanceId);
+
+    try {
+      appInstance.encodeState(newState);
+    } catch (e) {
+      if (e.code === INVALID_ARGUMENT) {
+        return Promise.reject(`${ERRORS.IMPROPERLY_FORMATTED_STRUCT}: ${e}`);
+      }
+      return Promise.reject(ERRORS.STATE_OBJECT_NOT_ENCODABLE);
+    }
+  }
+
+  protected async executeMethodImplementation(
+    requestHandler: RequestHandler,
+    params: Node.StateProposalParams
+  ): Promise<Node.StateProposalResult> {
+    const {
+      store,
+      publicIdentifier,
+      messagingService,
+      outgoing
+    } = requestHandler;
+    const { appInstanceId, newState } = params;
+
+    const appInstanceInfo = await store.getAppInstanceInfo(appInstanceId);
+
+    const to = getCounterpartyAddress(publicIdentifier, [
+      appInstanceInfo.proposedByIdentifier,
+      appInstanceInfo.proposedToIdentifier
+    ]);
+
+    const msg = {
+      from: requestHandler.publicIdentifier,
+      type: NODE_EVENTS.UPDATE_STATE,
+      data: { appInstanceId, newState }
+    } as UpdateStateMessage;
+
+    await messagingService.send(to, msg);
+
+    outgoing.emit(msg.type, msg);
+
+    return;
+  }
+}

--- a/packages/node/src/methods/errors.ts
+++ b/packages/node/src/methods/errors.ts
@@ -16,6 +16,8 @@ export const ERRORS = {
     "A proposed AppInstance cannot have an empty initial state",
   NO_APP_INSTANCE_FOR_TAKE_ACTION:
     "No AppInstanceId specified to takeAction on",
+  NO_APP_INSTANCE_FOR_STATE_PROPOSAL:
+    "No AppInstanceId specified to propose state for",
   NO_APP_CONTRACT_ADDR: "The App Contract address is empty",
   INVALID_ACTION: "Invalid action taken",
   INSUFFICIENT_FUNDS:

--- a/packages/types/src/node-protocol.ts
+++ b/packages/types/src/node-protocol.ts
@@ -67,10 +67,10 @@ export namespace Node {
     WITHDRAWAL_CONFIRMED = "withdrawalConfirmedEvent",
     WITHDRAWAL_FAILED = "withdrawalFailed",
     WITHDRAWAL_STARTED = "withdrawalStartedEvent",
-    PROPOSE_INSTALL = "proposeInstallEvent",	
-    PROPOSE_INSTALL_VIRTUAL = "proposeInstallVirtualEvent",	
-    PROTOCOL_MESSAGE_EVENT = "protocolMessageEvent",	
-    WITHDRAW_EVENT = "withdrawEvent",	
+    PROPOSE_INSTALL = "proposeInstallEvent",
+    PROPOSE_INSTALL_VIRTUAL = "proposeInstallVirtualEvent",
+    PROTOCOL_MESSAGE_EVENT = "protocolMessageEvent",
+    WITHDRAW_EVENT = "withdrawEvent",
     REJECT_INSTALL_VIRTUAL = "rejectInstallVirtualEvent"
   }
 
@@ -198,6 +198,13 @@ export namespace Node {
     newState: SolidityABIEncoderV2Struct;
   };
 
+  export type StateProposalParams = {
+    appInstanceId: AppInstanceID;
+    newState: SolidityABIEncoderV2Struct;
+  };
+
+  export type StateProposalResult = void;
+
   export type UninstallParams = {
     appInstanceId: AppInstanceID;
   };
@@ -241,6 +248,7 @@ export namespace Node {
     | GetStateParams
     | GetAppInstanceDetailsParams
     | TakeActionParams
+    | StateProposalParams
     | UninstallParams
     | CreateChannelParams
     | GetChannelAddressesParams;
@@ -256,6 +264,7 @@ export namespace Node {
     | GetStateResult
     | GetAppInstanceDetailsResult
     | TakeActionResult
+    | StateProposalResult
     | UninstallResult
     | CreateChannelResult
     | GetChannelAddressesResult;


### PR DESCRIPTION
### Description

Adds support for proposing a state update for an AppInstance.

Useful when the nature of the app requires that the advancement of an app's state be unanimously explicitly agreed-upon by all channel participants.

This is an immediate action item needed to support the work being done here: https://github.com/ConnextProject/monorepo/projects/1

Acceptance criteria:
- [ ] write controllers for handling the flow
- [ ] integration tests showcasing this call being made successfully and invalidly

### Relevant Issues:
- https://github.com/counterfactual/monorepo/issues/1341