### PR TITLE
[contracts] make free balance not uninstallable

### DIFF
--- a/packages/contracts/contracts/ConditionalTransactionDelegateTarget.sol
+++ b/packages/contracts/contracts/ConditionalTransactionDelegateTarget.sol
@@ -8,8 +8,39 @@ import "./ChallengeRegistry.sol";
 /// @title ConditionalTransactionDelegateTarget
 /// @author Liam Horne - <liam@l4v.io>
 /// @author Mitchell Van Der Hoeff - <mitchell@l4v.io>
-/// @notice Supports a complex transfer of funds contingent on some condition.
 contract ConditionalTransactionDelegateTarget {
+
+  function executeEffectOfFreeBalance(
+    ChallengeRegistry appRegistry,
+    bytes32 freeBalanceAppIdentityHash,
+    address ethInterpreterAddress
+  )
+    public
+  {
+    require(
+      appRegistry.isStateFinalized(freeBalanceAppIdentityHash),
+      "App is not finalized yet"
+    );
+
+    bytes memory outcome = appRegistry.getOutcome(
+      freeBalanceAppIdentityHash
+    );
+
+    uint256 max_uint = 2**256-1;
+
+    bytes memory payload = abi.encodeWithSignature(
+      "interpretOutcomeAndExecuteEffect(bytes,bytes)", outcome, abi.encode(max_uint)
+    );
+
+    // solium-disable-next-line no-unused-vars
+    (bool success, bytes memory returnData) = ethInterpreterAddress
+      .delegatecall(payload);
+
+    require(
+      success,
+      "Execution of executeEffectOfInterpretedAppOutcome failed"
+    );
+  }
 
   /// @notice Execute a fund transfer for a state channel app in a finalized state
   /// @param uninstallKey The key in the uninstall key registry

--- a/packages/contracts/contracts/ConditionalTransactionDelegateTarget.sol
+++ b/packages/contracts/contracts/ConditionalTransactionDelegateTarget.sol
@@ -19,7 +19,7 @@ contract ConditionalTransactionDelegateTarget {
   {
     require(
       appRegistry.isStateFinalized(freeBalanceAppIdentityHash),
-      "App is not finalized yet"
+      "Free Balance app instance is not finalized yet"
     );
 
     bytes memory outcome = appRegistry.getOutcome(
@@ -38,7 +38,7 @@ contract ConditionalTransactionDelegateTarget {
 
     require(
       success,
-      "Execution of executeEffectOfInterpretedAppOutcome failed"
+      "Execution of executeEffectOfFreeBalance failed"
     );
   }
 

--- a/packages/node/src/ethereum/setup-commitment.ts
+++ b/packages/node/src/ethereum/setup-commitment.ts
@@ -1,12 +1,6 @@
 import ConditionalTransactionDelegateTarget from "@counterfactual/contracts/build/ConditionalTransactionDelegateTarget.json";
 import { AppIdentity, NetworkContext } from "@counterfactual/types";
-import { MaxUint256 } from "ethers/constants";
-import {
-  defaultAbiCoder,
-  Interface,
-  keccak256,
-  solidityPack
-} from "ethers/utils";
+import { Interface } from "ethers/utils";
 
 import { MultisigCommitment } from "./multisig-commitment";
 import { MultisigOperation, MultisigTransaction } from "./types";
@@ -28,29 +22,12 @@ export class SetupCommitment extends MultisigCommitment {
     return {
       to: this.networkContext.ConditionalTransactionDelegateTarget,
       value: 0,
-      data: iface.functions.executeEffectOfInterpretedAppOutcome.encode([
+      data: iface.functions.executeEffectOfFreeBalance.encode([
         this.networkContext.ChallengeRegistry,
-        this.networkContext.UninstallKeyRegistry,
-        this.getUninstallKeyForUninstallKeyRegistry(),
         appIdentityToHash(this.freeBalanceAppIdentity),
-        this.networkContext.ETHInterpreter,
-        defaultAbiCoder.encode(["uint256"], [MaxUint256])
+        this.networkContext.ETHInterpreter
       ]),
       operation: MultisigOperation.DelegateCall
     };
-  }
-
-  private getUninstallKeyForUninstallKeyRegistry(): string {
-    return keccak256(
-      solidityPack(
-        ["address", "bytes32"],
-        [this.multisigAddress, this.getSaltForDependencyNonce()]
-      )
-    );
-  }
-
-  private getSaltForDependencyNonce(): string {
-    // We use 0 here because the ETH free balance has always the 0th appSeqNo
-    return keccak256(defaultAbiCoder.encode(["uint256"], [0]));
   }
 }

--- a/packages/node/test/machine/unit/ethereum/setup-commitment.spec.ts
+++ b/packages/node/test/machine/unit/ethereum/setup-commitment.spec.ts
@@ -67,25 +67,17 @@ describe("SetupCommitment", () => {
       desc = iface.parseTransaction({ data });
     });
 
-    it("should be to the executeEffectOfInterpretedAppOutcome method", () => {
+    it("should be to the executeEffectOfFreeBalance method", () => {
       expect(desc.sighash).toBe(
-        iface.functions.executeEffectOfInterpretedAppOutcome.sighash
+        iface.functions.executeEffectOfFreeBalance.sighash
       );
     });
 
     it("should contain expected arguments", () => {
-      const [
-        appRegistry,
-        uninstallKeyRegistry,
-        uninstallKey,
-        appIdentityHash,
-        {},
-        {}
-      ] = desc.args;
+      const [appRegistry, appIdentityHash, interpreterAddress] = desc.args;
       expect(appRegistry).toBe(networkContext.ChallengeRegistry);
-      expect(uninstallKeyRegistry).toEqual(networkContext.UninstallKeyRegistry);
-      expect(uninstallKey).toBe(freeBalanceETH.uninstallKey);
       expect(appIdentityHash).toBe(appIdentityToHash(freeBalanceETH.identity));
+      expect(interpreterAddress).toBe(networkContext.ETHInterpreter);
     });
   });
 });


### PR DESCRIPTION
This PR makes the free balance app instance permanently installed. It does this by adding a `executeEffectOfFreeBalance` delegate target which is similar to `executeEffectOfInterpretedAppOutcome` but without uninstall key and with the limit parameter specialized.

Motivation: This is part of work to make the active apps dispute mechanism go through the free balance app instance. The full set of contract changes (without client changes) to do this can be seen at https://github.com/counterfactual/monorepo/pull/1774 .