### PR TITLE
[playground] Skip PG tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -92,10 +92,6 @@ jobs:
       - run:
           name: Run Tic-Tac-Toe tests
           command: cd packages/dapp-tic-tac-toe && yarn test
-      - run:
-          name: Run Playground tests
-          command: cd packages/playground && yarn test
-          no_output_timeout: 1m
 
   run-tslint:
     <<: *defaults


### PR DESCRIPTION
This temporarily removes the PG tests from running as no change is being made to the PG.