### PR TITLE
Rename dispute to challenge everywhere

### DIFF
--- a/packages/contracts/contracts/libs/LibStateChannelApp.sol
+++ b/packages/contracts/contracts/libs/LibStateChannelApp.sol
@@ -9,7 +9,7 @@ contract LibStateChannelApp {
   // The mode that the App is currently in from POV of the blockchain
   enum AppStatus {
     ON,
-    DISPUTE,
+    IN_CHALLENGE,
     OFF
   }
 
@@ -29,8 +29,8 @@ contract LibStateChannelApp {
     AppStatus status;
     address latestSubmitter;
     bytes32 appStateHash;
-    uint256 disputeCounter;
-    uint256 disputeNonce;
+    uint256 challengeCounter;
+    uint256 challengeNonce;
     uint256 finalizesAt;
     uint256 nonce;
   }

--- a/packages/contracts/contracts/mixins/MAppRegistryCore.sol
+++ b/packages/contracts/contracts/mixins/MAppRegistryCore.sol
@@ -61,7 +61,7 @@ contract MAppRegistryCore {
   /// @param previousState The hash of a state this action is being taken on
   /// @param action The ABI encoded version of the action being taken
   /// @param setStateNonce The nonce of the state this action is being taken on
-  /// @param disputeNonce A nonce corresponding to how many actions have been taken on the
+  /// @param challengeNonce A nonce corresponding to how many actions have been taken on the
   ///                     state since a new state has been unanimously agreed by signing keys.
   /// @return A bytes32 hash of the arguments
   function computeActionHash(
@@ -69,7 +69,7 @@ contract MAppRegistryCore {
     bytes32 previousState,
     bytes memory action,
     uint256 setStateNonce,
-    uint256 disputeNonce
+    uint256 challengeNonce
   )
     internal
     pure
@@ -82,7 +82,7 @@ contract MAppRegistryCore {
         previousState,
         action,
         setStateNonce,
-        disputeNonce
+        challengeNonce
       )
     );
   }

--- a/packages/contracts/contracts/mixins/MixinAppRegistryCore.sol
+++ b/packages/contracts/contracts/mixins/MixinAppRegistryCore.sol
@@ -33,7 +33,7 @@ contract MixinAppRegistryCore is MAppRegistryCore {
     return (
       appChallenges[identityHash].status == LibStateChannelApp.AppStatus.OFF ||
       (
-        appChallenges[identityHash].status == LibStateChannelApp.AppStatus.DISPUTE &&
+        appChallenges[identityHash].status == LibStateChannelApp.AppStatus.IN_CHALLENGE &&
         appChallenges[identityHash].finalizesAt <= block.number
       )
     );

--- a/packages/contracts/contracts/mixins/MixinCancelChallenge.sol
+++ b/packages/contracts/contracts/mixins/MixinCancelChallenge.sol
@@ -14,11 +14,11 @@ contract MixinCancelChallenge is
   MAppRegistryCore
 {
 
-  /// @notice Unanimously agree to cancel a dispute
+  /// @notice Unanimously agree to cancel a challenge
   /// @param appIdentity an AppIdentity object pointing to the app being cancelled
-  /// @param signatures Signatures by all signing keys of the currently latest disputed
-  /// state; an indication of agreement of this state and valid to cancel a dispute
-  /// @dev Note this function is only callable when the state channel is in a DISPUTE state
+  /// @param signatures Signatures by all signing keys of the currently latest challenged
+  /// state; an indication of agreement of this state and valid to cancel a challenge
+  /// @dev Note this function is only callable when the state channel is in a IN_CHALLENGE state
   function cancelChallenge(
     AppIdentity memory appIdentity,
     bytes memory signatures
@@ -33,8 +33,8 @@ contract MixinCancelChallenge is
     AppChallenge storage challenge = appChallenges[identityHash];
 
     require(
-      challenge.status == AppStatus.DISPUTE && challenge.finalizesAt >= block.number,
-      "cancelChallenge called on app not in DISPUTE state"
+      challenge.status == AppStatus.IN_CHALLENGE && challenge.finalizesAt >= block.number,
+      "cancelChallenge called on app not in IN_CHALLENGE state"
     );
 
     bytes32 stateHash = computeAppChallengeHash(
@@ -51,7 +51,7 @@ contract MixinCancelChallenge is
       );
     }
 
-    challenge.disputeNonce = 0;
+    challenge.challengeNonce = 0;
     challenge.finalizesAt = 0;
     challenge.status = AppStatus.ON;
     challenge.latestSubmitter = msg.sender;

--- a/packages/contracts/contracts/mixins/MixinRespondToChallenge.sol
+++ b/packages/contracts/contracts/mixins/MixinRespondToChallenge.sol
@@ -16,7 +16,7 @@ contract MixinRespondToChallenge is
   MAppCaller
 {
 
-  /// @notice Respond to a dispute with a valid action
+  /// @notice Respond to a challenge with a valid action
   /// @param appIdentity an AppIdentity object pointing to the app for which there is a challenge to progress
   /// @param appState The ABI encoded latest signed application state
   /// @param action The ABI encoded action the submitter wishes to take
@@ -24,7 +24,7 @@ contract MixinRespondToChallenge is
   /// signing key for which it is their turn to take the submitted `action`
   /// @param claimFinal If set, the caller claims that the action progresses the state
   /// to a terminal / finalized state
-  /// @dev This function is only callable when the state channel is in a DISPUTE state
+  /// @dev This function is only callable when the state channel is in a IN_CHALLENGE state
   function respondToChallenge(
     AppIdentity memory appIdentity,
     bytes memory appState,
@@ -40,8 +40,8 @@ contract MixinRespondToChallenge is
     AppChallenge storage challenge = appChallenges[identityHash];
 
     require(
-      challenge.status == AppStatus.DISPUTE && challenge.finalizesAt >= block.number,
-      "respondToChallenge called on app not in DISPUTE state"
+      challenge.status == AppStatus.IN_CHALLENGE && challenge.finalizesAt >= block.number,
+      "respondToChallenge called on app not in IN_CHALLENGE state"
     );
 
     require(
@@ -72,7 +72,7 @@ contract MixinRespondToChallenge is
     );
 
     challenge.appStateHash = keccak256(newAppState);
-    challenge.disputeNonce += 1;
+    challenge.challengeNonce += 1;
     challenge.latestSubmitter = msg.sender;
 
     if (claimFinal) {
@@ -83,7 +83,7 @@ contract MixinRespondToChallenge is
       challenge.finalizesAt = block.number;
       challenge.status = AppStatus.OFF;
     } else {
-      challenge.status = AppStatus.DISPUTE;
+      challenge.status = AppStatus.IN_CHALLENGE;
       challenge.finalizesAt = block.number + appIdentity.defaultTimeout;
     }
 

--- a/packages/contracts/contracts/mixins/MixinSetOutcome.sol
+++ b/packages/contracts/contracts/mixins/MixinSetOutcome.sol
@@ -29,8 +29,8 @@ contract MixinSetOutcome is
 
     require(
       app.status == AppStatus.OFF ||
-      (app.status == AppStatus.DISPUTE && block.number > app.finalizesAt),
-      "setOutcome called on an app either still ON or in DISPUTE"
+      (app.status == AppStatus.IN_CHALLENGE && block.number > app.finalizesAt),
+      "setOutcome called on an app either still ON or in IN_CHALLENGE"
     );
 
     require(

--- a/packages/contracts/contracts/mixins/MixinSetState.sol
+++ b/packages/contracts/contracts/mixins/MixinSetState.sol
@@ -42,7 +42,7 @@ contract MixinSetState is
 
     require(
       challenge.status == AppStatus.ON ||
-      (challenge.status == AppStatus.DISPUTE && challenge.finalizesAt >= block.number),
+      (challenge.status == AppStatus.IN_CHALLENGE && challenge.finalizesAt >= block.number),
       "setState was called on an app that has already been finalized"
     );
 
@@ -62,12 +62,12 @@ contract MixinSetState is
       "Tried to call setState with an outdated nonce version"
     );
 
-    challenge.status = req.timeout > 0 ? AppStatus.DISPUTE : AppStatus.OFF;
+    challenge.status = req.timeout > 0 ? AppStatus.IN_CHALLENGE : AppStatus.OFF;
     challenge.appStateHash = req.appStateHash;
     challenge.nonce = req.nonce;
     challenge.finalizesAt = block.number + req.timeout;
-    challenge.disputeNonce = 0;
-    challenge.disputeCounter += 1;
+    challenge.challengeNonce = 0;
+    challenge.challengeCounter += 1;
     challenge.latestSubmitter = msg.sender;
   }
 

--- a/packages/contracts/contracts/mixins/MixinSetStateWithAction.sol
+++ b/packages/contracts/contracts/mixins/MixinSetStateWithAction.sol
@@ -31,7 +31,7 @@ contract MixinSetStateWithAction is
     bool checkForTerminal;
   }
 
-  /// @notice Create a dispute regarding the latest signed state and immediately after,
+  /// @notice Create a challenge regarding the latest signed state and immediately after,
   /// performs a unilateral action to update it.
   /// @param appIdentity An AppIdentity pointing to the app having its challenge progressed
   /// @param req A struct with the signed state update in it
@@ -55,7 +55,7 @@ contract MixinSetStateWithAction is
 
     require(
       challenge.status == AppStatus.ON ||
-      (challenge.status == AppStatus.DISPUTE && challenge.finalizesAt >= block.number),
+      (challenge.status == AppStatus.IN_CHALLENGE && challenge.finalizesAt >= block.number),
       "setStateWithAction was called on an app that has already been finalized"
     );
 
@@ -68,7 +68,7 @@ contract MixinSetStateWithAction is
       correctKeySignedTheAction(
         appIdentity.appDefinition,
         appIdentity.signingKeys,
-        challenge.disputeNonce,
+        challenge.challengeNonce,
         req,
         action
       ),
@@ -90,13 +90,13 @@ contract MixinSetStateWithAction is
       challenge.status = AppStatus.OFF;
     } else {
       challenge.finalizesAt = block.number + req.timeout;
-      challenge.status = AppStatus.DISPUTE;
+      challenge.status = AppStatus.IN_CHALLENGE;
     }
 
     challenge.appStateHash = keccak256(newState);
     challenge.nonce = req.nonce;
-    challenge.disputeNonce = 0;
-    challenge.disputeCounter += 1;
+    challenge.challengeNonce = 0;
+    challenge.challengeCounter += 1;
     challenge.latestSubmitter = msg.sender;
   }
 
@@ -121,7 +121,7 @@ contract MixinSetStateWithAction is
   function correctKeySignedTheAction(
     address appDefinition,
     address[] memory signingKeys,
-    uint256 disputeNonce,
+    uint256 challengeNonce,
     SignedAppChallengeUpdateWithAppState memory req,
     SignedAction memory action
   )
@@ -142,7 +142,7 @@ contract MixinSetStateWithAction is
         keccak256(req.appState),
         action.encodedAction,
         req.nonce,
-        disputeNonce
+        challengeNonce
       ),
       0
     );

