### PR TITLE
Remove /usr/local/bin/node in Docker container

### DIFF
--- a/.circleci/images/build/Dockerfile
+++ b/.circleci/images/build/Dockerfile
@@ -8,9 +8,10 @@ RUN apt-get update
 RUN apt-get install -y solc
 
 # install node 10.x
-RUN apt-get install -y curl
-RUN curl -sL https://deb.nodesource.com/setup_10.x | bash -
-RUN apt-get install nodejs
+RUN apt-get install -y curl && \
+    curl -sL https://deb.nodesource.com/setup_10.x | bash - && \
+    apt-get install nodejs && \
+    rm /usr/local/bin/node
 
 # update yarn
 RUN npm install -g yarn


### PR DESCRIPTION
This `node` is still at 10.4.0 but `/usr/bin/node` is 10.15.3 as required.