### PR TITLE
Specify yarn and node engines everywhere

### DIFF
--- a/packages/apps/package.json
+++ b/packages/apps/package.json
@@ -4,6 +4,10 @@
   "description": "Collection of various apps built on Counterfactual",
   "repository": "github.com/counterfactual/monorepo",
   "license": "MIT",
+  "engines": {
+    "yarn": "^1.10",
+    "node": "10.15.3"
+  },
   "files": [
     "build"
   ],

--- a/packages/cf-wallet.js/package.json
+++ b/packages/cf-wallet.js/package.json
@@ -5,6 +5,10 @@
   "types": "dist/src/index.d.ts",
   "main": "dist/index.js",
   "iife": "dist/index-iife.js",
+  "engines": {
+    "yarn": "^1.10",
+    "node": "10.15.3"
+  },
   "files": [
     "dist"
   ],

--- a/packages/cf.js/package.json
+++ b/packages/cf.js/package.json
@@ -5,6 +5,10 @@
   "types": "dist/src/index.d.ts",
   "main": "dist/index.js",
   "iife": "dist/index-iife.js",
+  "engines": {
+    "yarn": "^1.10",
+    "node": "10.15.3"
+  },
   "files": [
     "dist"
   ],

--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -3,6 +3,10 @@
   "version": "0.1.1",
   "description": "Smart contracts for Counterfactual",
   "license": "MIT",
+  "engines": {
+    "yarn": "^1.10",
+    "node": "10.15.3"
+  },
   "files": [
     "build",
     "contracts",

--- a/packages/dapp-high-roller/package.json
+++ b/packages/dapp-high-roller/package.json
@@ -1,6 +1,10 @@
 {
   "name": "@counterfactual/dapp-high-roller",
   "version": "0.1.0",
+  "engines": {
+    "yarn": "^1.10",
+    "node": "10.15.3"
+  },
   "scripts": {
     "netlify": "sh netlify.sh",
     "build": "stencil build && cp src/_redirects www/_redirects",

--- a/packages/dapp-tic-tac-toe/package.json
+++ b/packages/dapp-tic-tac-toe/package.json
@@ -1,6 +1,10 @@
 {
   "name": "@counterfactual/dapp-tic-tac-toe",
   "version": "0.1.2",
+  "engines": {
+    "yarn": "^1.10",
+    "node": "10.15.3"
+  },
   "dependencies": {
     "@counterfactual/apps": "0.1.1",
     "react": "^16.8.6",

--- a/packages/firebase-client/package.json
+++ b/packages/firebase-client/package.json
@@ -5,6 +5,10 @@
   "iife": "dist/index.iife.js",
   "types": "dist/index.d.ts",
   "license": "MIT",
+  "engines": {
+    "yarn": "^1.10",
+    "node": "10.15.3"
+  },
   "scripts": {
     "build": "tsc -p . && rollup -c",
     "build:watch": "tsc -p . && rollup -c -w",

--- a/packages/firebase-server/package.json
+++ b/packages/firebase-server/package.json
@@ -4,6 +4,10 @@
   "main": "dist/index.js",
   "types": "dist/src/index.d.ts",
   "license": "MIT",
+  "engines": {
+    "yarn": "^1.10",
+    "node": "10.15.3"
+  },
   "scripts": {
     "build": "tsc -p . && rollup -c",
     "build:watch": "tsc -p . && rollup -c -w",

--- a/packages/high-roller-bot/package.json
+++ b/packages/high-roller-bot/package.json
@@ -6,6 +6,10 @@
   "homepage": "https://github.com/counterfactual/monorepo",
   "license": "MIT",
   "main": "src/index.js",
+  "engines": {
+    "yarn": "^1.10",
+    "node": "10.15.3"
+  },
   "directories": {
     "lib": "src",
     "test": "tests"

--- a/packages/node-provider/package.json
+++ b/packages/node-provider/package.json
@@ -4,6 +4,10 @@
   "main": "dist/index.js",
   "types": "dist/src/index.d.ts",
   "module": "dist/index.es.js",
+  "engines": {
+    "yarn": "^1.10",
+    "node": "10.15.3"
+  },
   "files": [
     "dist"
   ],

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -5,6 +5,10 @@
   "iife": "dist/index.iife.js",
   "types": "dist/src/index.d.ts",
   "license": "MIT",
+  "engines": {
+    "yarn": "^1.10",
+    "node": "10.15.3"
+  },
   "scripts": {
     "build": "tsc -b . && rollup -c",
     "build:watch": "tsc -b . && rollup -c -w",

--- a/packages/playground-server/package.json
+++ b/packages/playground-server/package.json
@@ -5,6 +5,10 @@
   "author": "Counterfactual",
   "homepage": "https://github.com/counterfactual/monorepo",
   "license": "MIT",
+  "engines": {
+    "yarn": "^1.10",
+    "node": "10.15.3"
+  },
   "main": "src/index.ts",
   "directories": {
     "lib": "src",

--- a/packages/playground/package.json
+++ b/packages/playground/package.json
@@ -1,6 +1,10 @@
 {
   "name": "@counterfactual/playground",
   "version": "0.1.3",
+  "engines": {
+    "yarn": "^1.10",
+    "node": "10.15.3"
+  },
   "scripts": {
     "build": "stencil build --debug && cp src/_redirects www/_redirects",
     "serve": "stencil build --dev --watch --serve",

--- a/packages/postgresql-node-connector/package.json
+++ b/packages/postgresql-node-connector/package.json
@@ -3,5 +3,9 @@
   "version": "0.0.1",
   "description": "Implementation of a PostgreSQL storage service for the Counterfactual Node",
   "license": "MIT",
+  "engines": {
+    "yarn": "^1.10",
+    "node": "10.15.3"
+  },
   "dependencies": {}
 }

--- a/packages/tic-tac-toe-bot/package.json
+++ b/packages/tic-tac-toe-bot/package.json
@@ -6,6 +6,10 @@
   "homepage": "https://github.com/counterfactual/monorepo",
   "license": "MIT",
   "main": "src/index.js",
+  "engines": {
+    "yarn": "^1.10",
+    "node": "10.15.3"
+  },
   "directories": {
     "lib": "src",
     "test": "tests"

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -7,6 +7,10 @@
   "types": "dist/src/index.d.ts",
   "iife": "dist/index-iife.js",
   "license": "MIT",
+  "engines": {
+    "yarn": "^1.10",
+    "node": "10.15.3"
+  },
   "scripts": {
     "build": "tsc -b . && rollup -c"
   },

--- a/packages/typescript-typings/package.json
+++ b/packages/typescript-typings/package.json
@@ -3,7 +3,8 @@
   "version": "0.1.0",
   "license": "MIT",
   "engines": {
-    "node": ">=6.12"
+    "yarn": "^1.10",
+    "node": "10.15.3"
   },
   "description": "Counterfactual Types",
   "scripts": {


### PR DESCRIPTION
Useful when one package is being pulled in a deployment context like Heroku