### PR TITLE
[node] only pass protocolExecutionID

### DIFF
--- a/packages/node/src/protocol/install-virtual-app.ts
+++ b/packages/node/src/protocol/install-virtual-app.ts
@@ -119,7 +119,7 @@ export const INSTALL_VIRTUAL_APP_PROTOCOL: ProtocolExecutionFlow = {
     yield [
       Opcode.IO_SEND,
       {
-        ...context.message,
+        protocolExecutionID: context.message.protocolExecutionID,
         seq: -1,
         toXpub: respondingXpub,
         signature: s6
@@ -130,7 +130,7 @@ export const INSTALL_VIRTUAL_APP_PROTOCOL: ProtocolExecutionFlow = {
     yield [
       Opcode.IO_SEND,
       {
-        ...context.message,
+        protocolExecutionID: context.message.protocolExecutionID,
         seq: -1,
         toXpub: initiatingXpub,
         signature: s6,
@@ -173,7 +173,7 @@ export const INSTALL_VIRTUAL_APP_PROTOCOL: ProtocolExecutionFlow = {
     const m4 = yield [
       Opcode.IO_SEND_AND_WAIT,
       {
-        ...context.message,
+        protocolExecutionID: context.message.protocolExecutionID,
         seq: -1,
         toXpub: intermediaryXpub,
         signature: s4,

--- a/packages/node/src/protocol/take-action.ts
+++ b/packages/node/src/protocol/take-action.ts
@@ -78,7 +78,7 @@ export const TAKE_ACTION_PROTOCOL: ProtocolExecutionFlow = {
     yield [
       Opcode.IO_SEND,
       {
-        ...context.message,
+        protocolExecutionID: context.message.protocolExecutionID,
         toXpub: initiatingXpub,
         seq: -1,
         signature: mySig

--- a/packages/node/src/protocol/uninstall-virtual-app.ts
+++ b/packages/node/src/protocol/uninstall-virtual-app.ts
@@ -69,7 +69,7 @@ export const UNINSTALL_VIRTUAL_APP_PROTOCOL: ProtocolExecutionFlow = {
     const { signature: s6 } = yield [
       Opcode.IO_SEND_AND_WAIT,
       {
-        ...context.message,
+        protocolExecutionID: context.message.protocolExecutionID,
         seq: -1,
         toXpub: intermediaryXpub,
         signature: s4
@@ -118,7 +118,7 @@ export const UNINSTALL_VIRTUAL_APP_PROTOCOL: ProtocolExecutionFlow = {
       Opcode.IO_SEND_AND_WAIT,
       {
         // m4
-        ...context.message,
+        protocolExecutionID: context.message.protocolExecutionID,
         seq: -1,
         toXpub: initiatingXpub,
         signature: s3,
@@ -141,7 +141,7 @@ export const UNINSTALL_VIRTUAL_APP_PROTOCOL: ProtocolExecutionFlow = {
     yield [
       Opcode.IO_SEND,
       {
-        ...context.message,
+        protocolExecutionID: context.message.protocolExecutionID,
         seq: -1,
         toXpub: initiatingXpub,
         signature: s5
@@ -160,7 +160,7 @@ export const UNINSTALL_VIRTUAL_APP_PROTOCOL: ProtocolExecutionFlow = {
       Opcode.IO_SEND_AND_WAIT,
       {
         // m7
-        ...context.message,
+        protocolExecutionID: context.message.protocolExecutionID,
         seq: -1,
         toXpub: respondingXpub,
         signature: s6
@@ -196,7 +196,7 @@ export const UNINSTALL_VIRTUAL_APP_PROTOCOL: ProtocolExecutionFlow = {
       Opcode.IO_SEND_AND_WAIT,
       {
         // m3
-        ...context.message,
+        protocolExecutionID: context.message.protocolExecutionID,
         seq: -1,
         toXpub: intermediaryXpub,
         signature: s3
@@ -217,7 +217,7 @@ export const UNINSTALL_VIRTUAL_APP_PROTOCOL: ProtocolExecutionFlow = {
     yield [
       Opcode.IO_SEND,
       {
-        ...context.message,
+        protocolExecutionID: context.message.protocolExecutionID,
         seq: -1,
         toXpub: intermediaryXpub,
         signature: s7

--- a/packages/node/src/protocol/withdraw-eth.ts
+++ b/packages/node/src/protocol/withdraw-eth.ts
@@ -75,7 +75,7 @@ export const WITHDRAW_ETH_PROTOCOL: ProtocolExecutionFlow = {
     yield [
       Opcode.IO_SEND,
       {
-        ...context.message,
+        protocolExecutionID: context.message.protocolExecutionID,
         toXpub: respondingXpub,
         signature: s5,
         seq: -1
@@ -133,7 +133,7 @@ export const WITHDRAW_ETH_PROTOCOL: ProtocolExecutionFlow = {
     const m3 = yield [
       Opcode.IO_SEND_AND_WAIT,
       {
-        ...context.message,
+        protocolExecutionID: context.message.protocolExecutionID,
         toXpub: initiatingXpub,
         signature: s2,
         signature2: s4,


### PR DESCRIPTION
We should be extremely explicit about what goes into machine-level protocol messages; these `IO_SENDS` only need to pass and not `params`