### PR TITLE
Investigation of challenge(s1, s2) method instead of setStateWithAction(s, a) in AppRegistry

### DIFF
--- a/packages/contracts/contracts/libs/LibStateChannelApp.sol
+++ b/packages/contracts/contracts/libs/LibStateChannelApp.sol
@@ -13,6 +13,22 @@ contract LibStateChannelApp {
     CHALLENGE_WAS_FINALIZED
   }
 
+  struct FundingState {
+    bytes32 interpreterHash;
+  }
+
+  struct ChannelState {
+    address appDefinition;
+    address owner;
+    address[] participants;
+    bool isTerminal;
+    bytes appState;
+    bytes transitionData;
+    uint256 challengeTimeout;
+    uint256 nonce;
+    uint256 turnNum;
+  }
+
   // A minimal structure that uniquely identifies a single instance of an App
   struct AppIdentity {
     address owner;

--- a/packages/contracts/contracts/mixins/MChannelState.sol
+++ b/packages/contracts/contracts/mixins/MChannelState.sol
@@ -1,0 +1,25 @@
+pragma solidity 0.5.8;
+pragma experimental "ABIEncoderV2";
+
+import "../libs/LibStateChannelApp.sol";
+
+
+contract MChannelState {
+
+  /// @notice Compute the logical turn taker for some ChannelState
+  /// @param channelState A `ChannelState` struct
+  /// @return An address, the logical turn taker
+  function getTurnTaker(
+    LibStateChannelApp.ChannelState memory channelState
+  )
+    internal
+    pure
+    returns (address)
+  {
+    return channelState.participants[
+      channelState.turnNum % channelState.participants.length
+    ];
+  }
+
+
+}


### PR DESCRIPTION
Trying to wrap my head around the major changes needed to be made to the adjudicator to get our codebase up to speed with the as-yet-to-be-proposed SICP standard