### PR TITLE
Remove interpreterHash

### DIFF
--- a/packages/contracts/contracts/StateChannelTransaction.sol
+++ b/packages/contracts/contracts/StateChannelTransaction.sol
@@ -48,11 +48,6 @@ contract StateChannelTransaction {
       appIdentityHash
     );
 
-    // require(appRegistry.appInterpreters(appIdentityHash) == keccak256(abi.encodePacked(
-    //   interpreterAddress,
-    //   interpreterParams
-    // )));
-
     bytes memory payload = abi.encodeWithSignature(
       "interpret(bytes,bytes)", outcome, interpreterParams
     );

--- a/packages/contracts/contracts/libs/LibStateChannelApp.sol
+++ b/packages/contracts/contracts/libs/LibStateChannelApp.sol
@@ -18,7 +18,6 @@ contract LibStateChannelApp {
     address owner;
     address[] signingKeys;
     address appDefinition;
-    bytes32 interpreterHash;
     uint256 defaultTimeout;
   }
 

--- a/packages/contracts/contracts/mixins/MixinSetOutcome.sol
+++ b/packages/contracts/contracts/mixins/MixinSetOutcome.sol
@@ -42,8 +42,6 @@ contract MixinSetOutcome is
       appIdentity.appDefinition,
       finalState
     );
-
-    appInterpreters[identityHash] = appIdentity.interpreterHash;
   }
 
 }