--- a/packages/contracts/contracts/mixins/MixinVirtualAppSetState.sol
+++ b/packages/contracts/contracts/mixins/MixinVirtualAppSetState.sol
@@ -39,7 +39,7 @@ contract MixinVirtualAppSetState is
 
     require(
       challenge.status == AppStatus.ON,
-      "setState was called on a virtual app that is either in DISPUTE or OFF"
+      "setState was called on a virtual app that is either in IN_CHALLENGE or OFF"
     );
 
     require(
@@ -60,12 +60,12 @@ contract MixinVirtualAppSetState is
       req.nonce < req.nonceExpiry,
       "Tried to call setState with nonce greater than intermediary nonce expiry");
 
-    challenge.status = req.timeout > 0 ? AppStatus.DISPUTE : AppStatus.OFF;
+    challenge.status = req.timeout > 0 ? AppStatus.IN_CHALLENGE : AppStatus.OFF;
     challenge.appStateHash = req.appStateHash;
     challenge.nonce = req.nonce;
     challenge.finalizesAt = block.number + req.timeout;
-    challenge.disputeNonce = 0;
-    challenge.disputeCounter += 1;
+    challenge.challengeNonce = 0;
+    challenge.challengeCounter += 1;
     challenge.latestSubmitter = msg.sender;
   }
 

