### PR TITLE
[monorepo] cleanup related to virtualAppSetState

### DIFF
--- a/packages/contracts/contracts/mixins/MixinSetStateWithAction.sol
+++ b/packages/contracts/contracts/mixins/MixinSetStateWithAction.sol
@@ -7,6 +7,7 @@ import "../libs/LibAppCaller.sol";
 
 import "./MChallengeRegistryCore.sol";
 
+
 contract MixinSetStateWithAction is
   LibSignature,
   LibStateChannelApp,

--- a/packages/contracts/contracts/mixins/MixinVirtualAppSetState.sol
+++ b/packages/contracts/contracts/mixins/MixinVirtualAppSetState.sol
@@ -52,12 +52,12 @@ contract MixinVirtualAppSetState is
 
     require(
       req.versionNumber > challenge.versionNumber,
-      "Tried to call setState with an outdated versionNumber version"
+      "Tried to call virtualAppSetState with an outdated versionNumber version"
     );
 
     require(
       req.versionNumber < req.versionNumberExpiry,
-      "Tried to call setState with versionNumber greater than intermediary versionNumber expiry");
+      "Tried to call virtualAppSetState with versionNumber greater than intermediary versionNumber expiry");
 
     challenge.status = req.timeout > 0 ?
       ChallengeStatus.CHALLENGE_IS_OPEN :

--- a/packages/node/src/ethereum/virtual-app-set-state-commitment.ts
+++ b/packages/node/src/ethereum/virtual-app-set-state-commitment.ts
@@ -26,7 +26,7 @@ export class VirtualAppSetStateCommitment extends EthereumCommitment {
     // todo(xuanji): the following two are set to null for intermediary. This
     // is bad API design and should be fixed eventually.
     public readonly hashedSolidityABIEncoderV2Struct?: string,
-    public readonly appversionNumber?: BigNumberish
+    public readonly appVersionNumber?: BigNumberish
   ) {
     super();
   }
@@ -55,7 +55,7 @@ export class VirtualAppSetStateCommitment extends EthereumCommitment {
         [
           "0x19",
           appIdentityToHash(this.appIdentity),
-          this.appversionNumber!,
+          this.appVersionNumber!,
           this.timeout,
           this.hashedSolidityABIEncoderV2Struct
         ]
@@ -88,7 +88,7 @@ export class VirtualAppSetStateCommitment extends EthereumCommitment {
   ): any {
     return {
       appStateHash: this.hashedSolidityABIEncoderV2Struct!,
-      versionNumber: this.appversionNumber!,
+      versionNumber: this.appVersionNumber!,
       timeout: this.timeout,
       signatures: signaturesToBytes(
         intermediarySignature,

--- a/packages/node/test/machine/integration/virtual-app-set-state-commitment.spec.ts
+++ b/packages/node/test/machine/integration/virtual-app-set-state-commitment.spec.ts
@@ -1,10 +1,17 @@
 import ChallengeRegistry from "@counterfactual/contracts/build/ChallengeRegistry.json";
 import { NetworkContext } from "@counterfactual/types";
 import * as chai from "chai";
+import { randomBytes } from "crypto";
 import * as matchers from "ethereum-waffle/dist/matchers/matchers";
 import { Contract, Wallet } from "ethers";
 import { AddressZero, MaxUint256, WeiPerEther, Zero } from "ethers/constants";
-import { Signature, SigningKey, getAddress, hexlify, bigNumberify } from "ethers/utils";
+import {
+  bigNumberify,
+  getAddress,
+  hexlify,
+  Signature,
+  SigningKey
+} from "ethers/utils";
 
 import { VirtualAppSetStateCommitment } from "../../../src/ethereum/virtual-app-set-state-commitment";
 import { xkeysToSortedKthSigningKeys } from "../../../src/machine";
@@ -13,7 +20,6 @@ import { AppInstance, StateChannel } from "../../../src/models";
 import { toBeEq } from "./bignumber-jest-matcher";
 import { connectToGanache } from "./connect-ganache";
 import { getRandomHDNodes } from "./random-signing-keys";
-import { randomBytes } from "crypto";
 
 // The ChallengeRegistry.setState call _could_ be estimated but we haven't
 // written this test to do that yet

--- a/packages/node/test/unit/utils.ts
+++ b/packages/node/test/unit/utils.ts
@@ -63,13 +63,13 @@ export function createAppInstance(stateChannel?: StateChannel) {
     /* appSeqNo */ stateChannel
       ? stateChannel.numInstalledApps
       : Math.ceil(1000 * Math.random()),
-    { foo: AddressZero, bar: bigNumberify(0) },
-    0,
-    Math.ceil(1000 * Math.random()),
-    {
+    /* latestState */ { foo: AddressZero, bar: bigNumberify(0) },
+    /* latestversionNumber */ 0,
+    /* latestTimeout */ Math.ceil(1000 * Math.random()),
+    /* twoPartyOutcomeInterpreterParams */ {
       playerAddrs: [AddressZero, AddressZero],
       amount: Zero
     },
-    undefined
+    /* coinTransferInterpreterParams */ undefined
   );
 }


### PR DESCRIPTION
- fix some revert messages in solidity
- use proper case for `appversionNumber` 
- make the target app instance in the integration test not use the free balance app state