### PR TITLE
Remove variable name appId, replace w/ appDefinition

### DIFF
--- a/packages/cf-wallet.js/src/app-instance.ts
+++ b/packages/cf-wallet.js/src/app-instance.ts
@@ -17,7 +17,7 @@ export class AppInstance {
    */
   readonly id: AppInstanceID;
 
-  readonly appId: Address;
+  readonly appDefinition: Address;
   readonly abiEncodings: AppABIEncodings;
   readonly myDeposit: BigNumber;
   readonly peerDeposit: BigNumber;
@@ -26,7 +26,7 @@ export class AppInstance {
 
   constructor(info: AppInstanceInfo, readonly provider: Provider) {
     this.id = info.id;
-    this.appId = info.appId;
+    this.appDefinition = info.appDefinition;
     this.abiEncodings = info.abiEncodings;
     this.myDeposit = info.myDeposit;
     this.peerDeposit = info.peerDeposit;

--- a/packages/cf-wallet.js/test/provider.spec.ts
+++ b/packages/cf-wallet.js/test/provider.spec.ts
@@ -21,7 +21,7 @@ describe("CF.js Provider", () => {
   const TEST_APP_INSTANCE_INFO: AppInstanceInfo = {
     id: "TEST_ID",
     abiEncodings: { actionEncoding: "uint256", stateEncoding: "uint256" },
-    appId: "0x1515151515151515151515151515151515151515",
+    appDefinition: "0x1515151515151515151515151515151515151515",
     myDeposit: Zero,
     peerDeposit: Zero,
     timeout: Zero,
@@ -126,7 +126,7 @@ describe("CF.js Provider", () => {
       });
       const appInstance = await provider.install(TEST_APP_INSTANCE_INFO.id);
       expect(appInstance.id).toBe(TEST_APP_INSTANCE_INFO.id);
-      expect(appInstance.appId).toBe(TEST_APP_INSTANCE_INFO.appId);
+      expect(appInstance.appDefinition).toBe(TEST_APP_INSTANCE_INFO.appDefinition);
     });
 
     it("can install an app instance virtually", async () => {
@@ -157,7 +157,7 @@ describe("CF.js Provider", () => {
         expectedIntermediaries
       );
       expect(appInstance.id).toBe(TEST_APP_INSTANCE_INFO.id);
-      expect(appInstance.appId).toBe(TEST_APP_INSTANCE_INFO.appId);
+      expect(appInstance.appDefinition).toBe(TEST_APP_INSTANCE_INFO.appDefinition);
       expect(appInstance.isVirtual).toBeTruthy();
       expect(appInstance.intermediaries).toBe(expectedIntermediaries);
     });

--- a/packages/cf-wallet.js/test/provider.spec.ts
+++ b/packages/cf-wallet.js/test/provider.spec.ts
@@ -126,7 +126,9 @@ describe("CF.js Provider", () => {
       });
       const appInstance = await provider.install(TEST_APP_INSTANCE_INFO.id);
       expect(appInstance.id).toBe(TEST_APP_INSTANCE_INFO.id);
-      expect(appInstance.appDefinition).toBe(TEST_APP_INSTANCE_INFO.appDefinition);
+      expect(appInstance.appDefinition).toBe(
+        TEST_APP_INSTANCE_INFO.appDefinition
+      );
     });
 
     it("can install an app instance virtually", async () => {
@@ -157,7 +159,9 @@ describe("CF.js Provider", () => {
         expectedIntermediaries
       );
       expect(appInstance.id).toBe(TEST_APP_INSTANCE_INFO.id);
-      expect(appInstance.appDefinition).toBe(TEST_APP_INSTANCE_INFO.appDefinition);
+      expect(appInstance.appDefinition).toBe(
+        TEST_APP_INSTANCE_INFO.appDefinition
+      );
       expect(appInstance.isVirtual).toBeTruthy();
       expect(appInstance.intermediaries).toBe(expectedIntermediaries);
     });

--- a/packages/cf.js/API_REFERENCE.md
+++ b/packages/cf.js/API_REFERENCE.md
@@ -41,7 +41,7 @@
 - `AppFactory`
     - Properties
         - `provider: Provider`
-        - `appId: string`
+        - `appDefinition: string`
             - Address of the on-chain App Definition contract
         - `encodings:`[`AppABIEncodings`](#data-type-appabiencodings)
     - Instance methods
@@ -148,7 +148,7 @@ Requests that a peer start the install protocol for an app instance. At the same
 Params:
 - `proposedToIdentifier: string`
     - Address of the peer responding to the installation request of the app
-- `appId: string`
+- `appDefinition: string`
     - On-chain address of App Definition contract
 - `abiEncodings:`[`AppABIEncodings`](#data-type-appabiencodings)
     - ABI encodings used for states and actions of this app
@@ -175,7 +175,7 @@ Requests that a peer start the install protocol for a virtual app instance. At t
 Params:
 - `proposedToIdentifier: string`
     - Address of the peer responding to the installation request of the app
-- `appId: string`
+- `appDefinition: string`
     - On-chain address of App Definition contract
 - `abiEncodings:`[`AppABIEncodings`](#data-type-appabiencodings)
     - ABI encodings used for states and actions of this app
@@ -460,7 +460,7 @@ An instance of an installed app.
 - `id: string`
     - Opaque identifier used to refer to this app instance
     - No two distinct app instances (even in different channels) may share the same ID
-- `appId: string`
+- `appDefinition: string`
     - On-chain address of App Definition contract
 - `abiEncodings:`[`AppABIEncodings`](#data-type-appabiencodings)
     - ABI encodings used for states and actions of this app

--- a/packages/cf.js/src/app-factory.ts
+++ b/packages/cf.js/src/app-factory.ts
@@ -37,12 +37,12 @@ function parseBigNumber(val: BigNumberish, paramName: string): BigNumber {
 export class AppFactory {
   /**
    * Constructs a new instance
-   * @param appId Address of the on-chain contract containing the app logic.
+   * @param appDefinition Address of the on-chain contract containing the app logic.
    * @param encodings ABI encodings to encode and decode the app's state and actions
    * @param provider CFjs provider
    */
   constructor(
-    readonly appId: Address,
+    readonly appDefinition: Address,
     readonly encodings: AppABIEncodings,
     readonly provider: Provider
   ) {}
@@ -78,7 +78,7 @@ export class AppFactory {
         myDeposit,
         proposedToIdentifier: params.proposedToIdentifier,
         initialState: params.initialState,
-        appId: this.appId,
+        appDefinition: this.appDefinition,
         abiEncodings: this.encodings
       }
     );
@@ -120,7 +120,7 @@ export class AppFactory {
         proposedToIdentifier: params.proposedToIdentifier,
         initialState: params.initialState,
         intermediaries: params.intermediaries,
-        appId: this.appId,
+        appDefinition: this.appDefinition,
         abiEncodings: this.encodings
       }
     );

--- a/packages/cf.js/src/app-instance.ts
+++ b/packages/cf.js/src/app-instance.ts
@@ -27,7 +27,7 @@ export class AppInstance {
    */
   readonly id: AppInstanceID;
 
-  readonly appId: Address;
+  readonly appDefinition: Address;
   readonly abiEncodings: AppABIEncodings;
   readonly myDeposit: BigNumber;
   readonly peerDeposit: BigNumber;
@@ -40,7 +40,7 @@ export class AppInstance {
 
   constructor(info: AppInstanceInfo, readonly provider: Provider) {
     this.id = info.id;
-    this.appId = info.appId;
+    this.appDefinition = info.appDefinition;
     this.abiEncodings = info.abiEncodings;
     this.myDeposit = info.myDeposit;
     this.peerDeposit = info.peerDeposit;

--- a/packages/cf.js/test/app-factory.spec.ts
+++ b/packages/cf.js/test/app-factory.spec.ts
@@ -8,7 +8,7 @@ import { TEST_XPUBS, TestNodeProvider } from "./fixture";
 
 const TEST_APP = {
   abiEncodings: { actionEncoding: "uint256", stateEncoding: "uint256" },
-  appId: "0x1515151515151515151515151515151515151515"
+  appDefinition: "0x1515151515151515151515151515151515151515"
 };
 
 describe("CF.js AppFactory", () => {
@@ -20,7 +20,7 @@ describe("CF.js AppFactory", () => {
     nodeProvider = new TestNodeProvider();
     provider = new Provider(nodeProvider);
     appFactory = new AppFactory(
-      TEST_APP.appId,
+      TEST_APP.appDefinition,
       TEST_APP.abiEncodings,
       provider
     );

--- a/packages/cf.js/test/app-instance.spec.ts
+++ b/packages/cf.js/test/app-instance.spec.ts
@@ -15,7 +15,7 @@ describe("CF.js AppInstance", () => {
   const TEST_APP_INSTANCE_INFO: AppInstanceInfo = {
     id: "TEST_ID",
     abiEncodings: { actionEncoding: "uint256", stateEncoding: "uint256" },
-    appId: "0x1515151515151515151515151515151515151515",
+    appDefinition: "0x1515151515151515151515151515151515151515",
     myDeposit: bigNumberify(1000),
     peerDeposit: bigNumberify(1000),
     timeout: bigNumberify(10),

--- a/packages/cf.js/test/provider.spec.ts
+++ b/packages/cf.js/test/provider.spec.ts
@@ -166,7 +166,9 @@ describe("CF.js Provider", () => {
       });
       const appInstance = await provider.install(TEST_APP_INSTANCE_INFO.id);
       expect(appInstance.id).toBe(TEST_APP_INSTANCE_INFO.id);
-      expect(appInstance.appDefinition).toBe(TEST_APP_INSTANCE_INFO.appDefinition);
+      expect(appInstance.appDefinition).toBe(
+        TEST_APP_INSTANCE_INFO.appDefinition
+      );
     });
 
     it("can install an app instance virtually", async () => {
@@ -197,7 +199,9 @@ describe("CF.js Provider", () => {
         expectedIntermediaries
       );
       expect(appInstance.id).toBe(TEST_APP_INSTANCE_INFO.id);
-      expect(appInstance.appDefinition).toBe(TEST_APP_INSTANCE_INFO.appDefinition);
+      expect(appInstance.appDefinition).toBe(
+        TEST_APP_INSTANCE_INFO.appDefinition
+      );
       expect(appInstance.isVirtual).toBeTruthy();
       expect(appInstance.intermediaries).toBe(expectedIntermediaries);
     });

--- a/packages/cf.js/test/provider.spec.ts
+++ b/packages/cf.js/test/provider.spec.ts
@@ -20,7 +20,7 @@ describe("CF.js Provider", () => {
   const TEST_APP_INSTANCE_INFO: AppInstanceInfo = {
     id: "TEST_ID",
     abiEncodings: { actionEncoding: "uint256", stateEncoding: "uint256" },
-    appId: "0x1515151515151515151515151515151515151515",
+    appDefinition: "0x1515151515151515151515151515151515151515",
     myDeposit: Zero,
     peerDeposit: Zero,
     timeout: Zero,
@@ -166,7 +166,7 @@ describe("CF.js Provider", () => {
       });
       const appInstance = await provider.install(TEST_APP_INSTANCE_INFO.id);
       expect(appInstance.id).toBe(TEST_APP_INSTANCE_INFO.id);
-      expect(appInstance.appId).toBe(TEST_APP_INSTANCE_INFO.appId);
+      expect(appInstance.appDefinition).toBe(TEST_APP_INSTANCE_INFO.appDefinition);
     });
 
     it("can install an app instance virtually", async () => {
@@ -197,7 +197,7 @@ describe("CF.js Provider", () => {
         expectedIntermediaries
       );
       expect(appInstance.id).toBe(TEST_APP_INSTANCE_INFO.id);
-      expect(appInstance.appId).toBe(TEST_APP_INSTANCE_INFO.appId);
+      expect(appInstance.appDefinition).toBe(TEST_APP_INSTANCE_INFO.appDefinition);
       expect(appInstance.isVirtual).toBeTruthy();
       expect(appInstance.intermediaries).toBe(expectedIntermediaries);
     });

--- a/packages/dapp-high-roller/src/data/mock-app-instance.ts
+++ b/packages/dapp-high-roller/src/data/mock-app-instance.ts
@@ -25,7 +25,7 @@ export class AppInstance {
    */
   readonly id: AppInstanceID;
 
-  readonly appId: Address;
+  readonly appDefinition: Address;
   readonly abiEncodings: AppABIEncodings;
   readonly myDeposit: BigNumber;
   readonly peerDeposit: BigNumber;
@@ -35,7 +35,7 @@ export class AppInstance {
 
   constructor(info: AppInstanceInfo, readonly provider: cf.Provider) {
     this.id = info.id;
-    this.appId = info.appId;
+    this.appDefinition = info.appDefinition;
     this.abiEncodings = info.abiEncodings;
     this.myDeposit = info.myDeposit;
     this.peerDeposit = info.peerDeposit;

--- a/packages/dapp-high-roller/src/data/types.ts
+++ b/packages/dapp-high-roller/src/data/types.ts
@@ -18,7 +18,7 @@ export interface SignedStateHashUpdate {
 
 export type AppInstanceInfo = {
   id: AppInstanceID;
-  appId: Address;
+  appDefinition: Address;
   abiEncodings: AppABIEncodings;
   myDeposit: BigNumber;
   peerDeposit: BigNumber;
@@ -97,7 +97,7 @@ export namespace Node {
 
   export type ProposeInstallParams = {
     respondingAddress: Address;
-    appId: Address;
+    appDefinition: Address;
     abiEncodings: AppABIEncodings;
     myDeposit: BigNumber;
     peerDeposit: BigNumber;

--- a/packages/dapp-tic-tac-toe/src/MockNodeProvider.js
+++ b/packages/dapp-tic-tac-toe/src/MockNodeProvider.js
@@ -134,7 +134,7 @@ export default class NodeProvider {
       const { x, y } = this.determineOpponentAction();
       const boardCopy = JSON.parse(JSON.stringify(this.activeState.board));
       boardCopy[x][y] = 2;
-  
+
       const winClaim = checkVictory(boardCopy, 2);
       const draw = checkDraw(boardCopy);
 
@@ -177,7 +177,7 @@ export default class NodeProvider {
   generateAppInstanceDetail(params = {}) {
     return Object.assign({
       id: "0x60504030201",
-      appId: "0x123123456456",
+      appDefinition: "0x123123456456",
       abiEncodings: {
         actionEncoding: "tuple(ActionType actionType, uint256 playX, uint256 playY, WinClaim winClaim)",
         stateEncoding: "tuple(uint256 turnName, uint256 winner, uint256[3][3] board)"

--- a/packages/node/src/methods/app-instance/install-virtual/operation.ts
+++ b/packages/node/src/methods/app-instance/install-virtual/operation.ts
@@ -31,7 +31,7 @@ export async function installVirtual(
         intermediaryXpub: appInstanceInfo.intermediaries![0],
         defaultTimeout: appInstanceInfo.timeout.toNumber(),
         appInterface: {
-          addr: appInstanceInfo.appId,
+          addr: appInstanceInfo.appDefinition,
           ...appInstanceInfo.abiEncodings
         },
         initialState: appInstanceInfo.initialState,

--- a/packages/node/src/methods/app-instance/install/operation.ts
+++ b/packages/node/src/methods/app-instance/install/operation.ts
@@ -39,7 +39,7 @@ export async function install(
       initialState: appInstanceInfo.initialState,
       appInterface: {
         ...appInstanceInfo.abiEncodings,
-        addr: appInstanceInfo.appId
+        addr: appInstanceInfo.appDefinition
       },
       defaultTimeout: appInstanceInfo.timeout.toNumber()
     }

--- a/packages/node/src/models/proposed-app-instance-info.ts
+++ b/packages/node/src/models/proposed-app-instance-info.ts
@@ -13,7 +13,7 @@ import { xkeyKthAddress, xkeysToSortedKthAddresses } from "../machine";
 import { AppInstance, StateChannel } from "../models";
 
 export interface IProposedAppInstanceInfo {
-  appId: Address;
+  appDefinition: Address;
   abiEncodings: AppABIEncodings;
   myDeposit: BigNumber;
   peerDeposit: BigNumber;
@@ -26,7 +26,7 @@ export interface IProposedAppInstanceInfo {
 
 export interface ProposedAppInstanceInfoJSON {
   id: Bytes32;
-  appId: Address;
+  appDefinition: Address;
   abiEncodings: AppABIEncodings;
   myDeposit: string;
   peerDeposit: string;
@@ -49,7 +49,7 @@ export interface ProposedAppInstanceInfoJSON {
  */
 export class ProposedAppInstanceInfo implements AppInstanceInfo {
   id: Bytes32;
-  appId: Address;
+  appDefinition: Address;
   abiEncodings: AppABIEncodings;
   myDeposit: BigNumber;
   peerDeposit: BigNumber;
@@ -64,7 +64,7 @@ export class ProposedAppInstanceInfo implements AppInstanceInfo {
     channel?: StateChannel,
     overrideId?: Bytes32
   ) {
-    this.appId = proposeParams.appId;
+    this.appDefinition = proposeParams.appDefinition;
     this.abiEncodings = proposeParams.abiEncodings;
     this.myDeposit = proposeParams.myDeposit;
     this.peerDeposit = proposeParams.peerDeposit;
@@ -79,7 +79,7 @@ export class ProposedAppInstanceInfo implements AppInstanceInfo {
   // TODO: Note the construction of this is duplicated from the machine
   getIdentityHashFor(stateChannel: StateChannel) {
     const proposedAppInterface: AppInterface = {
-      addr: this.appId,
+      addr: this.appDefinition,
       ...this.abiEncodings
     };
 
@@ -130,7 +130,7 @@ export class ProposedAppInstanceInfo implements AppInstanceInfo {
   toJson() {
     return {
       id: this.id,
-      appId: this.appId,
+      appDefinition: this.appDefinition,
       abiEncodings: this.abiEncodings,
       myDeposit: this.myDeposit,
       peerDeposit: this.peerDeposit,
@@ -144,7 +144,7 @@ export class ProposedAppInstanceInfo implements AppInstanceInfo {
 
   static fromJson(json: ProposedAppInstanceInfoJSON): ProposedAppInstanceInfo {
     const proposeParams: IProposedAppInstanceInfo = {
-      appId: json.appId,
+      appDefinition: json.appDefinition,
       abiEncodings: json.abiEncodings,
       myDeposit: bigNumberify(json.myDeposit),
       peerDeposit: bigNumberify(json.peerDeposit),

--- a/packages/node/test/integration/utils.ts
+++ b/packages/node/test/integration/utils.ts
@@ -284,7 +284,9 @@ export function confirmProposedAppInstanceOnNode(
   expect(proposalParams.abiEncodings).toEqual(
     proposedAppInstanceInfo.abiEncodings
   );
-  expect(proposalParams.appDefinition).toEqual(proposedAppInstanceInfo.appDefinition);
+  expect(proposalParams.appDefinition).toEqual(
+    proposedAppInstanceInfo.appDefinition
+  );
 
   if (nonInitiatingNode) {
     expect(proposalParams.myDeposit).toEqual(

--- a/packages/node/test/integration/utils.ts
+++ b/packages/node/test/integration/utils.ts
@@ -201,7 +201,7 @@ export function makeRejectInstallRequest(
 export function makeTTTProposalRequest(
   proposedByIdentifier: string,
   proposedToIdentifier: string,
-  appId: string,
+  appDefinition: string,
   state: SolidityABIEncoderV2Type = {},
   myDeposit: BigNumber = Zero,
   peerDeposit: BigNumber = Zero
@@ -213,7 +213,7 @@ export function makeTTTProposalRequest(
     proposedToIdentifier,
     myDeposit,
     peerDeposit,
-    appId,
+    appDefinition,
     initialState,
     abiEncodings: {
       stateEncoding: tttStateEncoding,
@@ -246,7 +246,7 @@ export function makeTTTVirtualProposalRequest(
   proposedByIdentifier: string,
   proposedToIdentifier: string,
   intermediaries: string[],
-  appId: string,
+  appDefinition: string,
   initialState: SolidityABIEncoderV2Type = {},
   myDeposit: BigNumber = Zero,
   peerDeposit: BigNumber = Zero
@@ -254,7 +254,7 @@ export function makeTTTVirtualProposalRequest(
   const installProposalParams = makeTTTProposalRequest(
     proposedByIdentifier,
     proposedToIdentifier,
-    appId,
+    appDefinition,
     initialState,
     myDeposit,
     peerDeposit
@@ -284,7 +284,7 @@ export function confirmProposedAppInstanceOnNode(
   expect(proposalParams.abiEncodings).toEqual(
     proposedAppInstanceInfo.abiEncodings
   );
-  expect(proposalParams.appId).toEqual(proposedAppInstanceInfo.appId);
+  expect(proposalParams.appDefinition).toEqual(proposedAppInstanceInfo.appDefinition);
 
   if (nonInitiatingNode) {
     expect(proposalParams.myDeposit).toEqual(

--- a/packages/node/test/unit/utils.ts
+++ b/packages/node/test/unit/utils.ts
@@ -22,7 +22,7 @@ export function createProposedAppInstanceInfo(appInstanceId: string) {
     {
       proposedByIdentifier: computeRandomXpub(),
       proposedToIdentifier: computeRandomXpub(),
-      appId: AddressZero,
+      appDefinition: AddressZero,
       abiEncodings: {
         stateEncoding: "tuple(address foo, uint256 bar)",
         actionEncoding: undefined

--- a/packages/playground/src/components/node-listener/dialogs/propose-install/dialog-propose-install.tsx
+++ b/packages/playground/src/components/node-listener/dialogs/propose-install/dialog-propose-install.tsx
@@ -29,7 +29,9 @@ export class DialogProposeInstall {
 
   render() {
     const app = this.apps.find(app => {
-      return app.id[KOVAN_NETWORK_ID] === this.message.data.params.appDefinition;
+      return (
+        app.id[KOVAN_NETWORK_ID] === this.message.data.params.appDefinition
+      );
     });
 
     if (!app) {

--- a/packages/playground/src/components/node-listener/dialogs/propose-install/dialog-propose-install.tsx
+++ b/packages/playground/src/components/node-listener/dialogs/propose-install/dialog-propose-install.tsx
@@ -29,7 +29,7 @@ export class DialogProposeInstall {
 
   render() {
     const app = this.apps.find(app => {
-      return app.id[KOVAN_NETWORK_ID] === this.message.data.params.appId;
+      return app.id[KOVAN_NETWORK_ID] === this.message.data.params.appDefinition;
     });
 
     if (!app) {

--- a/packages/playground/src/components/node-listener/node-listener.tsx
+++ b/packages/playground/src/components/node-listener/node-listener.tsx
@@ -92,7 +92,9 @@ export class NodeListener {
       );
 
       const app: AppDefinition = this.apps.find(app => {
-        return app.id[KOVAN_NETWORK_ID] === installedApp.appInstance.appDefinition;
+        return (
+          app.id[KOVAN_NETWORK_ID] === installedApp.appInstance.appDefinition
+        );
       })!;
 
       if (!app) {

--- a/packages/playground/src/components/node-listener/node-listener.tsx
+++ b/packages/playground/src/components/node-listener/node-listener.tsx
@@ -92,7 +92,7 @@ export class NodeListener {
       );
 
       const app: AppDefinition = this.apps.find(app => {
-        return app.id[KOVAN_NETWORK_ID] === installedApp.appInstance.appId;
+        return app.id[KOVAN_NETWORK_ID] === installedApp.appInstance.appDefinition;
       })!;
 
       if (!app) {

--- a/packages/tic-tac-toe-bot/test/integration.spec.ts
+++ b/packages/tic-tac-toe-bot/test/integration.spec.ts
@@ -167,7 +167,7 @@ describe("ttt-bot", () => {
             winner: 0,
             board: [[0, 0, 0], [0, 0, 0], [0, 0, 0]]
           },
-          appId: NETWORK_CONTEXT["TicTacToe"],
+          appDefinition: NETWORK_CONTEXT["TicTacToe"],
           abiEncodings: {
             actionEncoding:
               "tuple(uint8 actionType, uint256 playX, uint256 playY, tuple(uint8 winClaimType, uint256 idx) winClaim)",

--- a/packages/types/src/data-types.ts
+++ b/packages/types/src/data-types.ts
@@ -5,7 +5,7 @@ import { ABIEncoding, AppInstanceID } from "./simple-types";
 
 export type AppInstanceInfo = {
   id: AppInstanceID;
-  appId: string;
+  appDefinition: string;
   abiEncodings: AppABIEncodings;
   myDeposit: BigNumber;
   peerDeposit: BigNumber;

--- a/packages/types/src/node.ts
+++ b/packages/types/src/node.ts
@@ -170,7 +170,7 @@ export namespace Node {
   export type InstallVirtualResult = InstallResult;
 
   export type ProposeInstallParams = {
-    appId: string;
+    appDefinition: string;
     abiEncodings: AppABIEncodings;
     myDeposit: BigNumber;
     peerDeposit: BigNumber;


### PR DESCRIPTION
`appId` is an outdated name. `appDefinition` is the more clear and commonly used term to refer to the address of a contract.