### PR TITLE
[node] Fix node test scripts

### DIFF
--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -8,8 +8,10 @@
   "scripts": {
     "build": "tsc -p . && rollup -c",
     "test": "yarn run test:machine && yarn run test:node",
-    "test:machine": "./scripts/test.sh",
-    "test:node": "jest --testPathIgnorePatterns=test/machine/integration --setupFiles dotenv-extended/config --runInBand --bail --forceExit",
+    "test:machine": "yarn run test:machine:integration && yarn run test:machine:unit",
+    "test:machine:integration": "./scripts/test.sh",
+    "test:machine:unit": "jest --testPathPattern=test/machine/unit --bail --forceExit",
+    "test:node": "jest --testPathIgnorePatterns=test/machine --setupFiles dotenv-extended/config --runInBand --bail --forceExit",
     "test:coverage": "jest --runInBand --detectOpenHandles --bail --coverage",
     "lint:fix": "tslint -c tslint.json -p . --fix",
     "lint": "tslint -c tslint.json -p ."

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -7,9 +7,9 @@
   "license": "MIT",
   "scripts": {
     "build": "tsc -p . && rollup -c",
-    "test": "yarn run test:no-ganache && yarn run test:with-ganache",
-    "test:with-ganache": "./scripts/test.sh",
-    "test:no-ganache": "jest --testPathIgnorePatterns=test/machine/integration --setupFiles dotenv-extended/config --runInBand --bail --forceExit",
+    "test": "yarn run test:machine && yarn run test:node",
+    "test:machine": "./scripts/test.sh",
+    "test:node": "jest --testPathIgnorePatterns=test/machine/integration --setupFiles dotenv-extended/config --runInBand --bail --forceExit",
     "test:coverage": "jest --runInBand --detectOpenHandles --bail --coverage",
     "lint:fix": "tslint -c tslint.json -p . --fix",
     "lint": "tslint -c tslint.json -p ."


### PR DESCRIPTION
### Description

During the transition of moving the machine package under the node package, the test script broke, preventing test regexes from being used to filter tests to run.

Now test regex for node tests can be specified via:
```
yarn test:node <regex>
```
