### PR TITLE
Rename interpret to interpretOutcomeAndExecuteEffect

### DIFF
--- a/packages/contracts/contracts/StateChannelTransaction.sol
+++ b/packages/contracts/contracts/StateChannelTransaction.sol
@@ -54,7 +54,7 @@ contract StateChannelTransaction {
     // )));
 
     bytes memory payload = abi.encodeWithSignature(
-      "interpret(bytes,bytes)", outcome, interpreterParams
+      "interpretOutcomeAndExecuteEffect(bytes,bytes)", outcome, interpreterParams
     );
 
     // solium-disable-next-line no-unused-vars

--- a/packages/contracts/contracts/interfaces/Interpreter.sol
+++ b/packages/contracts/contracts/interfaces/Interpreter.sol
@@ -9,5 +9,9 @@ contract Interpreter {
     ETH_TRANSFER
   }
 
-  function interpret(bytes calldata, bytes calldata) external;
+  function interpretOutcomeAndExecuteEffect(
+    bytes calldata,
+    bytes calldata
+  )
+    external;
 }

--- a/packages/contracts/contracts/interpreters/ETHInterpreter.sol
+++ b/packages/contracts/contracts/interpreters/ETHInterpreter.sol
@@ -18,7 +18,12 @@ contract ETHInterpreter is Interpreter {
     uint256 limit;
   }
 
-  function interpret(bytes calldata input, bytes calldata params) external {
+  function interpretOutcomeAndExecuteEffect(
+    bytes calldata input,
+    bytes calldata params
+  )
+    external
+  {
 
     ETHTransfer[] memory transfers =
       abi.decode(input, (ETHTransfer[]));

--- a/packages/contracts/contracts/interpreters/TwoPartyEthAsLump.sol
+++ b/packages/contracts/contracts/interpreters/TwoPartyEthAsLump.sol
@@ -12,9 +12,12 @@ contract TwoPartyEthAsLump is Interpreter {
     uint256 amount;
   }
 
-  function interpret(
-    bytes calldata encodedOutcome, bytes calldata encodedParams
-  ) external {
+  function interpretOutcomeAndExecuteEffect(
+    bytes calldata encodedOutcome,
+    bytes calldata encodedParams
+  )
+    external
+  {
 
     Params memory params = abi.decode(encodedParams, (Params));
 


### PR DESCRIPTION
Makes it more explicit based on shared terminology