### PR TITLE
make MAppCaller a library

### DIFF
--- a/packages/contracts/contracts/libs/LibAppCaller.sol
+++ b/packages/contracts/contracts/libs/LibAppCaller.sol
@@ -4,10 +4,10 @@ pragma experimental "ABIEncoderV2";
 import "../interfaces/CounterfactualApp.sol";
 
 
-/// @title MAppCaller
+/// @title LibAppCaller
 /// @author Liam Horne - <liam@l4v.io>
-/// @notice A mixin for the ChallengeRegistry to make staticcalls to Apps
-contract MAppCaller {
+/// @notice A library for the ChallengeRegistry to make staticcalls to Apps
+contract LibAppCaller {
 
   /// @notice A helper method to check if the state of an application is terminal or not
   /// @param appDefinition An address of an app definition to call

--- a/packages/contracts/contracts/mixins/MixinRespondToChallenge.sol
+++ b/packages/contracts/contracts/mixins/MixinRespondToChallenge.sol
@@ -3,16 +3,16 @@ pragma experimental "ABIEncoderV2";
 
 import "../libs/LibSignature.sol";
 import "../libs/LibStateChannelApp.sol";
+import "../libs/LibAppCaller.sol";
 
 import "./MChallengeRegistryCore.sol";
-import "./MAppCaller.sol";
 
 
 contract MixinRespondToChallenge is
   LibSignature,
   LibStateChannelApp,
-  MChallengeRegistryCore,
-  MAppCaller
+  LibAppCaller,
+  MChallengeRegistryCore
 {
 
   /// @notice Respond to a challenge with a valid action

--- a/packages/contracts/contracts/mixins/MixinSetOutcome.sol
+++ b/packages/contracts/contracts/mixins/MixinSetOutcome.sol
@@ -2,15 +2,15 @@ pragma solidity 0.5.10;
 pragma experimental "ABIEncoderV2";
 
 import "../libs/LibStateChannelApp.sol";
+import "../libs/LibAppCaller.sol";
 
 import "./MChallengeRegistryCore.sol";
-import "./MAppCaller.sol";
 
 
 contract MixinSetOutcome is
   LibStateChannelApp,
-  MChallengeRegistryCore,
-  MAppCaller
+  LibAppCaller,
+  MChallengeRegistryCore
 {
 
   /// @notice Fetch and store the outcome of a state channel application
@@ -38,7 +38,7 @@ contract MixinSetOutcome is
       "setOutcome called with incorrect witness data of finalState"
     );
 
-    appOutcomes[identityHash] = MAppCaller.computeOutcome(
+    appOutcomes[identityHash] = LibAppCaller.computeOutcome(
       appIdentity.appDefinition,
       finalState
     );

--- a/packages/contracts/contracts/mixins/MixinSetStateWithAction.sol
+++ b/packages/contracts/contracts/mixins/MixinSetStateWithAction.sol
@@ -3,16 +3,15 @@ pragma experimental "ABIEncoderV2";
 
 import "../libs/LibStateChannelApp.sol";
 import "../libs/LibSignature.sol";
+import "../libs/LibAppCaller.sol";
 
 import "./MChallengeRegistryCore.sol";
-import "./MAppCaller.sol";
-
 
 contract MixinSetStateWithAction is
   LibSignature,
   LibStateChannelApp,
-  MChallengeRegistryCore,
-  MAppCaller
+  LibAppCaller,
+  MChallengeRegistryCore
 {
 
   struct SignedAppChallengeUpdateWithAppState {
@@ -73,7 +72,7 @@ contract MixinSetStateWithAction is
       "setStateWithAction called with action signed by incorrect turn taker"
     );
 
-    bytes memory newState = MAppCaller.applyAction(
+    bytes memory newState = LibAppCaller.applyAction(
       appIdentity.appDefinition,
       req.appState,
       action.encodedAction
@@ -81,7 +80,7 @@ contract MixinSetStateWithAction is
 
     if (action.checkForTerminal) {
       require(
-        MAppCaller.isStateTerminal(appIdentity.appDefinition, newState),
+        LibAppCaller.isStateTerminal(appIdentity.appDefinition, newState),
         "Attempted to claim non-terminal state was terminal in setStateWithAction"
       );
       challenge.finalizesAt = block.number;
@@ -125,7 +124,7 @@ contract MixinSetStateWithAction is
     pure
     returns (bool)
   {
-    address turnTaker = MAppCaller.getTurnTaker(
+    address turnTaker = LibAppCaller.getTurnTaker(
       appDefinition,
       signingKeys,
       req.appState

--- a/packages/contracts/contracts/mixins/MixinVirtualAppSetState.sol
+++ b/packages/contracts/contracts/mixins/MixinVirtualAppSetState.sol
@@ -3,16 +3,16 @@ pragma experimental "ABIEncoderV2";
 
 import "../libs/LibStateChannelApp.sol";
 import "../libs/LibSignature.sol";
+import "../libs/LibAppCaller.sol";
 
 import "./MChallengeRegistryCore.sol";
-import "./MAppCaller.sol";
 
 
 contract MixinVirtualAppSetState is
   LibSignature,
   LibStateChannelApp,
-  MChallengeRegistryCore,
-  MAppCaller
+  LibAppCaller,
+  MChallengeRegistryCore
 {
 
   /// signatures[0], instead of signing a message that authorizes


### PR DESCRIPTION
Since this piece of code does not use any storage from the challenge registry, it should be a library