### PR TITLE
[node] Fix setting of deposits for non-matching amounts

### DIFF
--- a/packages/node/src/events/propose-install-virtual/operation.ts
+++ b/packages/node/src/events/propose-install-virtual/operation.ts
@@ -29,9 +29,15 @@ export async function setAppInstanceIDForProposeInstallVirtual(
     store
   );
 
+  const fixedDepositsParams = {
+    ...params,
+    myDeposit: params.peerDeposit,
+    peerDeposit: params.myDeposit
+  };
+
   const proposedAppInstanceInfo = new ProposedAppInstanceInfo(
     {
-      ...params,
+      ...fixedDepositsParams,
       proposedByIdentifier
     },
     channel

--- a/packages/node/src/events/propose-install/operation.ts
+++ b/packages/node/src/events/propose-install/operation.ts
@@ -17,9 +17,15 @@ export async function setAppInstanceIDForProposeInstall(
     store
   );
 
+  const fixedDepositsParams = {
+    ...params,
+    myDeposit: params.peerDeposit,
+    peerDeposit: params.myDeposit
+  };
+
   const proposedAppInstanceInfo = new ProposedAppInstanceInfo(
     {
-      ...params,
+      ...fixedDepositsParams,
       proposedByIdentifier
     },
     channel

--- a/packages/node/test/global-setup.jest.ts
+++ b/packages/node/test/global-setup.jest.ts
@@ -1,6 +1,7 @@
 import dotenvExtended from "dotenv-extended";
 import { Wallet } from "ethers";
 import { Web3Provider } from "ethers/providers";
+import { parseEther } from "ethers/utils";
 import { fromMnemonic } from "ethers/utils/hdnode";
 import fs from "fs";
 import ganache from "ganache-core";
@@ -15,7 +16,7 @@ dotenvExtended.load();
 
 const DIR = path.join(os.tmpdir(), "jest_ganache_global_setup");
 
-const CF_PATH = "m/44'/60'/0'/25446";
+export const CF_PATH = "m/44'/60'/0'/25446";
 
 export default async function globalSetup() {
   mkdirp.sync(DIR);
@@ -23,12 +24,14 @@ export default async function globalSetup() {
   const privateKeyA = fromMnemonic(A_MNEMONIC).derivePath(CF_PATH).privateKey;
   const privateKeyB = fromMnemonic(B_MNEMONIC).derivePath(CF_PATH).privateKey;
   const privateKeyC = fromMnemonic(C_MNEMONIC).derivePath(CF_PATH).privateKey;
+  const fundedPrivateKey = Wallet.createRandom().privateKey;
 
   const server = ganache.server({
     accounts: [
-      { balance: "120000000000000000", secretKey: privateKeyA },
-      { balance: "120000000000000000", secretKey: privateKeyB },
-      { balance: "120000000000000000", secretKey: privateKeyC }
+      { balance: parseEther("1").toString(), secretKey: privateKeyA },
+      { balance: parseEther("1").toString(), secretKey: privateKeyB },
+      { balance: parseEther("1").toString(), secretKey: privateKeyC },
+      { balance: parseEther("1").toString(), secretKey: fundedPrivateKey }
     ]
   });
 
@@ -41,7 +44,10 @@ export default async function globalSetup() {
   const wallet = new Wallet(privateKeyA, provider);
 
   fs.writeFileSync(
-    path.join(DIR, "addresses"),
-    JSON.stringify(await configureNetworkContext(wallet))
+    path.join(DIR, "accounts"),
+    JSON.stringify({
+      fundedPrivateKey,
+      contractAddresses: await configureNetworkContext(wallet)
+    })
   );
 }

--- a/packages/node/test/global-setup.jest.ts
+++ b/packages/node/test/global-setup.jest.ts
@@ -15,7 +15,7 @@ dotenvExtended.load();
 
 const DIR = path.join(os.tmpdir(), "jest_ganache_global_setup");
 
-export const CF_PATH = "m/44'/60'/0'/25446";
+const CF_PATH = "m/44'/60'/0'/25446";
 
 export default async function globalSetup() {
   mkdirp.sync(DIR);

--- a/packages/node/test/global-setup.jest.ts
+++ b/packages/node/test/global-setup.jest.ts
@@ -15,7 +15,7 @@ dotenvExtended.load();
 
 const DIR = path.join(os.tmpdir(), "jest_ganache_global_setup");
 
-const CF_PATH = "m/44'/60'/0'/25446";
+export const CF_PATH = "m/44'/60'/0'/25446";
 
 export default async function globalSetup() {
   mkdirp.sync(DIR);

--- a/packages/node/test/integration/install-virtual.spec.ts
+++ b/packages/node/test/integration/install-virtual.spec.ts
@@ -3,8 +3,8 @@ import { Wallet } from "ethers";
 import { One, Zero } from "ethers/constants";
 import {
   JsonRpcProvider,
-  TransactionRequest,
-  Provider
+  Provider,
+  TransactionRequest
 } from "ethers/providers";
 import { parseEther } from "ethers/utils";
 import { fromMnemonic } from "ethers/utils/hdnode";
@@ -22,11 +22,11 @@ import { CF_PATH } from "../global-setup.jest";
 import { LocalFirebaseServiceFactory } from "../services/firebase-server";
 
 import {
+  collateralizeChannel,
   confirmProposedVirtualAppInstanceOnNode,
   getApps,
   getMultisigCreationTransactionHash,
   getProposedAppInstances,
-  makeDepositRequest,
   makeInstallVirtualProposalRequest,
   makeInstallVirtualRequest,
   sleep
@@ -258,16 +258,6 @@ describe("Node method follows spec - proposeInstallVirtual", () => {
     }
   );
 });
-
-async function collateralizeChannel(
-  node1: Node,
-  node2: Node,
-  multisigAddress: string
-): Promise<void> {
-  const depositReq = makeDepositRequest(multisigAddress, One);
-  await node1.call(depositReq.type, depositReq);
-  await node2.call(depositReq.type, depositReq);
-}
 
 async function generateNewFundedMnemonics(
   fundedPrivateKey: string,

--- a/packages/node/test/integration/propose-install-virtual.spec.ts
+++ b/packages/node/test/integration/propose-install-virtual.spec.ts
@@ -1,4 +1,5 @@
 import { Node as NodeTypes } from "@counterfactual/types";
+import { One, Zero } from "ethers/constants";
 import { JsonRpcProvider } from "ethers/providers";
 import { v4 as generateUUID } from "uuid";
 
@@ -97,7 +98,10 @@ describe("Node method follows spec - proposeInstallVirtual", () => {
                 const intermediaries = [nodeB.publicIdentifier];
                 const installVirtualAppInstanceProposalRequest = makeInstallVirtualProposalRequest(
                   nodeC.publicIdentifier,
-                  intermediaries
+                  intermediaries,
+                  false,
+                  One,
+                  Zero
                 );
 
                 nodeC.on(
@@ -119,11 +123,13 @@ describe("Node method follows spec - proposeInstallVirtual", () => {
                     );
                     confirmProposedVirtualAppInstanceOnNode(
                       installVirtualAppInstanceProposalRequest.params,
-                      proposedAppInstanceB
+                      proposedAppInstanceB,
+                      true
                     );
                     confirmProposedVirtualAppInstanceOnNode(
                       installVirtualAppInstanceProposalRequest.params,
-                      proposedAppInstanceC
+                      proposedAppInstanceC,
+                      true
                     );
 
                     expect(proposedAppInstanceC.proposedByIdentifier).toEqual(
@@ -135,6 +141,10 @@ describe("Node method follows spec - proposeInstallVirtual", () => {
                     expect(proposedAppInstanceB.id).toEqual(
                       proposedAppInstanceC.id
                     );
+                    expect(proposedAppInstanceA.myDeposit).toEqual(One);
+                    expect(proposedAppInstanceA.peerDeposit).toEqual(Zero);
+                    expect(proposedAppInstanceC.myDeposit).toEqual(Zero);
+                    expect(proposedAppInstanceC.peerDeposit).toEqual(One);
                     done();
                   }
                 );

--- a/packages/node/test/integration/utils.ts
+++ b/packages/node/test/integration/utils.ts
@@ -424,3 +424,7 @@ export function makeTTTVirtualAppInstanceProposalReq(
     type: NodeTypes.MethodName.PROPOSE_INSTALL_VIRTUAL
   } as NodeTypes.MethodRequest;
 }
+
+export function sleep(timeInMilliseconds: number) {
+  return new Promise(resolve => setTimeout(resolve, timeInMilliseconds));
+}

--- a/packages/node/test/integration/utils.ts
+++ b/packages/node/test/integration/utils.ts
@@ -428,3 +428,13 @@ export function makeTTTVirtualAppInstanceProposalReq(
 export function sleep(timeInMilliseconds: number) {
   return new Promise(resolve => setTimeout(resolve, timeInMilliseconds));
 }
+
+export async function collateralizeChannel(
+  node1: Node,
+  node2: Node,
+  multisigAddress: string
+): Promise<void> {
+  const depositReq = makeDepositRequest(multisigAddress, One);
+  await node1.call(depositReq.type, depositReq);
+  await node2.call(depositReq.type, depositReq);
+}

--- a/packages/node/test/integration/utils.ts
+++ b/packages/node/test/integration/utils.ts
@@ -192,7 +192,9 @@ export function makeRejectInstallRequest(
 
 export function makeInstallProposalRequest(
   proposedToIdentifier: string,
-  nullInitialState: boolean = false
+  nullInitialState: boolean = false,
+  myDeposit: BigNumber = Zero,
+  peerDeposit: BigNumber = Zero
 ): NodeTypes.MethodRequest {
   let initialState;
 
@@ -206,6 +208,8 @@ export function makeInstallProposalRequest(
   const params: NodeTypes.ProposeInstallParams = {
     proposedToIdentifier,
     initialState,
+    myDeposit,
+    peerDeposit,
     appId: AddressZero,
     abiEncodings: {
       stateEncoding: "tuple(address foo, uint256 bar)",
@@ -214,8 +218,6 @@ export function makeInstallProposalRequest(
     asset: {
       assetType: AssetType.ETH
     } as BlockchainAsset,
-    myDeposit: Zero,
-    peerDeposit: Zero,
     timeout: One
   };
   return {
@@ -266,11 +268,15 @@ export function makeInstallVirtualRequest(
 export function makeInstallVirtualProposalRequest(
   proposedToIdentifier: string,
   intermediaries: string[],
-  nullInitialState: boolean = false
+  nullInitialState: boolean = false,
+  myDeposit: BigNumber = Zero,
+  peerDeposit: BigNumber = Zero
 ): NodeTypes.MethodRequest {
   const installProposalParams = makeInstallProposalRequest(
     proposedToIdentifier,
-    nullInitialState
+    nullInitialState,
+    myDeposit,
+    peerDeposit
   ).params as NodeTypes.ProposeInstallParams;
 
   const installVirtualParams: NodeTypes.ProposeInstallVirtualParams = {
@@ -290,7 +296,8 @@ export function makeInstallVirtualProposalRequest(
  */
 export function confirmProposedAppInstanceOnNode(
   methodParams: NodeTypes.MethodParams,
-  proposedAppInstanceInfo: AppInstanceInfo
+  proposedAppInstanceInfo: AppInstanceInfo,
+  nonInitiatingNode: boolean = false
 ) {
   const proposalParams = methodParams as NodeTypes.ProposeInstallParams;
   expect(proposalParams.abiEncodings).toEqual(
@@ -298,10 +305,19 @@ export function confirmProposedAppInstanceOnNode(
   );
   expect(proposalParams.appId).toEqual(proposedAppInstanceInfo.appId);
   expect(proposalParams.asset).toEqual(proposedAppInstanceInfo.asset);
-  expect(proposalParams.myDeposit).toEqual(proposedAppInstanceInfo.myDeposit);
-  expect(proposalParams.peerDeposit).toEqual(
-    proposedAppInstanceInfo.peerDeposit
-  );
+  if (nonInitiatingNode) {
+    expect(proposalParams.myDeposit).toEqual(
+      proposedAppInstanceInfo.peerDeposit
+    );
+    expect(proposalParams.peerDeposit).toEqual(
+      proposedAppInstanceInfo.myDeposit
+    );
+  } else {
+    expect(proposalParams.myDeposit).toEqual(proposedAppInstanceInfo.myDeposit);
+    expect(proposalParams.peerDeposit).toEqual(
+      proposedAppInstanceInfo.peerDeposit
+    );
+  }
   expect(proposalParams.timeout).toEqual(proposedAppInstanceInfo.timeout);
   // TODO: uncomment when getState is implemented
   // expect(proposalParams.initialState).toEqual(appInstanceInitialState);
@@ -309,9 +325,14 @@ export function confirmProposedAppInstanceOnNode(
 
 export function confirmProposedVirtualAppInstanceOnNode(
   methodParams: NodeTypes.MethodParams,
-  proposedAppInstance: AppInstanceInfo
+  proposedAppInstance: AppInstanceInfo,
+  nonInitiatingNode: boolean = false
 ) {
-  confirmProposedAppInstanceOnNode(methodParams, proposedAppInstance);
+  confirmProposedAppInstanceOnNode(
+    methodParams,
+    proposedAppInstance,
+    nonInitiatingNode
+  );
   const proposalParams = methodParams as NodeTypes.ProposeInstallVirtualParams;
   expect(proposalParams.intermediaries).toEqual(
     proposedAppInstance.intermediaries

--- a/packages/node/test/node-test-environment.jest.js
+++ b/packages/node/test/node-test-environment.jest.js
@@ -17,26 +17,27 @@ class NodeEnvironment extends NodeJSEnvironment {
 
   async setup() {
     await super.setup();
-    let addresses = readFileSync(path.join(DIR, "addresses"), "utf8");
-    if (!addresses) {
-      throw new Error("Contract addresses not found");
+    let accounts = readFileSync(path.join(DIR, "accounts"), "utf8");
+    if (!accounts) {
+      throw new Error("Accounts information not found");
     }
-    addresses = JSON.parse(addresses);
+    accounts = JSON.parse(accounts);
 
     const networkContext = {
       AppRegistry: AddressZero,
-      ETHBalanceRefundApp: addresses.ETHBalanceRefundApp,
+      ETHBalanceRefundApp: accounts.contractAddresses.ETHBalanceRefundApp,
       ETHBucket: AddressZero,
       MultiSend: AddressZero,
       NonceRegistry: AddressZero,
       StateChannelTransaction: AddressZero,
       ETHVirtualAppAgreement: AddressZero,
-      MinimumViableMultisig: addresses.MinimumViableMultisig,
-      ProxyFactory: addresses.ProxyFactory,
-      TicTacToe: addresses.TicTacToe
+      MinimumViableMultisig: accounts.contractAddresses.MinimumViableMultisig,
+      ProxyFactory: accounts.contractAddresses.ProxyFactory,
+      TicTacToe: accounts.contractAddresses.TicTacToe
     };
 
     this.global.networkContext = networkContext;
+    this.global.fundedPrivateKey = accounts.fundedPrivateKey;
     this.global.ganacheURL = `http://localhost:${process.env.GANACHE_PORT}`;
   }
 


### PR DESCRIPTION
### Description

There's a bug that's causing the Node to not account for deposits of differing amounts between two participants of a channel.

For example, with a channel A<->B that's funded with 2 ETH (1 ETH from each participant respectively), A initiating an installation of an app for `(A: 0.1 ETH, B: 0 ETH)` would incorrectly leave B's state as `(myDeposit: 0.1 ETH, peerDeposit: 0 ETH)` when it should obviously be `(myDeposit: 0 ETH, peerDeposit: 0.1 ETH)`