### PR TITLE
[Hotfix] Serve only High Roller in Production Playground

### DIFF
--- a/packages/playground-server/package.json
+++ b/packages/playground-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@counterfactual/playground-server",
-  "version": "0.1.12",
+  "version": "0.1.13",
   "description": "A backend for the Playground app.",
   "author": "Counterfactual",
   "homepage": "https://github.com/counterfactual/monorepo",

--- a/packages/playground-server/registry.json
+++ b/packages/playground-server/registry.json
@@ -8,23 +8,9 @@
       },
       "attributes": {
         "name": "High Roller",
-        "url": "https://high-roller-staging.counterfactual.com",
+        "url": "https://high-roller-production.counterfactual.com",
         "slug": "high-roller",
         "icon": "assets/images/logo.png"
-      },
-      "relationships": {}
-    },
-    {
-      "type": "app",
-      "id": {
-        "3": "0xe40b051B8c3697D2cB0527c1d2405D26BE595DeC",
-        "42": "0x3d9CbDd5e869638ca8A114289E42aeE8d0966B5b"
-      },
-      "attributes": {
-        "name": "Tic Tac Toe",
-        "url": "https://tic-tac-toe-staging.netlify.com",
-        "slug": "tic-tac-toe",
-        "icon": "images/logo.png"
       },
       "relationships": {}
     }

--- a/packages/playground-server/registry.json
+++ b/packages/playground-server/registry.json
@@ -27,5 +27,6 @@
         "icon": "images/logo.png"	
       },	
       "relationships": {}
+    }
   ]
 }

--- a/packages/playground-server/registry.json
+++ b/packages/playground-server/registry.json
@@ -22,7 +22,7 @@
       },
       "attributes": {
         "name": "Tic Tac Toe",
-        "url": "https://tic-tac-toe-production.counterfactual.com",
+        "url": "https://sad-franklin-d7df00.netlify.com",
         "slug": "tic-tac-toe",
         "icon": "images/logo.png"
       },

--- a/packages/playground-server/registry.json
+++ b/packages/playground-server/registry.json
@@ -13,6 +13,19 @@
         "icon": "assets/images/logo.png"
       },
       "relationships": {}
-    }
+    },
+    {	
+      "type": "app",	
+      "id": {	
+        "3": "0xe40b051B8c3697D2cB0527c1d2405D26BE595DeC",	
+        "42": "0x3d9CbDd5e869638ca8A114289E42aeE8d0966B5b"	
+      },	
+      "attributes": {	
+        "name": "Tic Tac Toe",	
+        "url": "https://tic-tac-toe-production.counterfactual.com",	
+        "slug": "tic-tac-toe",	
+        "icon": "images/logo.png"	
+      },	
+      "relationships": {}
   ]
 }

--- a/packages/playground-server/registry.json
+++ b/packages/playground-server/registry.json
@@ -14,18 +14,18 @@
       },
       "relationships": {}
     },
-    {	
-      "type": "app",	
-      "id": {	
-        "3": "0xe40b051B8c3697D2cB0527c1d2405D26BE595DeC",	
-        "42": "0x3d9CbDd5e869638ca8A114289E42aeE8d0966B5b"	
-      },	
-      "attributes": {	
-        "name": "Tic Tac Toe",	
-        "url": "https://tic-tac-toe-production.counterfactual.com",	
-        "slug": "tic-tac-toe",	
-        "icon": "images/logo.png"	
-      },	
+    {
+      "type": "app",
+      "id": {
+        "3": "0xe40b051B8c3697D2cB0527c1d2405D26BE595DeC",
+        "42": "0x3d9CbDd5e869638ca8A114289E42aeE8d0966B5b"
+      },
+      "attributes": {
+        "name": "Tic Tac Toe",
+        "url": "https://tic-tac-toe-production.counterfactual.com",
+        "slug": "tic-tac-toe",
+        "icon": "images/logo.png"
+      },
       "relationships": {}
     }
   ]


### PR DESCRIPTION
The Playground Server registry is pointing to `*-staging` subdomains for the dApps, which are highly unstable due to most recent refactors and changes to the Node, making `playground.counterfactual.com` a bit useless, since no games can be played.

This PR removes TTT from the apps list, since we do not have a frozen version of it, and points High Roller to the production version.