### PR TITLE
Remove outcomeType solidity function in favour of InstallParams field

### DIFF
--- a/packages/apps/contracts/ETHUnidirectionalTransferApp.sol
+++ b/packages/apps/contracts/ETHUnidirectionalTransferApp.sol
@@ -76,14 +76,6 @@ contract ETHUnidirectionalTransferApp is CounterfactualApp {
     return appState.finalized;
   }
 
-  function outcomeType()
-    external
-    pure
-    returns (uint256)
-  {
-    return uint256(Interpreter.OutcomeType.ETH_TRANSFER);
-  }
-
   function applyTransfer(
     AppState memory state,
     uint256 transferAmount,

--- a/packages/apps/contracts/HighRollerApp.sol
+++ b/packages/apps/contracts/HighRollerApp.sol
@@ -180,14 +180,6 @@ contract HighRollerApp is CounterfactualApp {
 
   }
 
-  function outcomeType()
-    external
-    pure
-    returns (uint256)
-  {
-    return uint256(Interpreter.OutcomeType.TWO_PARTY_FIXED_OUTCOME);
-  }
-
   function getWinningAmounts(uint256 num1, uint256 num2)
     internal
     pure

--- a/packages/apps/contracts/TicTacToeApp.sol
+++ b/packages/apps/contracts/TicTacToeApp.sol
@@ -52,14 +52,6 @@ contract TicTacToeApp is CounterfactualApp {
     WinClaim winClaim;
   }
 
-  function outcomeType()
-    external
-    pure
-    returns (uint256)
-  {
-    return uint256(Interpreter.OutcomeType.TWO_PARTY_FIXED_OUTCOME);
-  }
-
   function isStateTerminal(bytes calldata encodedState)
     external
     pure

--- a/packages/cf.js/src/app-factory.ts
+++ b/packages/cf.js/src/app-factory.ts
@@ -3,6 +3,7 @@ import {
   AppABIEncodings,
   AppInstanceID,
   Node,
+  OutcomeType,
   SolidityABIEncoderV2Type
 } from "@counterfactual/types";
 import { BigNumber, BigNumberish } from "ethers/utils";
@@ -65,6 +66,8 @@ export class AppFactory {
     timeout: BigNumberish;
     /** Initial state of app instance */
     initialState: SolidityABIEncoderV2Type;
+    /** The outcome type of the app instance */
+    outcomeType: OutcomeType;
   }): Promise<AppInstanceID> {
     const timeout = parseBigNumber(params.timeout, "timeout");
     const myDeposit = parseBigNumber(params.myDeposit, "myDeposit");
@@ -79,7 +82,8 @@ export class AppFactory {
         proposedToIdentifier: params.proposedToIdentifier,
         initialState: params.initialState,
         appDefinition: this.appDefinition,
-        abiEncodings: this.encodings
+        abiEncodings: this.encodings,
+        outcomeType: params.outcomeType
       }
     );
     const { appInstanceId } = response.result as Node.ProposeInstallResult;
