### PR TITLE
[postgres-connector] Include org scope in package name

### DIFF
--- a/packages/postgresql-node-connector/package.json
+++ b/packages/postgresql-node-connector/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "postgresql-node-connector",
+  "name": "@counterfactual/postgresql-node-connector",
   "version": "0.0.1",
   "description": "Implementation of a PostgreSQL storage service for the Counterfactual Node",
   "license": "MIT"


### PR DESCRIPTION
https://github.com/counterfactual/monorepo/pull/1586 missed scoping the package name.

As a side note: This package has been published with this updated name: https://www.npmjs.com/package/@counterfactual/postgresql-node-connector