### PR TITLE
postgresql-node-connector: Fix hard-coded username

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,9 @@ dist/
 functions/
 
 # cache
+.config
+.node-gyp
+.npm
 .rpt2_cache
 
 # coverage

--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,7 @@ package-lock.json
 .vscode
 .idea/
 *.iml
+*.sw[op]
 
 npm-debug.log*
 yarn-debug.log*

--- a/packages/postgresql-node-connector/package.json
+++ b/packages/postgresql-node-connector/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@counterfactual/postgresql-node-connector",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "main": "dist/index.js",
   "types": "dist/src/index.d.ts",
   "description": "Implementation of a PostgreSQL storage service for the Counterfactual Node",

--- a/packages/postgresql-node-connector/package.json
+++ b/packages/postgresql-node-connector/package.json
@@ -6,8 +6,8 @@
   "description": "Implementation of a PostgreSQL storage service for the Counterfactual Node",
   "license": "MIT",
   "engines": {
-    "yarn": "1.12.3",
-    "node": "10.15.3"
+    "yarn": ">=1.12",
+    "node": ">=10.15"
   },
   "scripts": {
     "prepublish": "tsc -b . && rollup -c",
@@ -20,16 +20,16 @@
   "dependencies": {
     "@counterfactual/types": "0.0.10",
     "pg": "7.11.0",
-    "reflect-metadata": "^0.1.13",
-    "typeorm": "^0.2.17"
+    "reflect-metadata": "0.1.13",
+    "typeorm": "0.2.18"
   },
   "devDependencies": {
     "@types/jest": "24.0.13",
-    "@types/node": "12.0.4",
+    "@types/node": "12.0.8",
     "@types/pg": "7.4.14",
     "dotenv-extended": "2.4.0",
     "jest": "24.8.0",
-    "rollup": "1.13.0",
+    "rollup": "1.15.1",
     "rollup-plugin-commonjs": "10.0.0",
     "rollup-plugin-node-resolve": "5.0.1",
     "rollup-plugin-typescript2": "0.21.1",

--- a/packages/postgresql-node-connector/package.json
+++ b/packages/postgresql-node-connector/package.json
@@ -6,8 +6,8 @@
   "description": "Implementation of a PostgreSQL storage service for the Counterfactual Node",
   "license": "MIT",
   "engines": {
-    "yarn": ">=1.12",
-    "node": ">=10.15"
+    "yarn": "1.12.3",
+    "node": "10.15.3"
   },
   "scripts": {
     "prepublish": "tsc -b . && rollup -c",

--- a/packages/postgresql-node-connector/src/index.ts
+++ b/packages/postgresql-node-connector/src/index.ts
@@ -14,13 +14,13 @@ export const POSTGRES_CONFIGURATION_ENV_KEYS = {
   port: "POSTGRES_PORT"
 };
 
-export interface PostgresConnectionOptions {
+export type PostgresConnectionOptions = ConnectionOptions & {
   username: string;
   host: string;
   database: string;
   password: string;
   port: number;
-}
+};
 
 export const EMPTY_POSTGRES_CONFIG: ConnectionOptions = {
   type: "postgres",
@@ -36,7 +36,7 @@ export class PostgresServiceFactory implements Node.ServiceFactory {
   private connection: Connection;
 
   constructor(
-    readonly configuration: ConnectionOptions | PostgresConnectionOptions,
+    readonly configuration: PostgresConnectionOptions,
     readonly tableName: string = "node_records"
   ) {
     this.connectionManager = new ConnectionManager();

--- a/packages/postgresql-node-connector/src/index.ts
+++ b/packages/postgresql-node-connector/src/index.ts
@@ -36,7 +36,7 @@ export class PostgresServiceFactory implements Node.ServiceFactory {
   private connection: Connection;
 
   constructor(
-    configuration: ConnectionOptions,
+    readonly configuration: PostgresConnectionOptions,
     readonly tableName: string = "node_records"
   ) {
     this.connectionManager = new ConnectionManager();
@@ -62,7 +62,7 @@ export class PostgresServiceFactory implements Node.ServiceFactory {
       TABLESPACE pg_default;
 
       ALTER TABLE "${this.tableName}"
-        OWNER to postgres;
+        OWNER to ${this.configuration.username};
      `);
 
     return this.connection;

--- a/packages/postgresql-node-connector/src/index.ts
+++ b/packages/postgresql-node-connector/src/index.ts
@@ -36,7 +36,7 @@ export class PostgresServiceFactory implements Node.ServiceFactory {
   private connection: Connection;
 
   constructor(
-    readonly configuration: PostgresConnectionOptions,
+    readonly configuration: ConnectionOptions | PostgresServiceFactory,
     readonly tableName: string = "node_records"
   ) {
     this.connectionManager = new ConnectionManager();

--- a/packages/postgresql-node-connector/src/index.ts
+++ b/packages/postgresql-node-connector/src/index.ts
@@ -36,7 +36,7 @@ export class PostgresServiceFactory implements Node.ServiceFactory {
   private connection: Connection;
 
   constructor(
-    readonly configuration: ConnectionOptions | PostgresServiceFactory,
+    readonly configuration: ConnectionOptions | PostgresConnectionOptions,
     readonly tableName: string = "node_records"
   ) {
     this.connectionManager = new ConnectionManager();


### PR DESCRIPTION
### Description

The `node_records` table creation query had a line that sets the owner to a hard-coded "postgres".

I replaced "postgres" with the username provided by the configuration.

### Related issues

none

- [ ] Deploy preview is functional
^ idk what this means but this change fixed a bug while deploying `ConnextProject/indra-v2` so there's that