### PR TITLE
Add limitOrTotal and beneficiaries to client API wrapper class (also rename them to be explicit)

### DIFF
--- a/packages/cf-wallet.js/src/app-instance.ts
+++ b/packages/cf-wallet.js/src/app-instance.ts
@@ -4,6 +4,10 @@ import {
   AppInstanceID,
   AppInstanceInfo
 } from "@counterfactual/types";
+import {
+  ETHTransferInterpreterParams,
+  TwoPartyOutcomeInterpreterParams
+} from "@counterfactual/types/dist/src/data-types";
 import { BigNumber } from "ethers/utils";
 
 import { Provider } from "./provider";
@@ -26,18 +30,8 @@ export class AppInstance {
   readonly myDeposit: BigNumber;
   readonly peerDeposit: BigNumber;
 
-  readonly twoPartyOutcomeInterpreterParams?: {
-    // Derived from:
-    // packages/contracts/contracts/interpreters/TwoPartyEthAsLump.sol#L10
-    playerAddrs: [string, string];
-    amount: BigNumber;
-  };
-
-  readonly ethTransferInterpreterParams?: {
-    // Derived from:
-    // packages/contracts/contracts/interpreters/ETHInterpreter.sol#L18
-    limit: BigNumber;
-  };
+  readonly twoPartyOutcomeInterpreterParams?: TwoPartyOutcomeInterpreterParams;
+  readonly ethTransferInterpreterParams?: ETHTransferInterpreterParams;
 
   readonly intermediaries?: Address[];
 

--- a/packages/cf-wallet.js/src/app-instance.ts
+++ b/packages/cf-wallet.js/src/app-instance.ts
@@ -25,8 +25,20 @@ export class AppInstance {
   // Funding-related fields
   readonly myDeposit: BigNumber;
   readonly peerDeposit: BigNumber;
-  readonly beneficiaries?: string[];
-  readonly limitOrTotal?: BigNumber;
+
+  readonly twoPartyOutcomeInterpreterParams?: {
+    // Derived from:
+    // packages/contracts/contracts/interpreters/TwoPartyEthAsLump.sol#L10
+    playerAddrs: [string, string];
+    amount: BigNumber;
+  };
+
+  readonly ethTransferInterpreterParams?: {
+    // Derived from:
+    // packages/contracts/contracts/interpreters/ETHInterpreter.sol#L18
+    limit: BigNumber;
+  };
+
   readonly intermediaries?: Address[];
 
   constructor(info: AppInstanceInfo, readonly provider: Provider) {
@@ -36,8 +48,8 @@ export class AppInstance {
     this.myDeposit = info.myDeposit;
     this.peerDeposit = info.peerDeposit;
     this.timeout = info.timeout;
-    this.limitOrTotal = info.limitOrTotal;
-    this.beneficiaries = info.beneficiaries;
+    this.twoPartyOutcomeInterpreterParams = info.twoPartyOutcomeInterpreterParams;
+    this.ethTransferInterpreterParams = info.ethTransferInterpreterParams;
     this.intermediaries = info.intermediaries;
   }
 

--- a/packages/cf-wallet.js/src/app-instance.ts
+++ b/packages/cf-wallet.js/src/app-instance.ts
@@ -48,7 +48,8 @@ export class AppInstance {
     this.myDeposit = info.myDeposit;
     this.peerDeposit = info.peerDeposit;
     this.timeout = info.timeout;
-    this.twoPartyOutcomeInterpreterParams = info.twoPartyOutcomeInterpreterParams;
+    this.twoPartyOutcomeInterpreterParams =
+      info.twoPartyOutcomeInterpreterParams;
     this.ethTransferInterpreterParams = info.ethTransferInterpreterParams;
     this.intermediaries = info.intermediaries;
   }

--- a/packages/cf-wallet.js/src/app-instance.ts
+++ b/packages/cf-wallet.js/src/app-instance.ts
@@ -17,11 +17,16 @@ export class AppInstance {
    */
   readonly id: AppInstanceID;
 
+  // Application-specific fields
   readonly appDefinition: Address;
   readonly abiEncodings: AppABIEncodings;
+  readonly timeout: BigNumber;
+
+  // Funding-related fields
   readonly myDeposit: BigNumber;
   readonly peerDeposit: BigNumber;
-  readonly timeout: BigNumber;
+  readonly beneficiaries?: string[];
+  readonly limitOrTotal?: BigNumber;
   readonly intermediaries?: Address[];
 
   constructor(info: AppInstanceInfo, readonly provider: Provider) {
@@ -31,6 +36,8 @@ export class AppInstance {
     this.myDeposit = info.myDeposit;
     this.peerDeposit = info.peerDeposit;
     this.timeout = info.timeout;
+    this.limitOrTotal = info.limitOrTotal;
+    this.beneficiaries = info.beneficiaries;
     this.intermediaries = info.intermediaries;
   }
 

--- a/packages/cf.js/src/app-instance.ts
+++ b/packages/cf.js/src/app-instance.ts
@@ -35,9 +35,23 @@ export class AppInstance {
   // Funding-related fields
   readonly myDeposit: BigNumber;
   readonly peerDeposit: BigNumber;
-  readonly beneficiaries?: string[];
-  readonly limitOrTotal?: BigNumber;
   readonly intermediaries?: Address[];
+
+  /**
+   * Interpreter-related Fields
+   */
+  twoPartyOutcomeInterpreterParams?: {
+    // Derived from:
+    // packages/contracts/contracts/interpreters/TwoPartyEthAsLump.sol#L10
+    playerAddrs: [string, string];
+    amount: BigNumber;
+  };
+
+  ethTransferInterpreterParams?: {
+    // Derived from:
+    // packages/contracts/contracts/interpreters/ETHInterpreter.sol#L18
+    limit: BigNumber;
+  };
 
   private readonly eventEmitter: EventEmitter = new EventEmitter();
   private readonly validEventTypes = Object.keys(AppInstanceEventType).map(
@@ -51,8 +65,9 @@ export class AppInstance {
     this.timeout = info.timeout;
     this.myDeposit = info.myDeposit;
     this.peerDeposit = info.peerDeposit;
-    this.limitOrTotal = info.limitOrTotal;
-    this.beneficiaries = info.beneficiaries;
+    this.twoPartyOutcomeInterpreterParams =
+      info.twoPartyOutcomeInterpreterParams;
+    this.ethTransferInterpreterParams = info.ethTransferInterpreterParams;
     this.intermediaries = info.intermediaries;
   }
 

--- a/packages/cf.js/src/app-instance.ts
+++ b/packages/cf.js/src/app-instance.ts
@@ -27,12 +27,18 @@ export class AppInstance {
    */
   readonly id: AppInstanceID;
 
+  // Application-specific fields
   readonly appDefinition: Address;
   readonly abiEncodings: AppABIEncodings;
+  readonly timeout: BigNumber;
+
+  // Funding-related fields
   readonly myDeposit: BigNumber;
   readonly peerDeposit: BigNumber;
-  readonly timeout: BigNumber;
+  readonly beneficiaries?: string[];
+  readonly limitOrTotal?: BigNumber;
   readonly intermediaries?: Address[];
+
   private readonly eventEmitter: EventEmitter = new EventEmitter();
   private readonly validEventTypes = Object.keys(AppInstanceEventType).map(
     key => AppInstanceEventType[key]
@@ -42,9 +48,11 @@ export class AppInstance {
     this.id = info.id;
     this.appDefinition = info.appDefinition;
     this.abiEncodings = info.abiEncodings;
+    this.timeout = info.timeout;
     this.myDeposit = info.myDeposit;
     this.peerDeposit = info.peerDeposit;
-    this.timeout = info.timeout;
+    this.limitOrTotal = info.limitOrTotal;
+    this.beneficiaries = info.beneficiaries;
     this.intermediaries = info.intermediaries;
   }
 

--- a/packages/cf.js/src/app-instance.ts
+++ b/packages/cf.js/src/app-instance.ts
@@ -6,6 +6,10 @@ import {
   Node,
   SolidityABIEncoderV2Type
 } from "@counterfactual/types";
+import {
+  ETHTransferInterpreterParams,
+  TwoPartyOutcomeInterpreterParams
+} from "@counterfactual/types/dist/src/data-types";
 import { BigNumber } from "ethers/utils";
 import EventEmitter from "eventemitter3";
 
@@ -40,18 +44,8 @@ export class AppInstance {
   /**
    * Interpreter-related Fields
    */
-  twoPartyOutcomeInterpreterParams?: {
-    // Derived from:
-    // packages/contracts/contracts/interpreters/TwoPartyEthAsLump.sol#L10
-    playerAddrs: [string, string];
-    amount: BigNumber;
-  };
-
-  ethTransferInterpreterParams?: {
-    // Derived from:
-    // packages/contracts/contracts/interpreters/ETHInterpreter.sol#L18
-    limit: BigNumber;
-  };
+  readonly twoPartyOutcomeInterpreterParams?: TwoPartyOutcomeInterpreterParams;
+  readonly ethTransferInterpreterParams?: ETHTransferInterpreterParams;
 
   private readonly eventEmitter: EventEmitter = new EventEmitter();
   private readonly validEventTypes = Object.keys(AppInstanceEventType).map(

--- a/packages/dapp-tic-tac-toe/src/Game.jsx
+++ b/packages/dapp-tic-tac-toe/src/Game.jsx
@@ -101,7 +101,7 @@ class Game extends Component {
   }
 
   get myNumber() {
-    const index = this.props.appInstance.beneficiaries.indexOf(
+    const index = this.props.appInstance.twoPartyOutcomeInterpreterParams.playerAddrs.indexOf(
       window.ethers.utils.getAddress(this.state.my0thKeyAddress)
     );
 

--- a/packages/node/src/ethereum/two-party-virtual-eth-as-lump-commitment.ts
+++ b/packages/node/src/ethereum/two-party-virtual-eth-as-lump-commitment.ts
@@ -33,9 +33,11 @@ export class TwoPartyVirtualEthAsLumpCommitment extends MultiSendCommitment {
       freeBalanceNonce,
       freeBalanceTimeout
     );
+
     if (this.networkContext.TwoPartyVirtualEthAsLump === undefined) {
       throw Error("undefined TwoPartyVirtualEthAsLump");
     }
+
     if (this.beneficiaries.length !== 2) {
       throw Error(
         `TwoPartyVirtualEthAsLump currently only supports 2 beneficiaries but got ${

--- a/packages/node/src/models/app-instance.ts
+++ b/packages/node/src/models/app-instance.ts
@@ -29,9 +29,21 @@ export type AppInstanceJson = {
   latestState: SolidityABIEncoderV2Type;
   latestNonce: number;
   latestTimeout: number;
-  beneficiaries: [string, string];
-  limitOrTotal: {
-    _hex: string;
+
+  /**
+   * Interpreter-related Fields
+   */
+  twoPartyOutcomeInterpreterParams?: {
+    // Derived from:
+    // packages/contracts/contracts/interpreters/TwoPartyEthAsLump.sol#L10
+    playerAddrs: [string, string];
+    amount: { _hex: string };
+  };
+
+  ethTransferInterpreterParams?: {
+    // Derived from:
+    // packages/contracts/contracts/interpreters/ETHInterpreter.sol#L18
+    limit: { _hex: string };
   };
 };
 
@@ -59,14 +71,12 @@ export type AppInstanceJson = {
 
  * @property latestTimeout The timeout used in the latest signed state update.
 
- * @property beneficiaries The free balance addresses of the two beneficiaries
- *           of the app (the two addresses who could potentially have money
- *           sent to them)
+ * @property ethTransferInterpreterParams The limit / maximum amount of funds
+ *           to be distributed for an app where the interpreter type is ETH_TRANSFER
 
- * @property limitOrTotal If the outcome type is TwoPartyOutcome, the total
- *           amount of ETH in wei allocated to the app; if the outcome type
- *           is ETHTransfer, the static upper bound on the total amount of ETH
- *           allowed to be transfered by this app
+ * @property twoPartyOutcomeInterpreterParams Addresses of the two beneficiaries
+ *           and the amount that is to be distributed for an app
+ *           where the interpreter type is TWO_PARTY_OUTCOME
  */
 // TODO: dont forget dependnecy nonce docstring
 export class AppInstance {
@@ -83,8 +93,17 @@ export class AppInstance {
     latestState: any,
     latestNonce: number,
     latestTimeout: number,
-    beneficiaries: [string, string],
-    limitOrTotal: BigNumber
+    twoPartyOutcomeInterpreterParams?: {
+      // Derived from:
+      // packages/contracts/contracts/interpreters/TwoPartyEthAsLump.sol#L10
+      playerAddrs: [string, string];
+      amount: BigNumber;
+    },
+    ethTransferInterpreterParams?: {
+      // Derived from:
+      // packages/contracts/contracts/interpreters/ETHInterpreter.sol#L18
+      limit: BigNumber;
+    }
   ) {
     this.json = {
       multisigAddress,
@@ -97,10 +116,21 @@ export class AppInstance {
       latestState,
       latestNonce,
       latestTimeout,
-      beneficiaries,
-      limitOrTotal: {
-        _hex: limitOrTotal.toHexString()
-      }
+      twoPartyOutcomeInterpreterParams: twoPartyOutcomeInterpreterParams
+        ? {
+            playerAddrs: twoPartyOutcomeInterpreterParams.playerAddrs,
+            amount: {
+              _hex: twoPartyOutcomeInterpreterParams.amount.toHexString()
+            }
+          }
+        : undefined,
+      ethTransferInterpreterParams: ethTransferInterpreterParams
+        ? {
+            limit: {
+              _hex: ethTransferInterpreterParams.limit.toHexString()
+            }
+          }
+        : undefined
     };
   }
 
@@ -125,8 +155,19 @@ export class AppInstance {
       latestState,
       json.latestNonce,
       json.latestTimeout,
-      json.beneficiaries,
-      bigNumberify(json.limitOrTotal._hex)
+      json.twoPartyOutcomeInterpreterParams
+        ? {
+            playerAddrs: json.twoPartyOutcomeInterpreterParams.playerAddrs,
+            amount: bigNumberify(
+              json.twoPartyOutcomeInterpreterParams.amount._hex
+            )
+          }
+        : undefined,
+      json.ethTransferInterpreterParams
+        ? {
+            limit: bigNumberify(json.ethTransferInterpreterParams.limit._hex)
+          }
+        : undefined
     );
     return ret;
   }
@@ -201,12 +242,23 @@ export class AppInstance {
     return this.json.latestNonce;
   }
 
-  public get limitOrTotal() {
-    return bigNumberify(this.json.limitOrTotal._hex);
+  public get ethTransferInterpreterParams() {
+    return this.json.ethTransferInterpreterParams
+      ? {
+          limit: bigNumberify(this.json.ethTransferInterpreterParams.limit._hex)
+        }
+      : undefined;
   }
 
-  public get beneficiaries() {
-    return this.json.beneficiaries;
+  public get twoPartyOutcomeInterpreterParams() {
+    return this.json.twoPartyOutcomeInterpreterParams
+      ? {
+          playerAddrs: this.json.twoPartyOutcomeInterpreterParams.playerAddrs,
+          amount: bigNumberify(
+            this.json.twoPartyOutcomeInterpreterParams.amount._hex
+          )
+        }
+      : undefined;
   }
 
   public get timeout() {

--- a/packages/node/src/models/app-instance.ts
+++ b/packages/node/src/models/app-instance.ts
@@ -4,6 +4,10 @@ import {
   AppInterface,
   SolidityABIEncoderV2Type
 } from "@counterfactual/types";
+import {
+  ETHTransferInterpreterParams,
+  TwoPartyOutcomeInterpreterParams
+} from "@counterfactual/types/dist/src/data-types";
 import { Contract } from "ethers";
 import { BaseProvider } from "ethers/providers";
 import {
@@ -93,17 +97,8 @@ export class AppInstance {
     latestState: any,
     latestNonce: number,
     latestTimeout: number,
-    twoPartyOutcomeInterpreterParams?: {
-      // Derived from:
-      // packages/contracts/contracts/interpreters/TwoPartyEthAsLump.sol#L10
-      playerAddrs: [string, string];
-      amount: BigNumber;
-    },
-    ethTransferInterpreterParams?: {
-      // Derived from:
-      // packages/contracts/contracts/interpreters/ETHInterpreter.sol#L18
-      limit: BigNumber;
-    }
+    twoPartyOutcomeInterpreterParams?: TwoPartyOutcomeInterpreterParams,
+    ethTransferInterpreterParams?: ETHTransferInterpreterParams
   ) {
     this.json = {
       multisigAddress,

--- a/packages/node/src/models/proposed-app-instance-info.ts
+++ b/packages/node/src/models/proposed-app-instance-info.ts
@@ -120,8 +120,10 @@ export class ProposedAppInstanceInfo implements AppInstanceInfo {
       bigNumberify(this.timeout).toNumber(),
       // the below two arguments are not currently used in app identity
       // computation
-      [AddressZero, AddressZero],
-      bigNumberify(this.myDeposit).add(this.peerDeposit)
+      undefined,
+      {
+        limit: bigNumberify(this.myDeposit).add(this.peerDeposit)
+      }
     );
 
     return proposedAppInstance.identityHash;

--- a/packages/node/src/models/state-channel.ts
+++ b/packages/node/src/models/state-channel.ts
@@ -2,7 +2,7 @@ import {
   ETHBucketAppState,
   SolidityABIEncoderV2Type
 } from "@counterfactual/types";
-import { AddressZero, MaxUint256, Zero } from "ethers/constants";
+import { MaxUint256, Zero } from "ethers/constants";
 import { BigNumber } from "ethers/utils";
 
 import {
@@ -99,8 +99,8 @@ function createETHFreeBalance(
     ],
     0,
     HARD_CODED_ASSUMPTIONS.freeBalanceInitialStateTimeout,
-    [AddressZero, AddressZero],
-    MaxUint256
+    undefined,
+    { limit: MaxUint256 }
   );
 }
 

--- a/packages/node/src/protocol/install-virtual-app.ts
+++ b/packages/node/src/protocol/install-virtual-app.ts
@@ -231,8 +231,13 @@ function createAndAddTarget(
     initialState,
     0, // app nonce
     defaultTimeout,
-    [initiatingAddress, intermediaryAddress],
-    bigNumberify(initiatingBalanceDecrement).add(respondingBalanceDecrement)
+    {
+      playerAddrs: [initiatingAddress, intermediaryAddress],
+      amount: bigNumberify(initiatingBalanceDecrement).add(
+        respondingBalanceDecrement
+      )
+    },
+    undefined
   );
 
   const newStateChannel = sc.addVirtualAppInstance(target);

--- a/packages/node/src/protocol/utils/get-outcome-increments.ts
+++ b/packages/node/src/protocol/utils/get-outcome-increments.ts
@@ -77,23 +77,25 @@ export async function computeFreeBalanceIncrements(
     case OutcomeType.TWO_PARTY_OUTCOME: {
       const [decoded] = defaultAbiCoder.decode(["uint256"], outcome);
 
-      const total = appInstance.limitOrTotal;
+      const total = appInstance.twoPartyOutcomeInterpreterParams!.amount;
+
       if (decoded.eq(Zero)) {
         return {
-          [appInstance.beneficiaries[0]]: total
+          [appInstance.twoPartyOutcomeInterpreterParams!.playerAddrs[0]]: total
         };
       }
       if (decoded.eq(One)) {
         return {
-          [appInstance.beneficiaries[1]]: total
+          [appInstance.twoPartyOutcomeInterpreterParams!.playerAddrs[1]]: total
         };
       }
 
       const i0 = total.div(2);
       const i1 = total.sub(i0);
+
       return {
-        [appInstance.beneficiaries[0]]: i0,
-        [appInstance.beneficiaries[1]]: i1
+        [appInstance.twoPartyOutcomeInterpreterParams!.playerAddrs[0]]: i0,
+        [appInstance.twoPartyOutcomeInterpreterParams!.playerAddrs[1]]: i1
       };
     }
     default: {

--- a/packages/node/src/protocol/withdraw-eth.ts
+++ b/packages/node/src/protocol/withdraw-eth.ts
@@ -1,5 +1,5 @@
 import { ETHBucketAppState, NetworkContext } from "@counterfactual/types";
-import { AddressZero, MaxUint256 } from "ethers/constants";
+import { MaxUint256 } from "ethers/constants";
 import { defaultAbiCoder } from "ethers/utils";
 
 import {
@@ -184,8 +184,8 @@ function addInstallRefundAppCommitmentToContext(
     },
     0,
     1008,
-    [AddressZero, AddressZero],
-    MaxUint256
+    undefined,
+    { limit: MaxUint256 }
   );
 
   const newStateChannel = stateChannel.installApp(refundAppInstance, {

--- a/packages/node/test/machine/integration/install-then-set-state.spec.ts
+++ b/packages/node/test/machine/integration/install-then-set-state.spec.ts
@@ -3,7 +3,7 @@ import MinimumViableMultisig from "@counterfactual/contracts/build/MinimumViable
 import ProxyFactory from "@counterfactual/contracts/build/ProxyFactory.json";
 import { NetworkContext } from "@counterfactual/types";
 import { Contract, Wallet } from "ethers";
-import { AddressZero, WeiPerEther, Zero } from "ethers/constants";
+import { WeiPerEther, Zero } from "ethers/constants";
 import { JsonRpcProvider } from "ethers/providers";
 import {
   defaultAbiCoder,
@@ -107,8 +107,10 @@ describe("Scenario: install AppInstance, set state, put on-chain", () => {
         state,
         0,
         freeBalanceETH.timeout, // Re-use ETH FreeBalance timeout
-        [AddressZero, AddressZero],
-        Zero
+        undefined,
+        {
+          limit: Zero
+        }
       );
 
       stateChannel = stateChannel.installApp(appInstance, {
@@ -156,7 +158,10 @@ describe("Scenario: install AppInstance, set state, put on-chain", () => {
         appInstance.appSeqNo,
         stateChannel.rootNonceValue,
         network.ETHInterpreter,
-        defaultAbiCoder.encode(["uint256"], [freeBalanceETH.limitOrTotal])
+        defaultAbiCoder.encode(
+          ["uint256"],
+          [freeBalanceETH.ethTransferInterpreterParams!.limit]
+        )
       );
 
       const installTx = installCommitment.transaction([

--- a/packages/node/test/machine/integration/two-party-virtual-eth-as-lump-commitment.spec.ts
+++ b/packages/node/test/machine/integration/two-party-virtual-eth-as-lump-commitment.spec.ts
@@ -96,8 +96,11 @@ describe("Scenario: install virtual AppInstance, put on-chain", () => {
         {}, // latest state
         1, // latest nonce
         0, // latest timeout
-        [AddressZero, AddressZero],
-        Zero
+        {
+          playerAddrs: [AddressZero, AddressZero],
+          amount: Zero
+        },
+        undefined
       );
 
       const beneficiaries = [

--- a/packages/node/test/machine/integration/virtual-app-set-state-commitment.spec.ts
+++ b/packages/node/test/machine/integration/virtual-app-set-state-commitment.spec.ts
@@ -76,8 +76,11 @@ beforeEach(() => {
     freeBalanceETH.toJson().latestState,
     freeBalanceETH.toJson().latestNonce,
     freeBalanceETH.timeout,
-    [AddressZero, AddressZero],
-    Zero
+    {
+      playerAddrs: [AddressZero, AddressZero],
+      amount: Zero
+    },
+    undefined
   );
 
   intermediaryCommitment = new VirtualAppSetStateCommitment(

--- a/packages/node/test/machine/unit/ethereum/virtual-app-set-state-commitment.spec.ts
+++ b/packages/node/test/machine/unit/ethereum/virtual-app-set-state-commitment.spec.ts
@@ -46,8 +46,11 @@ describe("Virtual App Set State Commitment", () => {
     { foo: AddressZero, bar: 0 },
     0,
     Math.ceil(1000 * Math.random()),
-    [AddressZero, AddressZero],
-    Zero
+    {
+      playerAddrs: [AddressZero, AddressZero],
+      amount: Zero
+    },
+    undefined
   );
 
   beforeAll(() => {

--- a/packages/node/test/machine/unit/models/app-instance/app-instance.spec.ts
+++ b/packages/node/test/machine/unit/models/app-instance/app-instance.spec.ts
@@ -26,8 +26,11 @@ describe("AppInstance", () => {
       { foo: getAddress(hexlify(randomBytes(20))), bar: 0 },
       999, // <------ nonce
       Math.ceil(1000 * Math.random()),
-      [AddressZero, AddressZero],
-      Zero
+      {
+        playerAddrs: [AddressZero, AddressZero],
+        amount: Zero
+      },
+      undefined
     );
 
     expect(appInstance).not.toBe(null);

--- a/packages/node/test/unit/utils.ts
+++ b/packages/node/test/unit/utils.ts
@@ -65,7 +65,10 @@ export function createAppInstance(stateChannel?: StateChannel) {
     { foo: AddressZero, bar: bigNumberify(0) },
     0,
     Math.ceil(1000 * Math.random()),
-    [AddressZero, AddressZero],
-    Zero
+    {
+      playerAddrs: [AddressZero, AddressZero],
+      amount: Zero
+    },
+    undefined
   );
 }

--- a/packages/types/src/data-types.ts
+++ b/packages/types/src/data-types.ts
@@ -3,6 +3,19 @@ import { BigNumber } from "ethers/utils";
 
 import { ABIEncoding, AppInstanceID } from "./simple-types";
 
+export type TwoPartyOutcomeInterpreterParams = {
+  // Derived from:
+  // packages/contracts/contracts/interpreters/TwoPartyEthAsLump.sol#L10
+  playerAddrs: [string, string];
+  amount: BigNumber;
+};
+
+export type ETHTransferInterpreterParams = {
+  // Derived from:
+  // packages/contracts/contracts/interpreters/ETHInterpreter.sol#L18
+  limit: BigNumber;
+};
+
 export type AppInstanceInfo = {
   id: AppInstanceID;
   appDefinition: string;
@@ -17,18 +30,8 @@ export type AppInstanceInfo = {
   /**
    * Interpreter-related Fields
    */
-  twoPartyOutcomeInterpreterParams?: {
-    // Derived from:
-    // packages/contracts/contracts/interpreters/TwoPartyEthAsLump.sol#L10
-    playerAddrs: [string, string];
-    amount: BigNumber;
-  };
-
-  ethTransferInterpreterParams?: {
-    // Derived from:
-    // packages/contracts/contracts/interpreters/ETHInterpreter.sol#L18
-    limit: BigNumber;
-  };
+  twoPartyOutcomeInterpreterParams?: TwoPartyOutcomeInterpreterParams;
+  ethTransferInterpreterParams?: ETHTransferInterpreterParams;
 };
 
 export type AppABIEncodings = {

--- a/packages/types/src/data-types.ts
+++ b/packages/types/src/data-types.ts
@@ -13,6 +13,8 @@ export type AppInstanceInfo = {
   proposedByIdentifier: string; // xpub
   proposedToIdentifier: string; // xpub
   intermediaries?: string[];
+  beneficiaries?: string[];
+  limitOrTotal?: BigNumber;
 };
 
 export type AppABIEncodings = {

--- a/packages/types/src/data-types.ts
+++ b/packages/types/src/data-types.ts
@@ -13,8 +13,22 @@ export type AppInstanceInfo = {
   proposedByIdentifier: string; // xpub
   proposedToIdentifier: string; // xpub
   intermediaries?: string[];
-  beneficiaries?: string[];
-  limitOrTotal?: BigNumber;
+
+  /**
+   * Interpreter-related Fields
+   */
+  twoPartyOutcomeInterpreterParams?: {
+    // Derived from:
+    // packages/contracts/contracts/interpreters/TwoPartyEthAsLump.sol#L10
+    playerAddrs: [string, string];
+    amount: BigNumber;
+  };
+
+  ethTransferInterpreterParams?: {
+    // Derived from:
+    // packages/contracts/contracts/interpreters/ETHInterpreter.sol#L18
+    limit: BigNumber;
+  };
 };
 
 export type AppABIEncodings = {


### PR DESCRIPTION
These fields were not added in the Interpreter PR #1263 (cc: @IIIIllllIIIIllllIIIIllllIIIIllllIIIIll for reference) to the clientside API wrapper class for an `AppInstance` inside `cf.js` and `cf-wallet.js`. This adds them.

**Field rename**
- `limitOrTotal` was `amount` if TwoPartyOutcome interpreter type or `limit` if ETHTransfer interpreter type.
- `beneficiaries` was `playerAddrs` if TwoPartyOutcome else meaningless (but set to `[0x0, 0x0]`)