### PR TITLE
[monorepo] change getFreeBalance return type

### DIFF
--- a/packages/cf.js/API_REFERENCE.md
+++ b/packages/cf.js/API_REFERENCE.md
@@ -376,9 +376,13 @@ Params:
 
 Result:
 
-- [`FreeBalance`](#data-type-ethbucket)
+```
+{
+    [s: string]: BigNumber;
+};
+```
 
-
+Returns a mapping from address to balance in wei. The address of a node with public identifier `publicIdentifier` is defined as `fromExtendedKey(publicIdentifier).derivePath("0").address`.
 
 Events
 ------
@@ -504,10 +508,3 @@ An instance of an installed app.
 
 - Plain Old Javascript Object representation of the action of an app instance.
 - ABI encoded/decoded using the `actionEncoding` field on the instance's [`AppABIEncodings`](#data-type-appabiencodings).
-
-### Data Type: `ETHBucket`
-
-- `alice: string`
-- `bob: string`
-- `aliceBalance: BigNumber`
-- `bobBalance: BigNumber`

--- a/packages/dapp-high-roller/src/data/types.ts
+++ b/packages/dapp-high-roller/src/data/types.ts
@@ -44,13 +44,6 @@ export interface SignedStateHashUpdate {
   signatures: string;
 }
 
-export interface ETHBucketAppState {
-  alice: string;
-  bob: string;
-  aliceBalance: BigNumber;
-  bobBalance: BigNumber;
-}
-
 export type AppInstanceInfo = {
   id: AppInstanceID;
   appId: Address;

--- a/packages/node/src/methods/app-instance/get-free-balance/controller.ts
+++ b/packages/node/src/methods/app-instance/get-free-balance/controller.ts
@@ -25,9 +25,16 @@ export default class GetFreeBalanceController extends NodeController {
 
     const stateChannel = await store.getStateChannel(multisigAddress);
 
+    const {
+      alice,
+      bob,
+      aliceBalance,
+      bobBalance
+    } = stateChannel.getFreeBalanceFor(AssetType.ETH)
+      .state as ETHBucketAppState;
     return {
-      state: stateChannel.getFreeBalanceFor(AssetType.ETH)
-        .state as ETHBucketAppState
+      [alice]: aliceBalance,
+      [bob]: bobBalance
     };
   }
 }

--- a/packages/node/src/node.ts
+++ b/packages/node/src/node.ts
@@ -1,7 +1,7 @@
 import { NetworkContext, Node as NodeTypes } from "@counterfactual/types";
 import { BaseProvider } from "ethers/providers";
 import { SigningKey } from "ethers/utils";
-import { HDNode } from "ethers/utils/hdnode";
+import { fromExtendedKey, HDNode } from "ethers/utils/hdnode";
 import EventEmitter from "eventemitter3";
 import { Memoize } from "typescript-memoize";
 
@@ -132,6 +132,12 @@ export class Node {
   @Memoize()
   get publicIdentifier(): string {
     return this.signer.neuter().extendedKey;
+  }
+
+  /// Address used for ETH free balance and maybe some other things
+  @Memoize()
+  get zeroethAddress(): string {
+    return fromExtendedKey(this.publicIdentifier).derivePath("0").address;
   }
 
   /**

--- a/packages/node/test/integration/secure-deposit.spec.ts
+++ b/packages/node/test/integration/secure-deposit.spec.ts
@@ -95,8 +95,9 @@ describe("Node method follows spec - deposit", () => {
           multisigAddress
         );
 
-        expect(freeBalanceState.aliceBalance).toEqual(One);
-        expect(freeBalanceState.bobBalance).toEqual(One);
+        for (const key in freeBalanceState) {
+          expect(freeBalanceState[key]).toEqual(One);
+        }
 
         done();
       }

--- a/packages/node/test/integration/utils.ts
+++ b/packages/node/test/integration/utils.ts
@@ -5,7 +5,6 @@ import {
   AppInstanceInfo,
   AssetType,
   BlockchainAsset,
-  ETHBucketAppState,
   NetworkContext,
   networkContextProps,
   Node as NodeTypes,
@@ -98,7 +97,7 @@ export async function getProposedAppInstanceInfo(
 export async function getFreeBalanceState(
   node: Node,
   multisigAddress: string
-): Promise<ETHBucketAppState> {
+): Promise<NodeTypes.GetFreeBalanceStateResult> {
   const req = {
     requestId: generateUUID(),
     type: NodeTypes.MethodName.GET_FREE_BALANCE_STATE,
@@ -107,8 +106,7 @@ export async function getFreeBalanceState(
     }
   };
   const response = await node.call(req.type, req);
-  const result = response.result as NodeTypes.GetFreeBalanceStateResult;
-  return result.state;
+  return response.result as NodeTypes.GetFreeBalanceStateResult;
 }
 
 export async function getApps(

--- a/packages/playground/src/components/account/account-deposit/account-deposit.tsx
+++ b/packages/playground/src/components/account/account-deposit/account-deposit.tsx
@@ -15,7 +15,7 @@ import { UserSession } from "../../../types";
 export class AccountDeposit {
   @Element() el!: HTMLStencilElement;
 
-  @Prop() ethWeb3WalletBalance: BigNumber = { _hex: "0x00" } as BigNumber;
+  @Prop() ethWeb3WalletBalance: BigNumber | number = 0;
   @Prop() user: UserSession = {} as UserSession;
   @Prop() updateAccount: (e) => void = e => {};
   @Prop() history: RouterHistory = {} as RouterHistory;
@@ -85,7 +85,7 @@ export class AccountDeposit {
           autofocus={true}
           provideFaucetLink={true}
           button={buttonTexts[this.stage]}
-          available={this.ethWeb3WalletBalance}
+          available={ethers.utils.bigNumberify(this.ethWeb3WalletBalance)}
           min={0.1}
           max={1}
           error={this.error}

--- a/packages/playground/src/components/account/account-eth-form/account-eth-form.tsx
+++ b/packages/playground/src/components/account/account-eth-form/account-eth-form.tsx
@@ -14,7 +14,7 @@ export class AccountEthForm {
   @Prop() provideFaucetLink: boolean = false;
   @Prop() min: number = 0.01;
   @Prop() max: number = 1;
-  @Prop() available: BigNumber = { _hex: "0x00" } as BigNumber;
+  @Prop() available: BigNumber | number = 0;
   @Prop({ mutable: true }) value: string | number = "";
   @Prop({ mutable: true }) error: string = "";
   @Prop() loading: boolean = false;

--- a/packages/playground/src/components/account/account-exchange/account-exchange.tsx
+++ b/packages/playground/src/components/account/account-exchange/account-exchange.tsx
@@ -16,15 +16,13 @@ const HUB_IS_DEPOSITING_ALERT =
 export class AccountExchange {
   @Element() el!: HTMLStencilElement;
   @Prop() user: UserSession = {} as UserSession;
-  @Prop() ethFreeBalanceWei: BigNumber = { _hex: "0x00" } as BigNumber;
-  @Prop() ethMultisigBalance: BigNumber = { _hex: "0x00" } as BigNumber;
-  @Prop() ethWeb3WalletBalance: BigNumber = { _hex: "0x00" } as BigNumber;
+  @Prop() ethFreeBalanceWei: BigNumber | number = 0;
+  @Prop() ethMultisigBalance: BigNumber | number = 0;
+  @Prop() ethWeb3WalletBalance: BigNumber | number = 0;
   @Prop() ethPendingDepositTxHash: string = "";
-  @Prop() ethPendingDepositAmountWei: BigNumber = { _hex: "0x00" } as BigNumber;
+  @Prop() ethPendingDepositAmountWei: BigNumber | number = 0;
   @Prop() ethPendingWithdrawalTxHash: string = "";
-  @Prop() ethPendingWithdrawalAmountWei: BigNumber = {
-    _hex: "0x00"
-  } as BigNumber;
+  @Prop() ethPendingWithdrawalAmountWei: BigNumber | number = 0;
   @Prop() network: string = "";
   @Prop() updateAccount: (e) => void = e => {};
   @Prop() deposit: (value: string) => Promise<any> = async () => ({});
@@ -96,7 +94,7 @@ export class AccountExchange {
 
   async onDepositClicked(e) {
     try {
-      await this.deposit(ethers.utils.parseEther(e.target.value));
+      await this.deposit(ethers.utils.parseEther(e.target.value).toHexString());
     } catch (e) {
       if (e.toString().includes("Cannot deposit while another deposit")) {
         window.alert(HUB_IS_DEPOSITING_ALERT);
@@ -108,7 +106,9 @@ export class AccountExchange {
 
   async onWithdrawClicked(e) {
     try {
-      await this.withdraw(ethers.utils.parseEther(e.target.value));
+      await this.withdraw(
+        ethers.utils.parseEther(e.target.value).toHexString()
+      );
     } catch (e) {
       if (e.toString().includes("Cannot withdraw while another deposit")) {
         window.alert(HUB_IS_DEPOSITING_ALERT);
@@ -184,7 +184,7 @@ export class AccountExchange {
             loading={this.isDepositPending ? true : false}
             provideFaucetLink={true}
             error={this.depositError}
-            available={this.ethWeb3WalletBalance}
+            available={ethers.utils.bigNumberify(this.ethWeb3WalletBalance)}
             min={0.1}
             max={1}
           />
@@ -200,7 +200,7 @@ export class AccountExchange {
             disabled={this.isWithdrawalPending ? true : false}
             loading={this.isWithdrawalPending ? true : false}
             error={this.withdrawalError}
-            available={this.ethFreeBalanceWei}
+            available={ethers.utils.bigNumberify(this.ethFreeBalanceWei)}
             min={0}
             max={Number(ethers.utils.formatEther(ethFreeBalanceWei))}
           />

--- a/packages/playground/src/components/app-root/app-root.tsx
+++ b/packages/playground/src/components/app-root/app-root.tsx
@@ -30,11 +30,7 @@ const NETWORK_NAME_URL_PREFIX_ON_ETHERSCAN = {
   "42": "kovan"
 };
 
-const TWO_BLOCK_TIMES_ON_AVG_ON_KOVAN = 24 * 1000;
 const HEARTBEAT_INTERVAL = 30 * 1000;
-
-const delay = (timeInMilliseconds: number) =>
-  new Promise(resolve => setTimeout(resolve, timeInMilliseconds));
 
 @Component({
   tag: "app-root",
@@ -365,7 +361,7 @@ export class AppRoot {
       response = await node.call(query.type, query);
     } catch (e) {
       // TODO: Use better typed error messages with error codes
-      if (e.includes("Call to getStateChannel failed")) {
+      if (e.includes("Call to getFreeBalanceState failed")) {
         await this.updateAccount({ hasCorruptStateChannelState: true });
         return {
           ethFreeBalanceWei: ethers.constants.Zero,
@@ -376,7 +372,7 @@ export class AppRoot {
       throw e;
     }
 
-    const { state } = response.result as Node.GetFreeBalanceStateResult;
+    const freeBalance = response.result as Node.GetFreeBalanceStateResult;
 
     // Had to reimplement this on the frontend because the method can't be imported
     // due to ethers not playing nice with ES Modules in this context.
@@ -386,27 +382,23 @@ export class AppRoot {
           .publicKey
       );
 
-    const balances = [
-      ethers.utils.bigNumberify(state.aliceBalance),
-      ethers.utils.bigNumberify(state.bobBalance)
-    ];
+    const myFreeBalanceAddress = getAddress(nodeAddress, 0);
+    const [counterpartyFreeBalanceAddress] = Object.keys(freeBalance).filter(
+      addr => addr !== myFreeBalanceAddress
+    );
 
-    const [myBalance, counterpartyBalance] = [
-      balances[
-        [state.alice, state.bob].findIndex(
-          address => address === getAddress(nodeAddress, 0)
-        )
-      ],
-      balances[
-        [state.alice, state.bob].findIndex(
-          address => address !== getAddress(nodeAddress, 0)
-        )
-      ]
-    ];
+    const myBalance = (freeBalance[
+      myFreeBalanceAddress
+    ] as unknown) as BigNumber;
+    const counterpartyBalance = (freeBalance[
+      counterpartyFreeBalanceAddress
+    ] as unknown) as BigNumber;
 
     const vals = {
       ethFreeBalanceWei: myBalance,
-      ethMultisigBalance: await provider!.getBalance(multisigAddress),
+      ethMultisigBalance: (await provider!.getBalance(
+        multisigAddress
+      )) as BigNumber,
       ethCounterpartyFreeBalanceWei: counterpartyBalance
     };
 

--- a/packages/playground/src/components/layout/layout-header/header-balance/header-balance.tsx
+++ b/packages/playground/src/components/layout/layout-header/header-balance/header-balance.tsx
@@ -10,7 +10,7 @@ import { UserSession } from "../../../../types";
 })
 export class HeaderBalance {
   @Element() el!: HTMLStencilElement;
-  @Prop() ethFreeBalanceWei: BigNumber = { _hex: "0x00" } as BigNumber;
+  @Prop() ethFreeBalanceWei: BigNumber | number = 0;
   @Prop() ethPendingDepositAmountWei?: number;
   @Prop({ mutable: true }) user: UserSession = {} as UserSession;
 

--- a/packages/tic-tac-toe-bot/src/bot.ts
+++ b/packages/tic-tac-toe-bot/src/bot.ts
@@ -5,7 +5,7 @@ import { Zero } from "ethers/constants";
 import { BigNumber, bigNumberify } from "ethers/utils";
 import { v4 as generateUUID } from "uuid";
 
-import { getFreeBalance, renderFreeBalanceInEth } from "./utils";
+import { getFreeBalance, logEthFreeBalance } from "./utils";
 
 function checkDraw(board: Board) {
   return board.every((row: BoardRow) =>
@@ -206,7 +206,7 @@ export async function connectNode(
       async (uninstallMsg: UninstallVirtualMessage) => {
         console.info(`Uninstalled app`);
         console.info(uninstallMsg);
-        renderFreeBalanceInEth(await getFreeBalance(node, multisigAddress));
+        logEthFreeBalance(await getFreeBalance(node, multisigAddress));
       }
     );
   }

--- a/packages/tic-tac-toe-bot/src/utils.ts
+++ b/packages/tic-tac-toe-bot/src/utils.ts
@@ -28,13 +28,13 @@ export async function getFreeBalance(
   return result as NodeTypes.GetFreeBalanceStateResult;
 }
 
-export function renderFreeBalanceInEth(
+export function logEthFreeBalance(
   freeBalance: NodeTypes.GetFreeBalanceStateResult
 ) {
-  const { alice, aliceBalance, bob, bobBalance } = freeBalance.state;
   console.info(`Channel's free balance`);
-  console.info(`Alice: ${formatEther(aliceBalance)}  - (${alice})`);
-  console.info(`Bob: ${formatEther(bobBalance)}  - (${bob})`);
+  for (const key in freeBalance) {
+    console.info(key, formatEther(freeBalance[key]));
+  }
 }
 
 export async function fetchMultisig(baseURL: string, token: string) {
@@ -49,22 +49,27 @@ export async function fetchMultisig(baseURL: string, token: string) {
   return (await getUser(baseURL, token)).multisigAddress;
 }
 
-// FIXME: cross-reference addresses to named-users so we can avoid using
-// Alice and Bob, especially when looking at logs
+/// Deposit and wait for counterparty deposit
 export async function deposit(
   node: Node,
   amount: string,
-  multisigAddress: string,
-  skip: boolean = false
+  multisigAddress: string
 ) {
-  if (skip) {
-    return;
+  const myFreeBalanceAddress = node.zeroethAddress;
+
+  const preDepositBalances = await getFreeBalance(node, multisigAddress);
+
+  if (Object.keys(preDepositBalances).length !== 2) {
+    throw Error("Unexpected number of entries");
   }
 
-  const { aliceBalance, bobBalance } = (await getFreeBalance(
-    node,
-    multisigAddress
-  )).state;
+  if (!preDepositBalances[myFreeBalanceAddress]) {
+    throw Error("My address not found");
+  }
+
+  const [counterpartyFreeBalanceAddress] = Object.keys(
+    preDepositBalances
+  ).filter(addr => addr !== myFreeBalanceAddress);
 
   console.log(`\nDepositing ${amount} ETH into ${multisigAddress}\n`);
   try {
@@ -78,42 +83,32 @@ export async function deposit(
       } as NodeTypes.DepositParams
     });
 
-    const updatedFreeBalance = await getFreeBalance(node, multisigAddress);
-    const updatedAliceBalance = updatedFreeBalance.state.aliceBalance;
-    const updatedBobBalance = updatedFreeBalance.state.bobBalance;
+    const postDepositBalances = await getFreeBalance(node, multisigAddress);
 
-    if (updatedAliceBalance.gt(aliceBalance)) {
-      console.info("Waiting for counter party to deposit same amount");
-      while (
-        !(await getFreeBalance(node, multisigAddress)).state.bobBalance.gt(
-          updatedBobBalance
-        )
-      ) {
-        console.info(
-          `Waiting ${DELAY_SECONDS} more seconds for counter party deposit`
-        );
-        await delay(DELAY_SECONDS * 1000);
-      }
-    } else if (updatedFreeBalance.state.bobBalance.gt(bobBalance)) {
-      console.info("Waiting for counter party to deposit same amount");
-      while (
-        !(await getFreeBalance(node, multisigAddress)).state.aliceBalance.gt(
-          updatedAliceBalance
-        )
-      ) {
-        console.info(
-          `Waiting ${DELAY_SECONDS} more seconds for counter party deposit`
-        );
-        await delay(DELAY_SECONDS * 1000);
-      }
-    } else {
-      throw Error(`Neither balance was updated.\n
-        Original Free Balance: alice: ${aliceBalance}, bob: ${bobBalance}\n
-        Updated Free Balance: alice: ${updatedAliceBalance}, bob: ${updatedBobBalance}
-      `);
+    if (
+      !postDepositBalances[myFreeBalanceAddress].gt(
+        preDepositBalances[myFreeBalanceAddress]
+      )
+    ) {
+      throw Error("My balance was not updated.");
     }
 
-    renderFreeBalanceInEth(await getFreeBalance(node, multisigAddress));
+    console.info("Waiting for counter party to deposit same amount");
+
+    const freeBalanceNotUpdated = async () => {
+      return !(await getFreeBalance(node, multisigAddress))[
+        counterpartyFreeBalanceAddress
+      ].gt(preDepositBalances[counterpartyFreeBalanceAddress]);
+    };
+
+    while (await freeBalanceNotUpdated()) {
+      console.info(
+        `Waiting ${DELAY_SECONDS} more seconds for counter party deposit`
+      );
+      await delay(DELAY_SECONDS * 1000);
+    }
+
+    logEthFreeBalance(await getFreeBalance(node, multisigAddress));
   } catch (e) {
     console.error(`Failed to deposit... ${e}`);
     throw e;

--- a/packages/types/src/node-protocol.ts
+++ b/packages/types/src/node-protocol.ts
@@ -1,6 +1,5 @@
 import { BigNumber } from "ethers/utils";
 
-import { ETHBucketAppState } from ".";
 import {
   AppABIEncodings,
   AppInstanceInfo,
@@ -99,7 +98,7 @@ export namespace Node {
   };
 
   export type GetFreeBalanceStateResult = {
-    state: ETHBucketAppState;
+    [ s: string ]: BigNumber
   };
 
   export type GetAppInstancesParams = {};

--- a/packages/typescript-typings/types/ethers/index.d.ts
+++ b/packages/typescript-typings/types/ethers/index.d.ts
@@ -1,7 +1,6 @@
 // This file should be removed in favour of the real "ethers" package typings.
 
-type BigNumber = {
-  private readonly _hex;
+declare class BigNumber {
   constructor(value: BigNumberish);
   fromTwos(value: number): BigNumber;
   toTwos(value: number): BigNumber;
@@ -23,7 +22,6 @@ type BigNumber = {
   toString(): string;
   toHexString(): string;
   static isBigNumber(value: any): value is BigNumber;
-  isBigNumber(value: any): value is BigNumber;
 };
 
 type Signer = {
@@ -50,19 +48,19 @@ declare class HDNode {
   derivePath(path: string): { publicKey: string };
 }
 
-declare var ethers = {
+declare var ethers: {
   utils: {
-    formatEther: (value: BigNumber) => string,
+    formatEther: (value: BigNumber | Number) => string,
     parseEther: (value: string) => BigNumber,
     bigNumberify: (value: any) => BigNumber,
     solidityKeccak256: (type: string[], data: any[]) => string,
     computeAddress: (value: any) => string,
-    HDNode: HDNode
+    HDNode: typeof HDNode
   },
   constants: {
     Zero: BigNumber
   },
   providers: {
-    Web3Provider: Web3Provider
+    Web3Provider: typeof Web3Provider
   }
 };


### PR DESCRIPTION
This PR changes the return type of the `GetFreeBalance` node RPC method from

```
{
  alice: string;
  bob: string;
  aliceBalance: BigNumber;
  bobBalance: BigNumber;
}
``` 

to

```
{
    [s: string]: BigNumber;
};
```

The motivation is to a more stable return type so that the ETHBucket contract can be upgraded (e.g. Interpreters, >2-party channels) independently of the consumers of the `GetFreeBalance` RPC method.