### PR TITLE
[Playground] Fix ethFreeBalanceWei was using incorrect var

### DIFF
--- a/packages/playground/src/components/account/account-exchange/account-exchange.tsx
+++ b/packages/playground/src/components/account/account-exchange/account-exchange.tsx
@@ -184,7 +184,7 @@ export class AccountExchange {
             loading={this.isDepositPending ? true : false}
             provideFaucetLink={true}
             error={this.depositError}
-            available={ethers.utils.bigNumberify(this.ethWeb3WalletBalance)}
+            available={ethers.utils.bigNumberify(ethWeb3WalletBalance)}
             min={0.1}
             max={1}
           />

--- a/packages/playground/src/components/account/account-exchange/account-exchange.tsx
+++ b/packages/playground/src/components/account/account-exchange/account-exchange.tsx
@@ -184,7 +184,7 @@ export class AccountExchange {
             loading={this.isDepositPending ? true : false}
             provideFaucetLink={true}
             error={this.depositError}
-            available={ethers.utils.bigNumberify(ethWeb3WalletBalance)}
+            available={ethers.utils.bigNumberify(ethFreeBalanceWei)}
             min={0.1}
             max={1}
           />

--- a/packages/playground/src/components/account/account-exchange/account-exchange.tsx
+++ b/packages/playground/src/components/account/account-exchange/account-exchange.tsx
@@ -184,7 +184,7 @@ export class AccountExchange {
             loading={this.isDepositPending ? true : false}
             provideFaucetLink={true}
             error={this.depositError}
-            available={ethers.utils.bigNumberify(ethFreeBalanceWei)}
+            available={ethers.utils.bigNumberify(this.ethWeb3WalletBalance)}
             min={0.1}
             max={1}
           />
@@ -200,7 +200,7 @@ export class AccountExchange {
             disabled={this.isWithdrawalPending ? true : false}
             loading={this.isWithdrawalPending ? true : false}
             error={this.withdrawalError}
-            available={ethers.utils.bigNumberify(this.ethFreeBalanceWei)}
+            available={ethers.utils.bigNumberify(ethFreeBalanceWei)}
             min={0}
             max={Number(ethers.utils.formatEther(ethFreeBalanceWei))}
           />


### PR DESCRIPTION
### Description

`this.ethFreeBalanceWei` could be undefined here.
That is why there is `const ethFreeBalanceWei = this.ethFreeBalanceWei || Zero;` above.

It seems the exchange page was broken for a while :)

### Related issues

Caused by: #1369 

- [ ] Deploy preview is functional
