### PR TITLE
[playground] Re-enable PG tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -92,6 +92,9 @@ jobs:
       - run:
           name: Run Tic-Tac-Toe tests
           command: cd packages/dapp-tic-tac-toe && yarn test
+      - run:
+          name: Run Playground tests
+          command: cd packages/playground && yarn test
 
   run-tslint:
     <<: *defaults


### PR DESCRIPTION
This is a placeholder to revert https://github.com/counterfactual/monorepo/pull/1426 when Playground starts being modified again