@@ -121,7 +125,9 @@ export class AppFactory {
         initialState: params.initialState,
         intermediaries: params.intermediaries,
         appDefinition: this.appDefinition,
-        abiEncodings: this.encodings
+        abiEncodings: this.encodings,
+        // FIXME: Hard-coded temporarily
+        outcomeType: OutcomeType.TWO_PARTY_FIXED_OUTCOME
       }
     );
     const {

--- a/packages/cf.js/test/app-factory.spec.ts
+++ b/packages/cf.js/test/app-factory.spec.ts
@@ -1,4 +1,4 @@
-import { Node } from "@counterfactual/types";
+import { Node, OutcomeType } from "@counterfactual/types";
 import { parseEther } from "ethers/utils";
 
 import { AppFactory } from "../src/app-factory";
@@ -38,9 +38,12 @@ describe("CF.js AppFactory", () => {
         expect(request.methodName).toBe(
           jsonRpcMethodNames[Node.MethodName.PROPOSE_INSTALL]
         );
+
         const params = request.parameters as Node.ProposeInstallParams;
+
         expect(params.initialState).toBe(expectedState);
         expect(params.myDeposit).toEqual(expectedDeposit);
+
         nodeProvider.simulateMessageFromNode({
           jsonrpc: "2.0",
           result: {
@@ -52,13 +55,16 @@ describe("CF.js AppFactory", () => {
           id: request.id as number
         });
       });
+
       const appInstanceId = await appFactory.proposeInstall({
         proposedToIdentifier: TEST_XPUBS[0],
         peerDeposit: expectedDeposit,
         myDeposit: expectedDeposit,
         timeout: "100",
-        initialState: expectedState
+        initialState: expectedState,
+        outcomeType: OutcomeType.ETH_TRANSFER
       });
+
       expect(appInstanceId).toBe(expectedAppInstanceId);
     });
 
@@ -110,7 +116,8 @@ describe("CF.js AppFactory", () => {
           peerDeposit: parseEther("0.5"),
           myDeposit: "$%GARBAGE$%",
           timeout: "100",
-          initialState: { val: "4000" }
+          initialState: { val: "4000" },
+          outcomeType: OutcomeType.ETH_TRANSFER
         });
         done.fail("Expected an error for invalid myDeposit");
       } catch (e) {

--- a/packages/cf.js/test/provider.spec.ts
+++ b/packages/cf.js/test/provider.spec.ts
@@ -297,7 +297,9 @@ describe("CF.js Provider", () => {
   describe("AppInstance management", () => {
     it("can expose the same AppInstance instance for a unique app instance ID", async () => {
       expect.assertions(1);
+
       let savedInstance: AppInstance;
+
       provider.on(EventType.REJECT_INSTALL, e => {
         const eventInstance = (e.data as RejectInstallEventData).appInstance;
         if (!savedInstance) {
@@ -306,6 +308,7 @@ describe("CF.js Provider", () => {
           expect(savedInstance).toBe(eventInstance);
         }
       });
+
       const msg = {
         jsonrpc: "2.0",
         result: {
@@ -315,6 +318,7 @@ describe("CF.js Provider", () => {
           }
         }
       } as JsonRpcNotification;
+
       nodeProvider.simulateMessageFromNode(msg);
       nodeProvider.simulateMessageFromNode(msg);
     });

--- a/packages/contracts/contracts/default-apps/ETHBalanceRefundApp.sol
+++ b/packages/contracts/contracts/default-apps/ETHBalanceRefundApp.sol
@@ -28,12 +28,4 @@ contract ETHBalanceRefundApp {
     return abi.encode(ret);
   }
 
-  function outcomeType()
-    external
-    pure
-    returns (Interpreter.OutcomeType)
-  {
-    return Interpreter.OutcomeType.ETH_TRANSFER;
-  }
-
 }

--- a/packages/contracts/contracts/default-apps/ETHBucket.sol
+++ b/packages/contracts/contracts/default-apps/ETHBucket.sol
@@ -20,12 +20,4 @@ contract ETHBucket is CounterfactualApp {
     return abi.encode(abi.decode(encodedState, (AppState)).transfers);
   }
 
-  function outcomeType()
-    external
-    pure
-    returns (uint256)
-  {
-    return uint256(Interpreter.OutcomeType.ETH_TRANSFER);
-  }
-
 }

--- a/packages/contracts/contracts/interfaces/CounterfactualApp.sol
+++ b/packages/contracts/contracts/interfaces/CounterfactualApp.sol
@@ -36,13 +36,4 @@ contract CounterfactualApp {
     revert("The computeOutcome method has no implementation for this App");
   }
 
-  // a hack
-  function outcomeType()
-    external
-    pure
-    returns (uint256)
-  {
-    revert("The outcomeType method has no implementation for this App");
-  }
-
 }

--- a/packages/contracts/contracts/test-fixtures/AppWithAction.sol
+++ b/packages/contracts/contracts/test-fixtures/AppWithAction.sol
@@ -63,11 +63,4 @@ contract AppWithAction is CounterfactualApp {
     return false;
   }
 
-  function outcomeType()
-    external
-    pure
-    returns (uint256)
-  {
-    return uint256(Interpreter.OutcomeType.TWO_PARTY_FIXED_OUTCOME);
-  }
 }

--- a/packages/contracts/contracts/test-fixtures/FixedTwoPartyOutcomeApp.sol
+++ b/packages/contracts/contracts/test-fixtures/FixedTwoPartyOutcomeApp.sol
@@ -17,12 +17,4 @@ contract TwoPartyFixedOutcomeApp {
     );
   }
 
-  function outcomeType()
-    external
-    pure
-    returns (uint256)
-  {
-    return uint256(Interpreter.OutcomeType.TWO_PARTY_FIXED_OUTCOME);
-  }
-
 }

--- a/packages/node/src/machine/types.ts
+++ b/packages/node/src/machine/types.ts
@@ -1,6 +1,7 @@
 import {
   AppInterface,
   NetworkContext,
+  OutcomeType,
   SolidityABIEncoderV2Type
 } from "@counterfactual/types";
 import { BaseProvider } from "ethers/providers";
@@ -80,6 +81,7 @@ export type InstallParams = {
   initialState: SolidityABIEncoderV2Type;
   appInterface: AppInterface;
   defaultTimeout: number;
+  outcomeType: OutcomeType;
 };
 
 export type UninstallParams = {

--- a/packages/node/src/methods/app-instance/install/operation.ts
+++ b/packages/node/src/methods/app-instance/install/operation.ts
@@ -41,7 +41,8 @@ export async function install(
         ...appInstanceInfo.abiEncodings,
         addr: appInstanceInfo.appDefinition
       },
-      defaultTimeout: appInstanceInfo.timeout.toNumber()
+      defaultTimeout: appInstanceInfo.timeout.toNumber(),
+      outcomeType: appInstanceInfo.outcomeType
     }
   );
 

--- a/packages/node/src/methods/state-channel/deposit/operation.ts
+++ b/packages/node/src/methods/state-channel/deposit/operation.ts
@@ -1,4 +1,4 @@
-import { Node } from "@counterfactual/types";
+import { Node, OutcomeType } from "@counterfactual/types";
 import { Zero } from "ethers/constants";
 import { TransactionRequest, TransactionResponse } from "ethers/providers";
 import { BigNumber, bigNumberify } from "ethers/utils";
@@ -64,7 +64,8 @@ export async function installBalanceRefundApp(
         actionEncoding: undefined
       },
       // this is the block-time equivalent of 7 days
-      defaultTimeout: 1008
+      defaultTimeout: 1008,
+      outcomeType: OutcomeType.ETH_TRANSFER
     }
   );
 

