### PR TITLE
[monorepo] Asks `renovate` to ignore @ebryn/jsonapi-ts

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -9,6 +9,7 @@
     "jest-cli",
     "jest",
     "workbox-build",
+    "@ebryn/jsonapi-ts",
     "@counterfactual/apps",
     "@counterfactual/cf.js",
     "@counterfactual/contracts",


### PR DESCRIPTION
This dependency isn't 100% respectful of semver, and it introduces breaking changes often.