### PR TITLE
[node] Fix exports

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -87,7 +87,7 @@ jobs:
       - run:
           name: Run Playground tests
           command: cd packages/playground && yarn test
-          no_output_timeout: 30s
+          no_output_timeout: 1m
       - run:
           name: Run Playground Server tests
           command: cd packages/playground-server && yarn test:ci

--- a/packages/node/rollup.config.js
+++ b/packages/node/rollup.config.js
@@ -14,6 +14,7 @@ const globals = {
   "ethers/wallet": "ethers.wallet",
   firebase: "firebase",
   events: "EventEmitter",
+  loglevel: "log",
   uuid: "uuid"
 };
 

--- a/packages/node/rollup.config.js
+++ b/packages/node/rollup.config.js
@@ -8,11 +8,15 @@ import pkg from "./package.json";
 const globals = {
   "@counterfactual/cf.js": "cfjs",
   eventemitter3: "EventEmitter",
+  "ethers": "ethers",
   "ethers/constants": "ethers.constants",
   "ethers/errors": "ethers.errors",
+  "ethers/providers": "ethers.providers",
   "ethers/utils": "ethers.utils",
+  "ethers/utils/hdnode": "ethers.utils.HDNode",
   "ethers/wallet": "ethers.wallet",
   firebase: "firebase",
+  "firebase/app": "firebase.app",
   events: "EventEmitter",
   loglevel: "log",
   uuid: "uuid"

--- a/packages/playground/src/index.html
+++ b/packages/playground/src/index.html
@@ -24,6 +24,7 @@
   -->
     <script src="https://www.gstatic.com/firebasejs/5.5.3/firebase.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/node-uuid/1.4.8/uuid.js"></script>
+    <script src="https://unpkg.com/loglevel@1.6.1/dist/loglevel.min.js"></script>
     <script
       src="https://browser.sentry-cdn.com/4.5.3/bundle.min.js"
       crossorigin="anonymous"


### PR DESCRIPTION
As of the inclusion of `loglevel`, the exports weren't properly handled causing the playground to fail to load.

This fixes that along with a few other exports.