--- a/packages/node/src/models/proposed-app-instance-info.ts
+++ b/packages/node/src/models/proposed-app-instance-info.ts
@@ -4,6 +4,7 @@ import {
   AppInstanceInfo,
   AppInterface,
   Bytes32,
+  OutcomeType,
   SolidityABIEncoderV2Type
 } from "@counterfactual/types";
 import { AddressZero } from "ethers/constants";
@@ -22,6 +23,7 @@ export interface IProposedAppInstanceInfo {
   proposedByIdentifier: string;
   proposedToIdentifier: string;
   intermediaries?: string[];
+  outcomeType: OutcomeType;
 }
 
 export interface ProposedAppInstanceInfoJSON {
@@ -35,6 +37,7 @@ export interface ProposedAppInstanceInfoJSON {
   proposedByIdentifier: string;
   proposedToIdentifier: string;
   intermediaries?: string[];
+  outcomeType: OutcomeType;
 }
 
 /**
@@ -58,6 +61,7 @@ export class ProposedAppInstanceInfo implements AppInstanceInfo {
   proposedByIdentifier: string;
   proposedToIdentifier: string;
   intermediaries?: string[];
+  outcomeType: OutcomeType;
 
   constructor(
     proposeParams: IProposedAppInstanceInfo,
@@ -73,6 +77,7 @@ export class ProposedAppInstanceInfo implements AppInstanceInfo {
     this.proposedToIdentifier = proposeParams.proposedToIdentifier;
     this.initialState = proposeParams.initialState;
     this.intermediaries = proposeParams.intermediaries;
+    this.outcomeType = proposeParams.outcomeType;
     this.id = overrideId || this.getIdentityHashFor(channel!);
   }
 
@@ -129,18 +134,19 @@ export class ProposedAppInstanceInfo implements AppInstanceInfo {
     return proposedAppInstance.identityHash;
   }
 
-  toJson() {
+  toJson(): ProposedAppInstanceInfoJSON {
     return {
       id: this.id,
       appDefinition: this.appDefinition,
       abiEncodings: this.abiEncodings,
-      myDeposit: this.myDeposit,
-      peerDeposit: this.peerDeposit,
+      myDeposit: this.myDeposit.toString(),
+      peerDeposit: this.peerDeposit.toString(),
       initialState: this.initialState,
-      timeout: this.timeout,
+      timeout: this.timeout.toString(),
       proposedByIdentifier: this.proposedByIdentifier,
       proposedToIdentifier: this.proposedToIdentifier,
-      intermediaries: this.intermediaries
+      intermediaries: this.intermediaries,
+      outcomeType: this.outcomeType
     };
   }
 
@@ -154,8 +160,10 @@ export class ProposedAppInstanceInfo implements AppInstanceInfo {
       initialState: json.initialState,
       proposedByIdentifier: json.proposedByIdentifier,
       proposedToIdentifier: json.proposedToIdentifier,
-      intermediaries: json.intermediaries
+      intermediaries: json.intermediaries,
+      outcomeType: json.outcomeType
     };
+
     return new ProposedAppInstanceInfo(proposeParams, undefined, json.id);
   }
 }

--- a/packages/node/src/protocol/install.ts
+++ b/packages/node/src/protocol/install.ts
@@ -1,6 +1,4 @@
-import CounterfactualApp from "@counterfactual/contracts/build/CounterfactualApp.json";
 import { NetworkContext, OutcomeType } from "@counterfactual/types";
-import { Contract } from "ethers";
 import { BigNumber, bigNumberify, defaultAbiCoder } from "ethers/utils";
 
 import { InstallCommitment } from "../ethereum";
@@ -97,27 +95,9 @@ async function proposeStateTransition(
     initialState,
     appInterface,
     defaultTimeout,
-    multisigAddress
+    multisigAddress,
+    outcomeType
   } = params as InstallParams;
-
-  const appDefinition = new Contract(
-    appInterface.addr,
-    CounterfactualApp.abi,
-    context.provider
-  );
-
-  let outcomeType: BigNumber;
-
-  try {
-    outcomeType = (await appDefinition.functions.outcomeType()) as BigNumber;
-  } catch (e) {
-    if (e.toString().indexOf("VM Exception") !== -1) {
-      throw new Error(
-        "The application logic contract being referenced in this installation request does not implement outcomeType()."
-      );
-    }
-    throw e;
-  }
 
   const stateChannel = context.stateChannelsMap.get(multisigAddress)!;
 
@@ -144,7 +124,7 @@ async function proposeStateTransition(
       }
     | undefined;
 
-  switch (outcomeType.toNumber()) {
+  switch (outcomeType) {
     case OutcomeType.ETH_TRANSFER: {
       ethTransferInterpreterParams = {
         limit: bigNumberify(initiatingBalanceDecrement).add(

--- a/packages/node/src/protocol/utils/get-outcome-increments.ts
+++ b/packages/node/src/protocol/utils/get-outcome-increments.ts
@@ -3,7 +3,7 @@ import { NetworkContext, OutcomeType } from "@counterfactual/types";
 import { Contract } from "ethers";
 import { One, Zero } from "ethers/constants";
 import { BaseProvider } from "ethers/providers";
-import { BigNumber, bigNumberify, defaultAbiCoder } from "ethers/utils";
+import { BigNumber, defaultAbiCoder } from "ethers/utils";
 
 import { StateChannel } from "../../models";
 
@@ -42,9 +42,15 @@ export async function computeFreeBalanceIncrements(
     appInstance.encodedLatestState
   );
 
-  const outcomeType = bigNumberify(
-    await appDefinition.functions.outcomeType()
-  ).toNumber();
+  // Temporary, better solution is to add outcomeType to AppInstance model
+  let outcomeType: OutcomeType | undefined;
+  if (typeof appInstance.ethTransferInterpreterParams !== "undefined") {
+    outcomeType = OutcomeType.ETH_TRANSFER;
+  } else if (
+    typeof appInstance.twoPartyOutcomeInterpreterParams !== "undefined"
+  ) {
+    outcomeType = OutcomeType.TWO_PARTY_FIXED_OUTCOME;
+  }
 
   switch (outcomeType) {
     case OutcomeType.ETH_TRANSFER: {

--- a/packages/node/test/integration/take-action.spec.ts
+++ b/packages/node/test/integration/take-action.spec.ts
@@ -1,7 +1,4 @@
-import {
-  Node as NodeTypes,
-  SolidityABIEncoderV2Type
-} from "@counterfactual/types";
+import { Node as NodeTypes } from "@counterfactual/types";
 import { bigNumberify } from "ethers/utils";
 
 import {
@@ -45,22 +42,21 @@ describe("Node method follows spec - takeAction", () => {
 
       it("can take action", async done => {
         await createChannel(nodeA, nodeB);
+
         const appInstanceId = await installTTTApp(nodeA, nodeB);
 
-        let newState: SolidityABIEncoderV2Type;
-
         nodeB.on(NODE_EVENTS.UPDATE_STATE, async (msg: UpdateStateMessage) => {
-          const getStateReq = generateGetStateRequest(msg.data.appInstanceId);
-
           const response = (await nodeB.router.dispatch(
-            getStateReq
+            generateGetStateRequest(msg.data.appInstanceId)
           )) as JsonRpcResponse;
 
-          const updatedState = (response.result as NodeTypes.GetStateResult)
-            .state;
-          expect(updatedState).toEqual(newState);
+          const { state } = response.result as NodeTypes.GetStateResult;
+
+          expect(state).toEqual(newState);
+
           done();
         });
+
         const takeActionReq = generateTakeActionRequest(
           appInstanceId,
           validAction
@@ -70,7 +66,7 @@ describe("Node method follows spec - takeAction", () => {
           takeActionReq
         )) as JsonRpcResponse;
 
-        newState = (response.result as NodeTypes.TakeActionResult).newState;
+        const { newState } = response.result as NodeTypes.TakeActionResult;
 
         expect(newState["board"][0][0]).toEqual(bigNumberify(1));
         expect(newState["turnNum"]).toEqual(bigNumberify(1));

--- a/packages/node/test/integration/utils.ts
+++ b/packages/node/test/integration/utils.ts
@@ -6,6 +6,7 @@ import {
   NetworkContext,
   networkContextProps,
   Node as NodeTypes,
+  OutcomeType,
   SolidityABIEncoderV2Type
 } from "@counterfactual/types";
 import { AddressZero, One, Zero } from "ethers/constants";
@@ -228,8 +229,10 @@ export function makeTTTProposalRequest(
       stateEncoding: tttStateEncoding,
       actionEncoding: tttActionEncoding
     } as AppABIEncodings,
-    timeout: One
+    timeout: One,
+    outcomeType: OutcomeType.TWO_PARTY_FIXED_OUTCOME
   };
+
   return jsonRpcDeserialize({
     params,
     id: Date.now(),
@@ -439,8 +442,6 @@ export async function installTTTApp(
       initialTTTState
     );
 
-    let appInstanceId: string;
-
     nodeB.on(NODE_EVENTS.PROPOSE_INSTALL, async (msg: ProposeMessage) => {
       confirmProposedAppInstanceOnNode(
         appInstanceInstallationProposalRequest.parameters,
@@ -467,8 +468,8 @@ export async function installTTTApp(
     const response = (await nodeA.router.dispatch(
       appInstanceInstallationProposalRequest
     )) as JsonRpcResponse;
-    appInstanceId = (response.result as NodeTypes.ProposeInstallResult)
-      .appInstanceId;
+
+    const { appInstanceId } = response.result as NodeTypes.ProposeInstallResult;
   });
 }
 

--- a/packages/node/test/machine/integration/protocols.spec.ts
+++ b/packages/node/test/machine/integration/protocols.spec.ts
@@ -1,5 +1,5 @@
 import AppWithAction from "@counterfactual/contracts/build/AppWithAction.json";
-import { NetworkContext } from "@counterfactual/types";
+import { NetworkContext, OutcomeType } from "@counterfactual/types";
 import { Contract, ContractFactory, Wallet } from "ethers";
 import { AddressZero, Zero } from "ethers/constants";
 import { JsonRpcProvider } from "ethers/providers";
@@ -53,6 +53,7 @@ describe("Three mininodes", () => {
       xkeyKthAddress(mininodeA.xpub, 1),
       xkeyKthAddress(mininodeB.xpub, 1)
     ]);
+
     await mininodeA.ie.runInstallProtocol(mininodeA.scm, {
       signingKeys,
       initiatingXpub: mininodeA.xpub,
@@ -71,10 +72,12 @@ describe("Three mininodes", () => {
           "tuple(address player1, address player2, uint256 counter)",
         actionEncoding: "tuple(uint256 increment)"
       },
-      defaultTimeout: 40
+      defaultTimeout: 40,
+      outcomeType: OutcomeType.TWO_PARTY_FIXED_OUTCOME
     });
 
     const appInstances = mininodeA.scm.get(AddressZero)!.appInstances;
+
     const [key] = [...appInstances.keys()].filter(key => {
       return (
         key !==

--- a/packages/node/test/unit/utils.ts
+++ b/packages/node/test/unit/utils.ts
@@ -1,5 +1,6 @@
 import {
   AppABIEncodings,
+  OutcomeType,
   SolidityABIEncoderV2Type
 } from "@counterfactual/types";
 import { Wallet } from "ethers";
@@ -33,7 +34,8 @@ export function createProposedAppInstanceInfo(appInstanceId: string) {
       initialState: {
         foo: AddressZero,
         bar: 0
-      } as SolidityABIEncoderV2Type
+      } as SolidityABIEncoderV2Type,
+      outcomeType: OutcomeType.ETH_TRANSFER
     },
     undefined,
     appInstanceId

--- a/packages/types/src/node.ts
+++ b/packages/types/src/node.ts
@@ -1,6 +1,7 @@
 import { BigNumber } from "ethers/utils";
 import { JsonRpcNotification, JsonRpcResponse, Rpc } from "rpc-server";
 
+import { OutcomeType } from ".";
 import { AppABIEncodings, AppInstanceInfo } from "./data-types";
 import { AppInstanceID, SolidityABIEncoderV2Type } from "./simple-types";
 
@@ -237,6 +238,7 @@ export namespace Node {
     timeout: BigNumber;
     initialState: SolidityABIEncoderV2Type;
     proposedToIdentifier: string;
+    outcomeType: OutcomeType;
   };
 
   export type ProposeInstallVirtualParams = ProposeInstallParams & {


### PR DESCRIPTION
This PR removes `outcomeType` as a mandatory field on `CounterfactualApp`.

Outstanding issues with the whole thing we will address in future PRs:
- Virtual apps still have a hard-coded requirement of `TwoPartyFixedOutcome`
- `interpreterAddress` and `interpreterParameters` are still hard-coded based on `outcomeType` in the `InstallParams`, but ought to be in the `InstallParams`