### PR TITLE
Create LibOutcome for code clarity

### DIFF
--- a/packages/apps/contracts/ETHUnidirectionalTransferApp.sol
+++ b/packages/apps/contracts/ETHUnidirectionalTransferApp.sol
@@ -1,12 +1,10 @@
 pragma solidity 0.5.9;
 pragma experimental "ABIEncoderV2";
 
-import "@counterfactual/contracts/contracts/interfaces/CounterfactualApp.sol";
-// solium-disable-next-line
-import "@counterfactual/contracts/contracts/interfaces/TwoPartyFixedOutcome.sol";
-import "@counterfactual/contracts/contracts/interfaces/Interpreter.sol";
-import "@counterfactual/contracts/contracts/interpreters/ETHInterpreter.sol";
 import "openzeppelin-solidity/contracts/math/SafeMath.sol";
+
+import "@counterfactual/contracts/contracts/interfaces/CounterfactualApp.sol";
+import "@counterfactual/contracts/contracts/libs/LibOutcome.sol";
 
 
 /// @title ETH Unidirectional Transfer App
@@ -15,9 +13,10 @@ import "openzeppelin-solidity/contracts/math/SafeMath.sol";
 contract ETHUnidirectionalTransferApp is CounterfactualApp {
 
   using SafeMath for uint256;
+  using LibOutcome for LibOutcome.TwoPartyFixedOutcome;
 
   struct AppState {
-    ETHInterpreter.ETHTransfer[] transfers; // [sender, receiver]
+    LibOutcome.ETHTransfer[] transfers; // [sender, receiver]
     bool finalized;
   }
 

--- a/packages/apps/contracts/HighRollerApp.sol
+++ b/packages/apps/contracts/HighRollerApp.sol
@@ -2,9 +2,7 @@ pragma solidity 0.5.9;
 pragma experimental "ABIEncoderV2";
 
 import "@counterfactual/contracts/contracts/interfaces/CounterfactualApp.sol";
-import "@counterfactual/contracts/contracts/interfaces/Interpreter.sol";
-// solium-disable-next-line max-len
-import "@counterfactual/contracts/contracts/interfaces/TwoPartyFixedOutcome.sol";
+import "@counterfactual/contracts/contracts/libs/LibOutcome.sol";
 
 
 /// @title High Roller App
@@ -14,6 +12,8 @@ import "@counterfactual/contracts/contracts/interfaces/TwoPartyFixedOutcome.sol"
 /// @dev This contract is an example of a dApp built to run on
 ///      the CounterFactual framework
 contract HighRollerApp is CounterfactualApp {
+
+  using LibOutcome for LibOutcome.TwoPartyFixedOutcome;
 
   enum ActionType {
     COMMIT_TO_HASH,
@@ -152,22 +152,22 @@ contract HighRollerApp is CounterfactualApp {
 
     // If P1 goes offline...
     if (appState.stage == Stage.WAITING_FOR_P1_COMMITMENT) {
-      return abi.encode(TwoPartyFixedOutcome.Outcome.SEND_TO_ADDR_TWO);
+      return abi.encode(LibOutcome.TwoPartyFixedOutcome.SEND_TO_ADDR_TWO);
     }
 
     // If P2 goes offline...
     if (appState.stage == Stage.P1_COMMITTED_TO_HASH) {
-      return abi.encode(TwoPartyFixedOutcome.Outcome.SEND_TO_ADDR_ONE);
+      return abi.encode(LibOutcome.TwoPartyFixedOutcome.SEND_TO_ADDR_ONE);
     }
 
     // If P1 goes offline...
     if (appState.stage == Stage.P2_COMMITTED_TO_NUM) {
-      return abi.encode(TwoPartyFixedOutcome.Outcome.SEND_TO_ADDR_TWO);
+      return abi.encode(LibOutcome.TwoPartyFixedOutcome.SEND_TO_ADDR_TWO);
     }
 
     // If P1 tried to cheat...
     if (appState.stage == Stage.P1_TRIED_TO_SUBMIT_ZERO) {
-      return abi.encode(TwoPartyFixedOutcome.Outcome.SEND_TO_ADDR_TWO);
+      return abi.encode(LibOutcome.TwoPartyFixedOutcome.SEND_TO_ADDR_TWO);
     }
 
     // Co-operative case
@@ -183,19 +183,19 @@ contract HighRollerApp is CounterfactualApp {
   function getWinningAmounts(uint256 num1, uint256 num2)
     internal
     pure
-    returns (TwoPartyFixedOutcome.Outcome)
+    returns (LibOutcome.TwoPartyFixedOutcome)
   {
     bytes32 randomSalt = calculateRandomSalt(num1, num2);
 
     (uint8 playerFirstTotal, uint8 playerSecondTotal) = highRoller(randomSalt);
 
     if (playerFirstTotal > playerSecondTotal)
-      return TwoPartyFixedOutcome.Outcome.SEND_TO_ADDR_ONE;
+      return LibOutcome.TwoPartyFixedOutcome.SEND_TO_ADDR_ONE;
 
     if (playerFirstTotal < playerSecondTotal)
-      return TwoPartyFixedOutcome.Outcome.SEND_TO_ADDR_TWO;
+      return LibOutcome.TwoPartyFixedOutcome.SEND_TO_ADDR_TWO;
 
-    return TwoPartyFixedOutcome.Outcome.SPLIT_AND_SEND_TO_BOTH_ADDRS;
+    return LibOutcome.TwoPartyFixedOutcome.SPLIT_AND_SEND_TO_BOTH_ADDRS;
 
   }
 

--- a/packages/apps/contracts/NimApp.sol
+++ b/packages/apps/contracts/NimApp.sol
@@ -2,8 +2,7 @@ pragma solidity 0.5.9;
 pragma experimental "ABIEncoderV2";
 
 import "@counterfactual/contracts/contracts/interfaces/CounterfactualApp.sol";
-// solium-disable-next-line
-import "@counterfactual/contracts/contracts/interfaces/TwoPartyFixedOutcome.sol";
+import "@counterfactual/contracts/contracts/libs/LibOutcome.sol";
 
 
 /*
@@ -11,6 +10,8 @@ Normal-form Nim
 https://en.wikipedia.org/wiki/Nim
 */
 contract NimApp is CounterfactualApp {
+
+  using LibOutcome for LibOutcome.TwoPartyFixedOutcome;
 
   struct Action {
     uint256 pileIdx;
@@ -75,9 +76,9 @@ contract NimApp is CounterfactualApp {
     AppState memory state = abi.decode(encodedState, (AppState));
 
     if (state.turnNum % 2 == 0) {
-      return abi.encode(TwoPartyFixedOutcome.Outcome.SEND_TO_ADDR_ONE);
+      return abi.encode(LibOutcome.TwoPartyFixedOutcome.SEND_TO_ADDR_ONE);
     } else {
-      return abi.encode(TwoPartyFixedOutcome.Outcome.SEND_TO_ADDR_TWO);
+      return abi.encode(LibOutcome.TwoPartyFixedOutcome.SEND_TO_ADDR_TWO);
     }
   }
 

--- a/packages/apps/contracts/TicTacToeApp.sol
+++ b/packages/apps/contracts/TicTacToeApp.sol
@@ -1,13 +1,13 @@
 pragma solidity 0.5.9;
 pragma experimental "ABIEncoderV2";
 
-import "@counterfactual/contracts/contracts/interfaces/Interpreter.sol";
 import "@counterfactual/contracts/contracts/interfaces/CounterfactualApp.sol";
-// solium-disable-next-line max-len
-import "@counterfactual/contracts/contracts/interfaces/TwoPartyFixedOutcome.sol";
+import "@counterfactual/contracts/contracts/libs/LibOutcome.sol";
 
 
 contract TicTacToeApp is CounterfactualApp {
+
+  using LibOutcome for LibOutcome.TwoPartyFixedOutcome;
 
   enum ActionType {
     PLAY,
@@ -114,16 +114,16 @@ contract TicTacToeApp is CounterfactualApp {
     AppState memory state = abi.decode(encodedState, (AppState));
 
     if (state.winner == 2) {
-      return abi.encode(TwoPartyFixedOutcome.Outcome.SEND_TO_ADDR_TWO);
+      return abi.encode(LibOutcome.TwoPartyFixedOutcome.SEND_TO_ADDR_TWO);
     } else if (state.winner == 1) {
-      return abi.encode(TwoPartyFixedOutcome.Outcome.SEND_TO_ADDR_ONE);
+      return abi.encode(LibOutcome.TwoPartyFixedOutcome.SEND_TO_ADDR_ONE);
     } else if (state.winner == GAME_DRAWN) {
-      return abi.encode(TwoPartyFixedOutcome.Outcome.SPLIT_AND_SEND_TO_BOTH_ADDRS);
+      return abi.encode(LibOutcome.TwoPartyFixedOutcome.SPLIT_AND_SEND_TO_BOTH_ADDRS);
     } else {
       if (state.turnNum % 2 == 0) {
-        return abi.encode(TwoPartyFixedOutcome.Outcome.SEND_TO_ADDR_ONE);
+        return abi.encode(LibOutcome.TwoPartyFixedOutcome.SEND_TO_ADDR_ONE);
       } else if (state.turnNum % 2 == 1) {
-        return abi.encode(TwoPartyFixedOutcome.Outcome.SEND_TO_ADDR_TWO);
+        return abi.encode(LibOutcome.TwoPartyFixedOutcome.SEND_TO_ADDR_TWO);
       }
     }
   }

--- a/packages/contracts/contracts/default-apps/ETHBalanceRefundApp.sol
+++ b/packages/contracts/contracts/default-apps/ETHBalanceRefundApp.sol
@@ -1,10 +1,12 @@
 pragma solidity 0.5.9;
 pragma experimental "ABIEncoderV2";
 
-import "../interpreters/ETHInterpreter.sol";
+import "../libs/LibOutcome.sol";
 
 
 contract ETHBalanceRefundApp {
+
+  using LibOutcome for LibOutcome.ETHTransfer;
 
   struct AppState {
     address recipient;
@@ -19,8 +21,7 @@ contract ETHBalanceRefundApp {
   {
     AppState memory appState = abi.decode(encodedState, (AppState));
 
-    ETHInterpreter.ETHTransfer[] memory ret = new
-      ETHInterpreter.ETHTransfer[](1);
+    LibOutcome.ETHTransfer[] memory ret = new LibOutcome.ETHTransfer[](1);
 
     ret[0].amount = address(appState.multisig).balance - appState.threshold;
     ret[0].to = appState.recipient;

--- a/packages/contracts/contracts/default-apps/ETHBucket.sol
+++ b/packages/contracts/contracts/default-apps/ETHBucket.sol
@@ -2,14 +2,15 @@ pragma solidity 0.5.9;
 pragma experimental "ABIEncoderV2";
 
 import "../interfaces/CounterfactualApp.sol";
-import "../interfaces/Interpreter.sol";
-import "../interpreters/ETHInterpreter.sol";
+import "../libs/LibOutcome.sol";
 
 
 contract ETHBucket is CounterfactualApp {
 
+  using LibOutcome for LibOutcome.ETHTransfer;
+
   struct AppState {
-    ETHInterpreter.ETHTransfer[] transfers;
+    LibOutcome.ETHTransfer[] transfers;
   }
 
   function computeOutcome(bytes calldata encodedState)

--- a/packages/contracts/contracts/interfaces/Interpreter.sol
+++ b/packages/contracts/contracts/interfaces/Interpreter.sol
@@ -4,12 +4,6 @@ pragma experimental "ABIEncoderV2";
 
 contract Interpreter {
 
-  enum OutcomeType {
-    TWO_PARTY_FIXED_OUTCOME,
-    TWO_PARTY_DYNAMIC_OUTCOME,
-    ETH_TRANSFER
-  }
-
   function interpretOutcomeAndExecuteEffect(
     bytes calldata,
     bytes calldata

--- a/packages/contracts/contracts/interpreters/ETHInterpreter.sol
+++ b/packages/contracts/contracts/interpreters/ETHInterpreter.sol
@@ -2,6 +2,7 @@ pragma solidity 0.5.9;
 pragma experimental "ABIEncoderV2";
 
 import "../interfaces/Interpreter.sol";
+import "../libs/LibOutcome.sol";
 
 /**
  * This file is excluded from ethlint/solium because of this issue:
@@ -9,10 +10,7 @@ import "../interfaces/Interpreter.sol";
  */
 contract ETHInterpreter is Interpreter {
 
-  struct ETHTransfer {
-    address to;
-    uint256 amount;
-  }
+  using LibOutcome for LibOutcome.ETHTransfer;
 
   struct Param {
     uint256 limit;
@@ -25,7 +23,9 @@ contract ETHInterpreter is Interpreter {
     external
   {
 
-    ETHTransfer[] memory transfers = abi.decode(input, (ETHTransfer[]));
+    LibOutcome.ETHTransfer[] memory transfers = abi.decode(
+      input, (LibOutcome.ETHTransfer[])
+    );
 
     uint256 limitRemaining = abi.decode(params, (Param)).limit;
 

--- a/packages/contracts/contracts/interpreters/TwoPartyEthAsLump.sol
+++ b/packages/contracts/contracts/interpreters/TwoPartyEthAsLump.sol
@@ -2,10 +2,12 @@ pragma solidity 0.5.9;
 pragma experimental "ABIEncoderV2";
 
 import "../interfaces/Interpreter.sol";
-import "../interfaces/TwoPartyFixedOutcome.sol";
+import "../libs/LibOutcome.sol";
 
 
 contract TwoPartyEthAsLump is Interpreter {
+
+  using LibOutcome for LibOutcome.TwoPartyFixedOutcome;
 
   struct Params {
     address payable[2] playerAddrs;
@@ -21,15 +23,15 @@ contract TwoPartyEthAsLump is Interpreter {
 
     Params memory params = abi.decode(encodedParams, (Params));
 
-    TwoPartyFixedOutcome.Outcome outcome = abi.decode(
+    LibOutcome.TwoPartyFixedOutcome outcome = abi.decode(
       encodedOutcome,
-      (TwoPartyFixedOutcome.Outcome)
+      (LibOutcome.TwoPartyFixedOutcome)
     );
 
-    if (outcome == TwoPartyFixedOutcome.Outcome.SEND_TO_ADDR_ONE) {
+    if (outcome == LibOutcome.TwoPartyFixedOutcome.SEND_TO_ADDR_ONE) {
       params.playerAddrs[0].transfer(params.amount);
       return;
-    } else if (outcome == TwoPartyFixedOutcome.Outcome.SEND_TO_ADDR_TWO) {
+    } else if (outcome == LibOutcome.TwoPartyFixedOutcome.SEND_TO_ADDR_TWO) {
       params.playerAddrs[1].transfer(params.amount);
       return;
     }

--- a/packages/contracts/contracts/libs/LibOutcome.sol
+++ b/packages/contracts/contracts/libs/LibOutcome.sol
@@ -1,12 +1,15 @@
 pragma solidity 0.5.9;
 pragma experimental "ABIEncoderV2";
 
-import "../interfaces/Interpreter.sol";
 
+library LibOutcome {
 
-contract TwoPartyFixedOutcome {
+  struct ETHTransfer {
+    address to;
+    uint256 amount;
+  }
 
-  enum Outcome {
+  enum TwoPartyFixedOutcome {
     SEND_TO_ADDR_ONE,
     SEND_TO_ADDR_TWO,
     SPLIT_AND_SEND_TO_BOTH_ADDRS

--- a/packages/contracts/contracts/test-fixtures/AppWithAction.sol
+++ b/packages/contracts/contracts/test-fixtures/AppWithAction.sol
@@ -2,13 +2,14 @@ pragma solidity 0.5.9;
 pragma experimental "ABIEncoderV2";
 
 import "../interfaces/CounterfactualApp.sol";
-import "../interfaces/Interpreter.sol";
-import "../interfaces/TwoPartyFixedOutcome.sol";
+import "../libs/LibOutcome.sol";
 
 // there is a counter; player2 can unanimously increment it
 
 
 contract AppWithAction is CounterfactualApp {
+
+  using LibOutcome for LibOutcome.TwoPartyFixedOutcome;
 
   struct State {
     address player1;
@@ -36,7 +37,7 @@ contract AppWithAction is CounterfactualApp {
     pure
     returns (bytes memory)
   {
-    return abi.encode(TwoPartyFixedOutcome.Outcome.SEND_TO_ADDR_ONE);
+    return abi.encode(LibOutcome.TwoPartyFixedOutcome.SEND_TO_ADDR_ONE);
   }
 
   function applyAction(

--- a/packages/contracts/contracts/test-fixtures/FixedTwoPartyOutcomeApp.sol
+++ b/packages/contracts/contracts/test-fixtures/FixedTwoPartyOutcomeApp.sol
@@ -2,10 +2,12 @@ pragma solidity 0.5.9;
 pragma experimental "ABIEncoderV2";
 
 import "../interfaces/Interpreter.sol";
-import "../interfaces/TwoPartyFixedOutcome.sol";
+import "../libs/LibOutcome.sol";
 
 
 contract TwoPartyFixedOutcomeApp {
+
+  using LibOutcome for LibOutcome.TwoPartyFixedOutcome;
 
   function computeOutcome(bytes calldata)
     external
@@ -13,7 +15,7 @@ contract TwoPartyFixedOutcomeApp {
     returns (bytes memory)
   {
     return abi.encode(
-      TwoPartyFixedOutcome.Outcome.SPLIT_AND_SEND_TO_BOTH_ADDRS
+      LibOutcome.TwoPartyFixedOutcome.SPLIT_AND_SEND_TO_BOTH_ADDRS
     );
   }
 


### PR DESCRIPTION
Outcome type is a very different concept than Interpreter but the data structure definitions for common outcome types was very coupled to the contract code and namespace of interpreters. This explicitly de-couples them.