### PR TITLE
Attempt to delete a rambunctious file

### DIFF
--- a/packages/playground-server/scripts/postinstall.sh
+++ b/packages/playground-server/scripts/postinstall.sh
@@ -5,4 +5,5 @@ set -e
 if [ ! -z "${IS_HEROKU_ENV}" ]; then
     echo "📟  Detected Heroku. Transpiling Typescript into JS for Node.JS to run on server."
     tsc -p tsconfig.heroku.json &> /dev/null || :
+    rm -rf ./node_modules/websocket/.git
 fi


### PR DESCRIPTION
For some reason `playground-server-staging` builds are failing on Heroku

```
       npm ERR! path /tmp/build_7640c419819b5fe55ff7ba526690ab79/node_modules/websocket
       npm ERR! code EISGIT
       npm ERR! git /tmp/build_7640c419819b5fe55ff7ba526690ab79/node_modules/websocket: Appears to be a git repo or submodule.
       npm ERR! git     /tmp/build_7640c419819b5fe55ff7ba526690ab79/node_modules/websocket
       npm ERR! git Refusing to remove it. Update manually,
       npm ERR! git or move it out of the way first.
       
       npm ERR! A complete log of this run can be found in:
       npm ERR!     /tmp/npmcache.irycY/_logs/2019-05-31T16_23_00_099Z-debug.log
```