### PR TITLE
[Dapp High Roller] Generate random numberSalt for commitToHash action

### DIFF
--- a/packages/dapp-high-roller/src/components/app-game/app-game.tsx
+++ b/packages/dapp-high-roller/src/components/app-game/app-game.tsx
@@ -15,7 +15,7 @@ import {
 import HighRollerUITunnel from "../../data/high-roller";
 import { AppInstance } from "../../data/mock-app-instance";
 import { cf, HighRollerUIMutableState } from "../../data/types";
-import { computeCommitHash, getProp, generateSalt } from "../../utils/utils";
+import { computeCommitHash, generateSalt, getProp } from "../../utils/utils";
 
 const { AddressZero, HashZero } = ethers.constants;
 const { bigNumberify } = ethers.utils;

--- a/packages/dapp-high-roller/src/components/app-game/app-game.tsx
+++ b/packages/dapp-high-roller/src/components/app-game/app-game.tsx
@@ -15,7 +15,7 @@ import {
 import HighRollerUITunnel from "../../data/high-roller";
 import { AppInstance } from "../../data/mock-app-instance";
 import { cf, HighRollerUIMutableState } from "../../data/types";
-import { computeCommitHash, getProp } from "../../utils/utils";
+import { computeCommitHash, getProp, generateSalt } from "../../utils/utils";
 
 const { AddressZero, HashZero } = ethers.constants;
 const { bigNumberify } = ethers.utils;
@@ -148,9 +148,7 @@ export class AppGame {
         startGameAction
       )) as HighRollerAppState;
 
-      // TODO randomize this and save it in proposingPlayer state
-      const numberSalt =
-        "0xdfdaa4d168f0be935a1e1d12b555995bc5ea67bd33fce1bc5be0a1e0a381fc90";
+      const numberSalt = generateSalt();
       const playerFirstNumber =
         1 + Math.floor(Math.random() * Math.floor(1000));
       const hash = computeCommitHash(numberSalt, playerFirstNumber);
@@ -165,7 +163,8 @@ export class AppGame {
         ...((await this.appInstance.takeAction(
           commitHashAction
         )) as HighRollerAppState),
-        playerFirstNumber: bigNumberify(playerFirstNumber)
+        playerFirstNumber: bigNumberify(playerFirstNumber),
+        salt: numberSalt
       } as HighRollerAppState;
 
       this.updateUIState({

--- a/packages/dapp-high-roller/src/components/app-provider/app-provider.tsx
+++ b/packages/dapp-high-roller/src/components/app-provider/app-provider.tsx
@@ -120,13 +120,9 @@ export class AppProvider {
     );
 
     if (state.stage === HighRollerStage.REVEALING) {
-      // TODO randomize this and save it in proposingPlayer state
-      const numberSalt =
-        "0xdfdaa4d168f0be935a1e1d12b555995bc5ea67bd33fce1bc5be0a1e0a381fc90";
-
       return await this.appInstance.takeAction({
         actionType: ActionType.REVEAL,
-        actionHash: numberSalt,
+        actionHash: state.salt,
         number: state.playerFirstNumber.toString()
       });
     }

--- a/packages/dapp-high-roller/src/components/app-provider/app-provider.tsx
+++ b/packages/dapp-high-roller/src/components/app-provider/app-provider.tsx
@@ -122,7 +122,7 @@ export class AppProvider {
     if (state.stage === HighRollerStage.REVEALING) {
       return await this.appInstance.takeAction({
         actionType: ActionType.REVEAL,
-        actionHash: state.salt,
+        actionHash: this.highRollerState.salt,
         number: state.playerFirstNumber.toString()
       });
     }

--- a/packages/dapp-high-roller/src/utils/utils.ts
+++ b/packages/dapp-high-roller/src/utils/utils.ts
@@ -19,4 +19,8 @@ function computeCommitHash(appSalt: string, chosenNumber: number) {
   );
 }
 
-export { getProp, computeCommitHash };
+function generateSalt() {
+  return ethers.utils.bigNumberify(ethers.utils.randomBytes(32)).toHexString();
+}
+
+export { getProp, computeCommitHash, generateSalt };


### PR DESCRIPTION
### Description

Add `generateSalt` function from [here](https://github.com/counterfactual/getting-started/blob/8507d9f567d809d957c45e48c148a164b2601d37/src/js/app.js#L337) to utils. Use in `handleRoll` to generate a random salt and add it to the `HighRollerAppState`. Retrieve from state in `onUpdateState`.


### Related issues

resolves #1319 