### PR TITLE
Fix players variable reliance of TicTacToe app code

### DIFF
--- a/packages/apps/contracts/HighRollerApp.sol
+++ b/packages/apps/contracts/HighRollerApp.sol
@@ -2,6 +2,7 @@ pragma solidity 0.5.9;
 pragma experimental "ABIEncoderV2";
 
 import "@counterfactual/contracts/contracts/interfaces/CounterfactualApp.sol";
+import "@counterfactual/contracts/contracts/interfaces/Interpreter.sol";
 import "@counterfactual/contracts/contracts/interfaces/TwoPartyOutcome.sol";
 
 
@@ -139,6 +140,14 @@ contract HighRollerApp is CounterfactualApp {
     }
   }
 
+  function outcomeType()
+    external
+    pure
+    returns (uint256)
+  {
+    return uint256(Interpreter.OutcomeType.TWO_PARTY_OUTCOME);
+  }
+
   function getWinningAmounts(uint256 num1, uint256 num2)
     internal
     pure
@@ -208,4 +217,5 @@ contract HighRollerApp is CounterfactualApp {
   {
     return uint8(uint64(q) % 6);
   }
+
 }

--- a/packages/dapp-tic-tac-toe/src/Game.jsx
+++ b/packages/dapp-tic-tac-toe/src/Game.jsx
@@ -101,7 +101,7 @@ class Game extends Component {
   }
 
   get myNumber() {
-    const index = this.state.gameState.players.indexOf(
+    const index = this.props.appInstance.beneficiaries.indexOf(
       window.ethers.utils.getAddress(this.state.my0thKeyAddress)
     );
 


### PR DESCRIPTION
TicTacToe client logic depended on the `players` variable in the `AppState` of the `TicTacToe`. However, we could not rely on this anymore since the Interpreter PR (#1263) removed this variable from the contract. Now that it is gone, we rely on the `beneficiaries` field of the `AppInstance` that @IIIIllllIIIIllllIIIIllllIIIIllllIIIIll added. This field is temporary (since it is hard coded to a specific interpreter but happens to be getting written to in the Install Protocol (see [1]).

Also, separately, the `interpreterParams` for the `TwoPartyEthAsLump.sol` interpreter were being incorrectly set, this fixes that.

[1] https://github.com/counterfactual/monorepo/blob/6fe51b12c5dc1b4c54cb794a393c052488d1f472/packages/node/src/protocol/install.ts#L143