### PR TITLE
[node] Expose ETH free balance address

### DIFF
--- a/packages/high-roller-bot/package.json
+++ b/packages/high-roller-bot/package.json
@@ -29,7 +29,7 @@
     "url": "https://github.com/counterfactual/monorepo/issues"
   },
   "dependencies": {
-    "@counterfactual/node": "0.1.15",
+    "@counterfactual/node": "0.1.16",
     "@counterfactual/types": "0.0.9",
     "eventemitter3": "^3.1.0"
   },

--- a/packages/high-roller-bot/src/utils.ts
+++ b/packages/high-roller-bot/src/utils.ts
@@ -55,7 +55,7 @@ export async function deposit(
   amount: string,
   multisigAddress: string
 ) {
-  const myFreeBalanceAddress = node.zeroethAddress;
+  const myFreeBalanceAddress = node.ethFreeBalanceAddress;
 
   const preDepositBalances = await getFreeBalance(node, multisigAddress);
 

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@counterfactual/node",
-  "version": "0.1.15",
+  "version": "0.1.16",
   "main": "dist/index.js",
   "iife": "dist/index.iife.js",
   "types": "dist/src/index.d.ts",

--- a/packages/node/src/node.ts
+++ b/packages/node/src/node.ts
@@ -23,10 +23,7 @@ import {
   NodeMessage,
   NodeMessageWrappedProtocolMessage
 } from "./types";
-
-function timeout(ms) {
-  return new Promise(resolve => setTimeout(resolve, ms));
-}
+import { timeout } from "./utils";
 
 export interface NodeConfig {
   // The prefix for any keys used in the store by this Node depends on the
@@ -135,10 +132,9 @@ export class Node {
     return this.signer.neuter().extendedKey;
   }
 
-  /// Address used for ETH free balance and maybe some other things
   @Memoize()
-  get zeroethAddress(): string {
-    return fromExtendedKey(this.publicIdentifier).derivePath("0").address;
+  get ethFreeBalanceAddress(): string {
+    return getETHFreeBalanceAddress(this.publicIdentifier);
   }
 
   /**
@@ -386,6 +382,13 @@ export class Node {
       params: JSON.stringify(msg.params, Object.keys(msg.params).sort())
     });
   }
+}
+
+/**
+ * Address used for ETH free balance
+ */
+export function getETHFreeBalanceAddress(publicIdentifier: string) {
+  return fromExtendedKey(publicIdentifier).derivePath("0").address;
 }
 
 const isBrowser =

--- a/packages/node/src/utils.ts
+++ b/packages/node/src/utils.ts
@@ -83,3 +83,7 @@ export function getBalanceIncrement(
 ): BigNumber {
   return afterDeposit.sub(beforeDeposit);
 }
+
+export function timeout(ms: number) {
+  return new Promise(resolve => setTimeout(resolve, ms));
+}

--- a/packages/playground-server/package.json
+++ b/packages/playground-server/package.json
@@ -31,7 +31,7 @@
     "url": "https://github.com/counterfactual/monorepo/issues"
   },
   "dependencies": {
-    "@counterfactual/node": "0.1.15",
+    "@counterfactual/node": "0.1.16",
     "@counterfactual/types": "0.0.9",
     "@counterfactual/typescript-typings": "0.1.0",
     "@ebryn/jsonapi-ts": "0.1.17",

--- a/packages/playground/package.json
+++ b/packages/playground/package.json
@@ -13,7 +13,7 @@
     "test:watch": "stencil test --spec --e2e --watchAll"
   },
   "dependencies": {
-    "@counterfactual/node": "0.1.15",
+    "@counterfactual/node": "0.1.16",
     "@counterfactual/types": "0.0.9",
     "@stencil/core": "0.18.1-0",
     "@stencil/router": "0.3.3",

--- a/packages/tic-tac-toe-bot/package.json
+++ b/packages/tic-tac-toe-bot/package.json
@@ -31,7 +31,7 @@
   },
   "dependencies": {
     "@counterfactual/dapp-tic-tac-toe": "0.1.2",
-    "@counterfactual/node": "0.1.15",
+    "@counterfactual/node": "0.1.16",
     "@counterfactual/types": "^0.0.9",
     "eventemitter3": "^3.1.0"
   },

--- a/packages/tic-tac-toe-bot/src/utils.ts
+++ b/packages/tic-tac-toe-bot/src/utils.ts
@@ -55,7 +55,7 @@ export async function deposit(
   amount: string,
   multisigAddress: string
 ) {
-  const myFreeBalanceAddress = node.zeroethAddress;
+  const myFreeBalanceAddress = node.ethFreeBalanceAddress;
 
   const preDepositBalances = await getFreeBalance(node, multisigAddress);
 


### PR DESCRIPTION
### Description

Previously trying to calculate the ETH free balance address was too cumbersome:
```
fromExtendedKey(node.publicIdentifier).derivePath("0").address
```

This introduces a getter `ethFreeBalanceAddress` that retrieves the above computed address.