### PR TITLE
[types] use more accurate types

### DIFF
--- a/packages/types/src/data-types.ts
+++ b/packages/types/src/data-types.ts
@@ -12,8 +12,8 @@ export type AppInstanceInfo = {
   myDeposit: BigNumber;
   peerDeposit: BigNumber;
   timeout: BigNumber;
-  proposedByIdentifier: Address;
-  proposedToIdentifier: Address;
+  proposedByIdentifier: string; // xpub
+  proposedToIdentifier: string; // xpub
   intermediaries?: Address[];
 };
 


### PR DESCRIPTION
The `proposed{By,To}Identifier` fields of `AppInstanceInfo` contain node public identifiers, not addresses