### PR TITLE
Update Dockerfile of CircleCI Node environment

### DIFF
--- a/.circleci/images/build/Dockerfile
+++ b/.circleci/images/build/Dockerfile
@@ -1,4 +1,4 @@
-FROM resinci/npm-x86_64-ubuntu-node10
+FROM node:10.15.3-jessie
 
 # install solc binary
 RUN add-apt-repository ppa:ethereum/ethereum


### PR DESCRIPTION
Docker Hub autobuilds from the `master` branch so this is needed for the https://github.com/counterfactual/monorepo/pull/1544 build to succeed.

We need it because in that PR it requires Node > 10.5 and the new docker image has that.

Here is the error this should fix:

```bash
#!/bin/bash -eo pipefail
yarn --frozen-lockfile
yarn install v1.16.0
[1/5] Validating package.json...
[2/5] Resolving packages...
[3/5] Fetching packages...
info fsevents@2.0.6: The platform "linux" is incompatible with this module.
info "fsevents@2.0.6" is an optional dependency and failed compatibility check. Excluding it from installation.
info fsevents@2.0.6: The engine "node" is incompatible with this module. Expected version "^8.16.0 || ^10.6.0 || >=11.0.0". Got "10.4.0"
info fsevents@1.2.9: The platform "linux" is incompatible with this module.
info "fsevents@1.2.9" is an optional dependency and failed compatibility check. Excluding it from installation.
error @grpc/grpc-js@0.4.0: The engine "node" is incompatible with this module. Expected version "^8.13.0 || >=10.10.0". Got "10.4.0"
error Found incompatible module.
info Visit https://yarnpkg.com/en/docs/cli/install for documentation about this command.
Exited with code 1
```