### PR TITLE
Split up heroku postbuild script in playground-server

### DIFF
--- a/packages/playground-server/package.json
+++ b/packages/playground-server/package.json
@@ -19,6 +19,7 @@
   },
   "scripts": {
     "heroku-postbuild": "sh ./scripts/heroku-postbuild.sh",
+    "build": "echo 'No build necessary'",
     "postinstall": "sh ./scripts/postinstall.sh",
     "lint": "tslint -c tslint.json -p .",
     "lint:fix": "tslint -c tslint.json -p . --fix",

--- a/packages/playground-server/package.json
+++ b/packages/playground-server/package.json
@@ -18,7 +18,7 @@
     "url": "git+https://github.com/counterfactual/monorepo.git"
   },
   "scripts": {
-    "build": "echo 'No build necessary'",
+    "heroku-postbuild": "sh ./scripts/heroku-postbuild.sh",
     "postinstall": "sh ./scripts/postinstall.sh",
     "lint": "tslint -c tslint.json -p .",
     "lint:fix": "tslint -c tslint.json -p . --fix",

--- a/packages/playground-server/package.json
+++ b/packages/playground-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@counterfactual/playground-server",
-  "version": "0.1.14",
+  "version": "0.1.15",
   "description": "A backend for the Playground app.",
   "author": "Counterfactual",
   "homepage": "https://github.com/counterfactual/monorepo",

--- a/packages/playground-server/scripts/heroku-postbuild.sh
+++ b/packages/playground-server/scripts/heroku-postbuild.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+
+set -e
+
+if [ ! -z "${IS_HEROKU_ENV}" ]; then
+    echo "📟  Detected Heroku. Transpiling Typescript into JS for Node.JS to run on server."
+    tsc -b tsconfig.heroku.json
+fi

--- a/packages/playground-server/scripts/postinstall.sh
+++ b/packages/playground-server/scripts/postinstall.sh
@@ -3,7 +3,6 @@
 set -e
 
 if [ ! -z "${IS_HEROKU_ENV}" ]; then
-    echo "📟  Detected Heroku. Transpiling Typescript into JS for Node.JS to run on server."
-    tsc -p tsconfig.heroku.json &> /dev/null || :
+    echo "Deleting ./node_modules/websocket/.git -- incorrectly added installation artifact"
     rm -rf ./node_modules/websocket/.git
 fi


### PR DESCRIPTION
When running `yarn --focus --production` in the `playground` package I encountered an issue where the `postinstall` script of the `playground-server` package.

```
error /Users/liam/src/code/monorepo/node_modules/@counterfactual/playground-server, /Users/liam/src/co
de/monorepo/packages/playground/node_modules/@counterfactual/playground-server: Command failed.
Exit code: 127
Command: sh ./scripts/postinstall.sh
Arguments: 
Directory: /Users/liam/src/code/monorepo/packages/playground/node_modules/@counterfactual/playground-s
```

I don't fully know why this package is even involved