--- a/packages/contracts/test/app-registry-dispute.spec.ts
+++ b/packages/contracts/test/app-registry-dispute.spec.ts
@@ -77,7 +77,7 @@ function encodeAction(state: SolidityABIEncoderV2Type) {
   );
 }
 
-describe("AppRegistry Dispute", () => {
+describe("AppRegistry Challenge", () => {
   let provider: Web3Provider;
   let wallet: Wallet;
 

--- a/packages/contracts/test/app-registry.spec.ts
+++ b/packages/contracts/test/app-registry.spec.ts
@@ -261,8 +261,8 @@ describe("AppRegistry", () => {
       status,
       latestSubmitter,
       appStateHash,
-      disputeCounter,
-      disputeNonce,
+      challengeCounter,
+      challengeNonce,
       finalizesAt,
       nonce
     } = await appRegistry.functions.appChallenges(appInstance.identityHash);
@@ -270,8 +270,8 @@ describe("AppRegistry", () => {
     expect(status).to.be.eq(1);
     expect(latestSubmitter).to.be.eq(await wallet.getAddress());
     expect(appStateHash).to.be.eq(stateHash);
-    expect(disputeCounter).to.be.eq(1);
-    expect(disputeNonce).to.be.eq(0);
+    expect(challengeCounter).to.be.eq(1);
+    expect(challengeNonce).to.be.eq(0);
     expect(finalizesAt).to.be.eq((await provider.getBlockNumber()) + 10);
     expect(nonce).to.be.eq(1);
   });

--- a/packages/contracts/test/utils/index.ts
+++ b/packages/contracts/test/utils/index.ts
@@ -26,12 +26,12 @@ export const computeActionHash = (
   previousState: string,
   action: string,
   setStateNonce: number,
-  disputeNonce: number
+  challengeNonce: number
 ) =>
   keccak256(
     solidityPack(
       ["bytes1", "address", "bytes", "bytes", "uint256", "uint256"],
-      ["0x19", turnTaker, previousState, action, setStateNonce, disputeNonce]
+      ["0x19", turnTaker, previousState, action, setStateNonce, challengeNonce]
     )
   );
 

--- a/packages/specs/source/adjudication-layer.md
+++ b/packages/specs/source/adjudication-layer.md
@@ -51,21 +51,21 @@ struct AppChallenge {
     AppStatus status;
     address latestSubmitter;
     bytes32 appStateHash;
-    uint256 disputeCounter;
-    uint256 disputeNonce;
+    uint256 challengeCounter;
+    uint256 challengeNonce;
     uint256 finalizesAt;
     uint256 nonce;
 }
 ```
 
-Where `AppStatus` is one of `ON`, `OFF`, or `DISPUTE`.
+Where `AppStatus` is one of `ON`, `OFF`, or `IN_CHALLENGE`.
 
 Here is a description of why each field exists in this data structure:
 
 - **`status`**: A challenge exists in one of four logical states.
   - `ON`: Has never been opened (the "null" challenge and default for all off-chain apps)
-  - `DISPUTE`: Open and its timeout parameter is in the future (can be responded to)
-  - `DISPUTE`: Was opened and the timeout expired (the challenge was finalized)
+  - `IN_CHALLENGE`: Open and its timeout parameter is in the future (can be responded to)
+  - `IN_CHALLENGE`: Was opened and the timeout expired (the challenge was finalized)
   - `OFF`: Was finalized explicitly
 
 ![statechannel statuses](img/statechannel-statuses.svg)
@@ -80,9 +80,9 @@ Thus, this parameter simply records which state the challenge is in.
 
 - **`nonce`**: This is the nonce (i.e., the monotonically increasing version number of the state) at which the `appStateHash` is versioned for a particular challenge.
 
-- **`disputeNonce`**: It is allowed for a challenge to be responded to by issuing a new challenge. This idea is isomorphic to the familar state channels concept of "continuing the game on-chain". In this event, you want to keep track of the number of times a challenge has been "re-issued" as a new sense of versioning. We cannot simply increment the `nonce` field for reasons that are described in the section below: [on-chain progressions of off-chain state](#on-chain-progressions-of-off-chain-state).
+- **`challengeNonce`**: It is allowed for a challenge to be responded to by issuing a new challenge. This idea is isomorphic to the familar state channels concept of "continuing the game on-chain". In this event, you want to keep track of the number of times a challenge has been "re-issued" as a new sense of versioning. We cannot simply increment the `nonce` field for reasons that are described in the section below: [on-chain progressions of off-chain state](#on-chain-progressions-of-off-chain-state).
 
-- **`disputeCounter`**: A challenge _can_ be unanimously cancelled by all parties. In this scenario the `disputeNonce` goes back to 0. However, the `disputeCounter` is a permanent marker of how many times a challenge has been issued and re-issued on-chain. Parties can pre-agree that if this counter ever reaches an excessively high number, to simply conclude the application at some pre-determined outcome. This is simply a special mechanism to conclude applications in cases of excessive griefing by one counterparty. For more information, I recommend reading the [economic risks](https://github.com/counterfactual/paper/blob/master/main.tex#L343) section of the [Counterfactual paper](https://l4.ventures/papers/statechannels.pdf).
+- **`challengeCounter`**: A challenge _can_ be unanimously cancelled by all parties. In this scenario the `challengeNonce` goes back to 0. However, the `challengeCounter` is a permanent marker of how many times a challenge has been issued and re-issued on-chain. Parties can pre-agree that if this counter ever reaches an excessively high number, simply conclude the application at some pre-determined outcome. This is simply a special mechanism to conclude applications in cases of excessive griefing by one counterparty. For more information, I recommend reading the [economic risks](https://github.com/counterfactual/paper/blob/master/main.tex#L343) section of the [Counterfactual paper](https://l4.ventures/papers/statechannels.pdf).
 
 Since the contract that Counterfactual relies on for managing challenges is a singleton and is responsible for challnges that can occur in multiple different state channels simultaneously, it implements a mapping from what is called an `AppIdentity` to the challenge data structure described above.
 
@@ -137,9 +137,9 @@ It is possible that an application may have a challenge initiated on-chain and t
 
 - Honest party A initiates a challenge on-chain with B after B is unresponsive at nonce `k`
 - B comes back online and tries to update the state of the application by signing a unilateral action (thereby incrementing the nonce to `k + 1`) and sending it to A
-- B _also_ goes to chain and makes an on-chain challenge progression with a _different_ action, thereby incrementing the `disputeNonce` to `1`
+- B _also_ goes to chain and makes an on-chain challenge progression with a _different_ action, thereby incrementing the `challengeNonce` to `1`
 
-A is now in a bizarre spot where he can _either_ respond to the challenge on-chain again (making the `disputeNonce` equal to `2`) or he could sign the state with nonce `k + 1`. In the latter case, the newly doubly-signed (`k + 1`)-versioned state would be able to be submitted on-chain and **overwrite** whatever state was on-chain with `disputeNonce` at `1`.
+A is now in a bizarre spot where he can _either_ respond to the challenge on-chain again (making the `challengeNonce` equal to `2`) or he could sign the state with nonce `k + 1`. In the latter case, the newly doubly-signed (`k + 1`)-versioned state would be able to be submitted on-chain and **overwrite** whatever state was on-chain with `challengeNonce` at `1`.
 
 **Can we punish stale state attacks?**
 

--- a/packages/types/src/simple-types.ts
+++ b/packages/types/src/simple-types.ts
@@ -7,10 +7,12 @@ export type Bytes32 = string;
 
 // The application-specific state of an app instance, to be interpreted by the
 // app developer. We just treat it as an opaque blob; however since we pass this
-// around in protocol messages and include this in transaction data in disputes,
+// around in protocol messages and include this in transaction data in challenges,
 // we impose some restrictions on the type; they must be serializable both as
 // JSON and as solidity structs.
-export type SolidityABIEncoderV2Type = SolidityABIEncoderV2Struct | SolidityABIEncoderV2SArray;
+export type SolidityABIEncoderV2Type =
+  | SolidityABIEncoderV2Struct
+  | SolidityABIEncoderV2SArray;
 
 type SolidityABIEncoderV2Struct = {
   [x: string]:


### PR DESCRIPTION
Generally we've agreed on this new naming, so let's use the word challenge instead of dispute.