--- a/packages/contracts/test/eth-virtual-app-agreement.spec.ts
+++ b/packages/contracts/test/eth-virtual-app-agreement.spec.ts
@@ -12,9 +12,18 @@ import {
 
 import AppRegistry from "../build/AppRegistry.json";
 import DelegateProxy from "../build/DelegateProxy.json";
+<<<<<<< HEAD
 import FixedTwoPartyOutcomeApp from "../build/FixedTwoPartyOutcomeApp.json";
 import NonceRegistry from "../build/NonceRegistry.json";
 import TwoPartyVirtualEthAsLump from "../build/TwoPartyVirtualEthAsLump.json";
+||||||| merged common ancestors
+import TwoPartyVirtualEthAsLump from "../build/TwoPartyVirtualEthAsLump.json";
+import ResolveTo2App from "../build/ResolveTo2App.json";
+=======
+import NonceRegistry from "../build/NonceRegistry.json";
+import ResolveTo2App from "../build/ResolveTo2App.json";
+import TwoPartyVirtualEthAsLump from "../build/TwoPartyVirtualEthAsLump.json";
+>>>>>>> Remove interpreterHash
 
 import { expect } from "./utils/index";
 
@@ -97,7 +106,6 @@ describe("TwoPartyVirtualEthAsLump", () => {
       owner: await wallet.getAddress(),
       signingKeys: [],
       appDefinition: fixedTwoPartyOutcome.address,
-      interpreterHash: HashZero,
       defaultTimeout: 10
     };
 
@@ -108,7 +116,6 @@ describe("TwoPartyVirtualEthAsLump", () => {
             address owner,
             address[] signingKeys,
             address appDefinition,
-            bytes32 interpreterHash,
             uint256 defaultTimeout
           )`
         ],

--- a/packages/contracts/test/eth-virtual-app-agreement.spec.ts
+++ b/packages/contracts/test/eth-virtual-app-agreement.spec.ts
@@ -12,18 +12,9 @@ import {
 
 import AppRegistry from "../build/AppRegistry.json";
 import DelegateProxy from "../build/DelegateProxy.json";
-<<<<<<< HEAD
 import FixedTwoPartyOutcomeApp from "../build/FixedTwoPartyOutcomeApp.json";
 import NonceRegistry from "../build/NonceRegistry.json";
 import TwoPartyVirtualEthAsLump from "../build/TwoPartyVirtualEthAsLump.json";
-||||||| merged common ancestors
-import TwoPartyVirtualEthAsLump from "../build/TwoPartyVirtualEthAsLump.json";
-import ResolveTo2App from "../build/ResolveTo2App.json";
-=======
-import NonceRegistry from "../build/NonceRegistry.json";
-import ResolveTo2App from "../build/ResolveTo2App.json";
-import TwoPartyVirtualEthAsLump from "../build/TwoPartyVirtualEthAsLump.json";
->>>>>>> Remove interpreterHash
 
 import { expect } from "./utils/index";
 

--- a/packages/contracts/test/utils/index.ts
+++ b/packages/contracts/test/utils/index.ts
@@ -45,7 +45,6 @@ export class AppInstance {
       owner: this.owner,
       signingKeys: this.signingKeys,
       appDefinition: this.appDefinition,
-      interpreterHash: HashZero,
       defaultTimeout: this.defaultTimeout
     };
   }
@@ -66,7 +65,6 @@ export class AppInstance {
             address owner,
             address[] signingKeys,
             address appDefinition,
-            bytes32 interpreterHash,
             uint256 defaultTimeout
           )`
         ],

--- a/packages/node/src/ethereum/utils/encodings.ts
+++ b/packages/node/src/ethereum/utils/encodings.ts
@@ -22,7 +22,6 @@ export const APP_IDENTITY = `
     address owner,
     address[] signingKeys,
     address appDefinition,
-    bytes32 interpreterHash,
     uint256 defaultTimeout
   )`;
 

--- a/packages/node/src/models/app-instance.ts
+++ b/packages/node/src/models/app-instance.ts
@@ -158,7 +158,6 @@ export class AppInstance {
       owner: this.json.multisigAddress,
       signingKeys: this.json.signingKeys,
       appDefinition: this.json.appInterface.addr,
-      interpreterHash: HashZero, // todo(xuanji)
       defaultTimeout: this.json.defaultTimeout
     };
   }

--- a/packages/node/src/models/app-instance.ts
+++ b/packages/node/src/models/app-instance.ts
@@ -5,7 +5,6 @@ import {
   SolidityABIEncoderV2Type
 } from "@counterfactual/types";
 import { Contract } from "ethers";
-import { HashZero } from "ethers/constants";
 import { BaseProvider } from "ethers/providers";
 import {
   BigNumber,

--- a/packages/node/test/machine/unit/ethereum/eth-virtual-app-agreement-commitment.spec.ts
+++ b/packages/node/test/machine/unit/ethereum/eth-virtual-app-agreement-commitment.spec.ts
@@ -135,7 +135,7 @@ describe("ETH Virtual App Agreement Commitment", () => {
 
         it("should build the expected AppIdentity argument", () => {
           const [
-            [owner, signingKeys, appDefinition, {}, defaultTimeout]
+            [owner, signingKeys, appDefinition, defaultTimeout]
           ] = calldata.args;
           const expected = freeBalanceETH.identity;
           expect(owner).toBe(expected.owner);

--- a/packages/node/test/machine/unit/ethereum/install-commitment.spec.ts
+++ b/packages/node/test/machine/unit/ethereum/install-commitment.spec.ts
@@ -130,7 +130,7 @@ describe("InstallCommitment", () => {
 
         it("should build the expected AppIdentity argument", () => {
           const [
-            [owner, signingKeys, appDefinition, {}, defaultTimeout]
+            [owner, signingKeys, appDefinition, defaultTimeout]
           ] = calldata.args;
           const expected = freeBalanceETH.identity;
           expect(owner).toBe(expected.owner);

--- a/packages/node/test/machine/unit/ethereum/set-state-commitment.spec.ts
+++ b/packages/node/test/machine/unit/ethereum/set-state-commitment.spec.ts
@@ -64,13 +64,7 @@ describe("Set State Commitment", () => {
     });
 
     it("should contain expected AppIdentity argument", () => {
-      const [
-        owner,
-        signingKeys,
-        appDefinition,
-        {} /* interpreterHash */,
-        defaultTimeout
-      ] = desc.args[0];
+      const [owner, signingKeys, appDefinition, defaultTimeout] = desc.args[0];
       expect(owner).toBe(appInstance.identity.owner);
       expect(signingKeys).toEqual(appInstance.identity.signingKeys);
       expect(appDefinition).toBe(appInstance.identity.appDefinition);

--- a/packages/node/test/machine/unit/ethereum/uninstall-commitment.spec.ts
+++ b/packages/node/test/machine/unit/ethereum/uninstall-commitment.spec.ts
@@ -126,7 +126,7 @@ describe("Uninstall Commitment", () => {
 
         it("should build the expected AppIdentity argument", () => {
           const [
-            [owner, signingKeys, appDefinition, {}, defaultTimeout]
+            [owner, signingKeys, appDefinition, defaultTimeout]
           ] = calldata.args;
 
           const expected = freeBalanceETH.identity;

--- a/packages/node/test/machine/unit/ethereum/virtual-app-set-state-commitment.spec.ts
+++ b/packages/node/test/machine/unit/ethereum/virtual-app-set-state-commitment.spec.ts
@@ -87,13 +87,7 @@ describe("Virtual App Set State Commitment", () => {
     });
 
     it("should contain expected AppIdentity argument", () => {
-      const [
-        owner,
-        signingKeys,
-        appDefinition,
-        {},
-        defaultTimeout
-      ] = desc.args[0];
+      const [owner, signingKeys, appDefinition, defaultTimeout] = desc.args[0];
       expect(owner).toBe(appInstance.identity.owner);
       expect(signingKeys).toEqual(appInstance.identity.signingKeys);
       expect(appDefinition).toBe(appInstance.identity.appDefinition);

--- a/packages/specs/source/adjudication-layer.md
+++ b/packages/specs/source/adjudication-layer.md
@@ -15,7 +15,6 @@ struct AppIdentity {
     address owner;
     address[] signingKeys;
     address appDefinition;
-    bytes32 interpreterHash;
     uint256 defaultTimeout;
 }
 ```
@@ -25,8 +24,6 @@ struct AppIdentity {
 - **`signingKeys`**: In addition to using `owner` to authorize a function call, it is also possible to pass in signatures directly into the `AppRegistry` itself. In this case, this field is used to validate signatures against to.
 
 - **`appDefinition`**: Address ofthe app definition contract.
-
-- **`interpreterHash`**: Hash of interpreter address and params to the interpreter to be used in determining what effects the outcome has.
 
 - **`defaultTimeout`**: Should the application that this data structure is describing ever be put on-chain, this property describes how long the timeout period would be if that challenge ever gets responded to on-chain. In the case of a challenge _initially_ being put on chain, the timeout period is a required parameter regardless, so this field is not used in that case.
 

--- a/packages/specs/source/protocols/update.md
+++ b/packages/specs/source/protocols/update.md
@@ -28,8 +28,8 @@ appIdentityHash := keccak256(
   [
     0x19,
     keccak256(encode(
-      [address, address[], address, bytes32, uint256 ],
-      [owner, signingKeys, appDefinition, interpreterHash, defaultTimeout]
+      [address, address[], address, uint256 ],
+      [owner, signingKeys, appDefinition, defaultTimeout]
     )),
     0,
     TIMEOUT,

--- a/packages/types/src/app-instance.ts
+++ b/packages/types/src/app-instance.ts
@@ -7,7 +7,6 @@ export type AppIdentity = {
   owner: string;
   signingKeys: string[];
   appDefinition: string;
-  interpreterHash: string;
   defaultTimeout: number;
 };
 


### PR DESCRIPTION
We needed `termsHash` before because the `resolve` function used it in its arguments (because we wanted to allow an application to use `terms.limit`). Now, however, the interpreter is a higher-order concept and so we no longer need this state.