### PR TITLE
Update yarn to 1.12.3 on Dockerfile (needs to happen first)

### DIFF
--- a/.circleci/images/build/Dockerfile
+++ b/.circleci/images/build/Dockerfile
@@ -12,5 +12,5 @@ RUN apt-get install -y curl && \
     curl -sL https://deb.nodesource.com/node_10.x/pool/main/n/nodejs/nodejs_10.15.3-1nodesource1_amd64.deb > nodejs-10.15.3.deb && \
     dpkg -i nodejs-10.15.3.deb && \
     rm /usr/local/bin/node && \
-    npm install -g yarn@1.10 && \
+    npm install -g yarn@1.12.3 && \
     rm /usr/local/bin/yarn


### PR DESCRIPTION
Has to happen before https://github.com/counterfactual/monorepo/pull/1628 so the image gets built on `master` merge.