### PR TITLE
[monorepo] rename ledger -> direct

### DIFF
--- a/packages/contracts/contracts/TwoPartyVirtualEthAsLump.sol
+++ b/packages/contracts/contracts/TwoPartyVirtualEthAsLump.sol
@@ -8,7 +8,7 @@ import "./NonceRegistry.sol";
 /// @title TwoPartyVirtualEthAsLump
 /// @notice Commitment target to support "virtual apps", i.e., apps which have
 /// ETH committed to them via intermediary lock-up instead of having ETH directly
-/// committed in a ledger channel.
+/// committed in a direct channel.
 /// The `target` contract must return via resolution the outcome of the app,
 /// and the resolve function must be TwoPartyOutcome type.
 /// We do not use the interpreter mechanism in StateChannelTransaction.sol

--- a/packages/node/src/machine/virtual-app-key.ts
+++ b/packages/node/src/machine/virtual-app-key.ts
@@ -6,7 +6,7 @@ import { defaultAbiCoder, keccak256 } from "ethers/utils";
 /// Note that despite the name, currently these channels simply contain virtual
 /// app target instances and do not support full functionality that might be
 /// expected of a "virtual channel" such as the ability to convert it to a
-/// ledger channel, or to install apps without the intermediary's involvement.
+/// direct channel, or to install apps without the intermediary's involvement.
 export function virtualChannelKey(users: string[], intermediary: string) {
   if (users.length !== 2) {
     throw Error("virtualChannelKey can only calculate with 2 users");

--- a/packages/specs/source/protocols/install-virtual-app.md
+++ b/packages/specs/source/protocols/install-virtual-app.md
@@ -4,7 +4,7 @@ This is the Install Virtual App Protocol.
 
 ## Roles
 
-Three users run the protocol. They are designated as `initiating`, `responding`, and `intermediary`. The first two parties are the users wishing to interact together in a virtual app, who do not necessarily have a ledger channel between them. It is required that `initiating` and `intermediary` have a ledger channel together, and that `responding` and `intermediary` have a ledger channel together.
+Three users run the protocol. They are designated as `initiating`, `responding`, and `intermediary`. The first two parties are the users wishing to interact together in a virtual app, who do not necessarily have a direct channel between them. It is required that `initiating` and `intermediary` have a direct channel together, and that `responding` and `intermediary` have a direct channel together.
 
 ## The `InstallVirtualAppParams` type
 


### PR DESCRIPTION
From the state channels standardization workshop, it seems to me that "direct channel" is more unambiguous than "ledger channel".