### PR TITLE
[contracts] delete type-specialized staticcall wrappers

### DIFF
--- a/packages/contracts/contracts/libs/LibStaticCall.sol
+++ b/packages/contracts/contracts/libs/LibStaticCall.sol
@@ -28,45 +28,6 @@ library LibStaticCall {
     }
   }
 
-  /// @notice Execute a STATICCALL expecting a boolean return type
-  /// @param to The address the call is being made to
-  /// @param data The calldata being sent to the contract being static called
-  /// @return The return data of the static call encoded as a boolean
-  function staticcall_as_bool(address to, bytes memory data)
-    public
-    view
-    returns (bool)
-  {
-    executeStaticCall(to, data);
-    assembly { return(mload(0x40), returndatasize) }
-  }
-
-  /// @notice Execute a STATICCALL expecting a uint256 return type
-  /// @param to The address the call is being made to
-  /// @param data The calldata being sent to the contract being static called
-  /// @return The return data of the static call encoded as a uint256
-  function staticcall_as_uint256(address to, bytes memory data)
-    public
-    view
-    returns (uint256)
-  {
-    executeStaticCall(to, data);
-    assembly { return(mload(0x40), returndatasize) }
-  }
-
-  /// @notice Execute a STATICCALL expecting a address return type
-  /// @param to The address the call is being made to
-  /// @param data The calldata being sent to the contract being static called
-  /// @return The return data of the static call encoded as a address
-  function staticcall_as_address(address to, bytes memory data)
-    public
-    view
-    returns (address)
-  {
-    executeStaticCall(to, data);
-    assembly { return(mload(0x40), returndatasize) }
-  }
-
   /// @notice Execute a STATICCALL expecting a bytes return type
   /// @param to The address the call is being made to
   /// @param data The calldata being sent to the contract being static called

--- a/packages/contracts/contracts/test-fixtures/TestCaller.sol
+++ b/packages/contracts/contracts/test-fixtures/TestCaller.sol
@@ -20,17 +20,4 @@ contract TestCaller {
     return to.staticcall_as_bytes(data);
   }
 
-  function execStaticCallBool(
-    address to,
-    bytes4 selector,
-    bytes memory params
-  )
-    public
-    view
-    returns (bool)
-  {
-    bytes memory data = abi.encodePacked(selector, params);
-    return to.staticcall_as_bool(data);
-  }
-
 }

--- a/packages/contracts/test/static-call.spec.ts
+++ b/packages/contracts/test/static-call.spec.ts
@@ -44,24 +44,6 @@ describe("StaticCall", () => {
       expect(ret).to.eq(helloWorldString);
     });
 
-    it("retrieves true bool from external pure function", async () => {
-      const ret = await testCaller.functions.execStaticCallBool(
-        echo.address,
-        echo.interface.functions.returnArg.sighash,
-        defaultAbiCoder.encode(["bool"], [true])
-      );
-      expect(ret).to.be.true;
-    });
-
-    it("retrieves false bool from external pure function", async () => {
-      const ret = await testCaller.functions.execStaticCallBool(
-        echo.address,
-        echo.interface.functions.returnArg.sighash,
-        defaultAbiCoder.encode(["bool"], [false])
-      );
-      expect(ret).to.be.false;
-    });
-
     it("retrieves argument from external pure function", async () => {
       const ret = await testCaller.functions.execStaticCall(
         echo.address,


### PR DESCRIPTION
These have no forseeable uses AFAICT. The `staticcall_as_bytes` wrapper could still be used for calling `resolve`.