### PR TITLE
[contracts] Deploy new contracts

### DIFF
--- a/packages/apps/package.json
+++ b/packages/apps/package.json
@@ -29,7 +29,7 @@
     "ethlint": "1.2.4",
     "mocha": "6.1.4",
     "solc": "0.5.8",
-    "truffle": "5.0.12",
+    "truffle": "5.0.10",
     "truffle-deploy-registry": "0.5.1",
     "truffle-hdwallet-provider": "1.0.9",
     "ts-mocha": "6.0.0",

--- a/packages/contracts/networks/3.json
+++ b/packages/contracts/networks/3.json
@@ -63,5 +63,15 @@
     "contractName": "ETHVirtualAppAgreement",
     "address": "0xD72E893bb1F92504B8B0530223746da2BDfA9Cf3",
     "transactionHash": "0x7968b26641f18966fb4ce282922231ee3a024516fa50e686ae066edb3b85e841"
+  },
+  {
+    "contractName": "TwoPartyEthAsLump",
+    "address": "0x7dA69562B798815d7EBC44518d15fd1e62Ae49Ec",
+    "transactionHash": "0xb99748dc3b599714af0131a25e1466098a8ef3f03bb714c581a089b5c6be8961"
+  },
+  {
+    "contractName": "TwoPartyVirtualEthAsLump",
+    "address": "0x4841352e40654f7D7750b6de66A2A011bfA2ca23",
+    "transactionHash": "0x64d0701afbe25600924d373f8fc0eb14f52b9f116172fafb476313c99e4384ae"
   }
 ]

--- a/packages/contracts/networks/4.json
+++ b/packages/contracts/networks/4.json
@@ -60,8 +60,13 @@
     "transactionHash": "0x9c0c624f2dcff4825e77e9bce1f3b164d4d739e7604701921fdf6b306e08a586"
   },
   {
-    "contractName": "ETHVirtualAppAgreement",
-    "address": "0xdb2Ed0d73d0E6b8f431c999EC97D1AcFf5A0Ee2E",
-    "transactionHash": "0x01d7744c5108118cb2bcac0e06ce17961c191707d47ff793c24453f2c27b9b1d"
+    "contractName": "TwoPartyEthAsLump",
+    "address": "0x7B0A7Da6654bF0F091Eb9Fa1b42A6489FEB71deA",
+    "transactionHash": "0x0ffb2f20189f31891e7ae8c297fca85e7d95d221c603390df24b8daad7daaff1"
+  },
+  {
+    "contractName": "TwoPartyVirtualEthAsLump",
+    "address": "0x903217387B06a84F4dD0bEA565Ad8765Fc7cAA58",
+    "transactionHash": "0xea9799ac626b88b12855220f58e1c702b936eff09bdc0b3895ab05943648a7d2"
   }
 ]

--- a/packages/contracts/networks/42.json
+++ b/packages/contracts/networks/42.json
@@ -60,8 +60,13 @@
     "transactionHash": "0x9c234897542c6d9687140a7431aa2e64b0be75bc87933d0e7cb88de4b315d59e"
   },
   {
-    "contractName": "ETHVirtualAppAgreement",
-    "address": "0x74FE8597D6e1547a219B69dA45e3ADADbC53a8c0",
-    "transactionHash": "0x17a88814aaebeb3e3938c1d04b4be4de102c7445b9127075a2cd4303d4f8c3a3"
+    "contractName": "TwoPartyEthAsLump",
+    "address": "0x780b6Bc1f2B887c5d70fBFf8911AE2922E1942FC",
+    "transactionHash": "0x66e37c26bbe4c6227e9952bd396c840cf3f94afd9e49ddaf79c50f22909c26d3"
+  },
+  {
+    "contractName": "TwoPartyVirtualEthAsLump",
+    "address": "0x5476b5941F6161831EEA096Ff7db9926bec5c9FB",
+    "transactionHash": "0xb13c0783d2c40686c201bec47be42015a36dc9e7c31641fa5b4f9a21031496cb"
   }
 ]

--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -42,7 +42,7 @@
     "shx": "0.3.2",
     "solc": "0.5.8",
     "solidity-coverage": "0.5.11",
-    "truffle": "5.0.12",
+    "truffle": "5.0.10",
     "truffle-deploy-registry": "0.5.1",
     "truffle-hdwallet-provider": "1.0.9",
     "ts-mocha": "6.0.0",

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -40,7 +40,7 @@
     "rollup-plugin-json": "4.0.0",
     "rollup-plugin-node-resolve": "5.0.0",
     "rollup-plugin-typescript2": "0.21.0",
-    "truffle": "5.0.12",
+    "truffle": "5.0.10",
     "ts-jest": "24.0.2",
     "ts-mockito": "2.3.1",
     "tslint": "5.16.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -17610,6 +17610,16 @@ truffle-interface-adapter@^0.1.5:
     bn.js "^4.11.8"
     web3 "1.0.0-beta.37"
 
+truffle@5.0.10:
+  version "5.0.10"
+  resolved "https://registry.npmjs.org/truffle/-/truffle-5.0.10.tgz#f773522becbed0f66b372c6a9a1f36d233337e1e"
+  integrity sha512-wVp7ruznIm1iX7fTHZwjKZCaOkkQcTR1eWOCi2yTQ85wg1iQITpV7NLDpVandaNcz5Z0e8EdOrH9lFKLgxiAxQ==
+  dependencies:
+    app-module-path "^2.2.0"
+    mocha "^4.1.0"
+    original-require "1.0.1"
+    solc "0.5.0"
+
 truffle@5.0.12:
   version "5.0.12"
   resolved "https://registry.yarnpkg.com/truffle/-/truffle-5.0.12.tgz#05ab7d2561a3ee4fd5e026dcc4b91b8f3c6e3795"

--- a/yarn.lock
+++ b/yarn.lock
@@ -17620,16 +17620,6 @@ truffle@5.0.10:
     original-require "1.0.1"
     solc "0.5.0"
 
-truffle@5.0.12:
-  version "5.0.12"
-  resolved "https://registry.yarnpkg.com/truffle/-/truffle-5.0.12.tgz#05ab7d2561a3ee4fd5e026dcc4b91b8f3c6e3795"
-  integrity sha512-dqnDmtTGNcnL29PHQwPE/CVmFFeGLuTFeb4TS3VY/vbASefu118IKXcadOWzkCPPwktv/njwylHSPhwoS00F2A==
-  dependencies:
-    app-module-path "^2.2.0"
-    mocha "^4.1.0"
-    original-require "1.0.1"
-    solc "0.5.0"
-
 ts-jest@24.0.2:
   version "24.0.2"
   resolved "https://registry.yarnpkg.com/ts-jest/-/ts-jest-24.0.2.tgz#8dde6cece97c31c03e80e474c749753ffd27194d"


### PR DESCRIPTION
A couple of contracts (`TwoPartyEthAsLump` and `TwoPartyVirtualEthAsLump`) weren't deployed as part of the [Interpreters PR](github.com/counterfactual/monorepo/pull/1263).

This deploys them and reverts truffle back to a version that makes migrations functional.