### PR TITLE
[repo] Add typescript references for types package

### DIFF
--- a/packages/cf.js/package.json
+++ b/packages/cf.js/package.json
@@ -11,7 +11,7 @@
   "repository": "https://github.com/counterfactual/monorepo/tree/master/packages/cf.js",
   "license": "MIT",
   "scripts": {
-    "build": "tsc -b && rollup -c",
+    "build": "tsc -b . && rollup -c",
     "lint": "tslint -c tslint.json -p tsconfig.json",
     "lint:fix": "yarn lint --fix",
     "test": "jest --detectOpenHandles",

--- a/packages/cf.js/tsconfig.json
+++ b/packages/cf.js/tsconfig.json
@@ -6,5 +6,8 @@
     "outDir": "dist/",
     "types": ["jest"]
   },
+  "references": [
+    { "path": "../types" }
+  ],
   "include": ["src", "test"]
 }

--- a/packages/dapp-high-roller/tsconfig.json
+++ b/packages/dapp-high-roller/tsconfig.json
@@ -12,6 +12,9 @@
     // @types/mocha has a duplicate conflict, this is the suggested temp fix.
     "skipLibCheck": true,
   },
+  "references": [
+    { "path": "../types" }
+  ],
   "include": [
     "src"
   ]

--- a/packages/high-roller-bot/scripts/postinstall.sh
+++ b/packages/high-roller-bot/scripts/postinstall.sh
@@ -4,5 +4,5 @@ set -e
 
 if [ ! -z "${IS_HEROKU_ENV}" ]; then
     echo "📟  Detected Heroku. Transpiling Typescript into JS for Node.JS to run on server."
-    tsc -p tsconfig.heroku.json &> /dev/null || :
+    tsc -b tsconfig.heroku.json &> /dev/null || :
 fi

--- a/packages/high-roller-bot/tsconfig.json
+++ b/packages/high-roller-bot/tsconfig.json
@@ -6,5 +6,8 @@
       "../../node_modules/@types",
       "../../node_modules/@counterfactual/typescript-typings/types"
     ]
-  }
+  },
+  "references": [
+    { "path": "../types" }
+  ]
 }

--- a/packages/node-provider/package.json
+++ b/packages/node-provider/package.json
@@ -9,8 +9,8 @@
   ],
   "license": "MIT",
   "scripts": {
-    "build": "tsc -p tsconfig.json && rollup -c",
-    "test": "tsc -b && jest --runInBand --detectOpenHandles --bail --forceExit",
+    "build": "tsc -b . && rollup -c",
+    "test": "tsc -b . && jest --runInBand --detectOpenHandles --bail --forceExit",
     "test-debug": "node --inspect-brk jest --runInBand",
     "lint:fix": "tslint -c tslint.json -p . --fix",
     "lint": "tslint -c tslint.json -p .",

--- a/packages/node-provider/tsconfig.json
+++ b/packages/node-provider/tsconfig.json
@@ -5,6 +5,9 @@
     "noImplicitAny": true,
     "types": ["jest", "node"]
   },
+  "references": [
+    { "path": "../types" }
+  ],
   "include": ["src", "test"],
   "exclude": ["dist"]
 }

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -6,8 +6,8 @@
   "types": "dist/src/index.d.ts",
   "license": "MIT",
   "scripts": {
-    "build": "tsc -p . && rollup -c",
-    "build:watch": "tsc -p . && rollup -c -w",
+    "build": "tsc -b . && rollup -c",
+    "build:watch": "tsc -b . && rollup -c -w",
     "test": "jest --setupFiles dotenv-extended/config --runInBand --bail --forceExit",
     "test:coverage": "jest --runInBand --detectOpenHandles --bail --coverage",
     "lint:fix": "tslint -c tslint.json -p . --fix",

--- a/packages/node/tsconfig.json
+++ b/packages/node/tsconfig.json
@@ -11,5 +11,8 @@
     ],
     "types": ["jest"]
   },
+  "references": [
+    { "path": "../types" }
+  ],
   "include": ["src", "test"]
 }

--- a/packages/playground-server/tsconfig.json
+++ b/packages/playground-server/tsconfig.json
@@ -9,5 +9,8 @@
       "../../node_modules/@counterfactual/typescript-typings/types"
     ],
     "strictPropertyInitialization": false
-  }
+  },
+  "references": [
+    { "path": "../types" }
+  ],
 }

--- a/packages/playground/tsconfig.json
+++ b/packages/playground/tsconfig.json
@@ -18,6 +18,9 @@
     ],
     "types": ["jest", "ethers"]
   },
+  "references": [
+    { "path": "../types" }
+  ],
   "include": ["src"],
   "exclude": ["__mocks__", "src/**/*.spec.ts", "src/**/*.e2e.ts"]
 }

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -4,7 +4,7 @@
   "description": "TypeScript typings for common Counterfactual types",
   "main": "dist/index.js",
   "module": "dist/index.esm.js",
-  "types": "dist/index.d.ts",
+  "types": "dist/src/index.d.ts",
   "iife": "dist/index-iife.js",
   "license": "MIT",
   "scripts": {

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -8,7 +8,7 @@
   "iife": "dist/index-iife.js",
   "license": "MIT",
   "scripts": {
-    "build": "tsc -p . && rollup -c"
+    "build": "tsc -b . && rollup -c"
   },
   "devDependencies": {
     "ethers": "4.0.27",

--- a/packages/types/tsconfig.json
+++ b/packages/types/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
+    "composite": true,
     "outDir": "dist"
   },
   "include": ["src/*"]

--- a/packages/types/tsconfig.json
+++ b/packages/types/tsconfig.json
@@ -4,5 +4,5 @@
     "composite": true,
     "outDir": "dist"
   },
-  "include": ["src/*"]
+  "include": ["src/*.ts"]
 }


### PR DESCRIPTION
1. Uses "build mode" in replacement of "project mode" everywhere (i.e., uses `-b`)
2. Changes `types` to use the `composite` flag
3. Replaces `tsconfig.json` with `.` when that is implicit