### PR TITLE
update node to use types 0.0.17

### DIFF
--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -52,7 +52,7 @@
     "@counterfactual/cf.js": "0.2.1",
     "@counterfactual/contracts": "0.1.3",
     "@counterfactual/firebase-client": "0.0.3",
-    "@counterfactual/types": "0.0.16",
+    "@counterfactual/types": "0.0.17",
     "ethers": "4.0.32",
     "eventemitter3": "^4.0.0",
     "loglevel": "^1.6.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -924,6 +924,11 @@
   resolved "https://registry.yarnpkg.com/@counterfactual/types/-/types-0.0.13.tgz#d523f272158adffce4c8ab51403d9a1b5addf5af"
   integrity sha512-mG4mLvWwJu1/SunpJQtgZBRYtvXPRcLP/MbSbkweahcEtRBZQmPjNKhTTaDzBNFlmzm7nqDuDCPBC7vwx9qBWg==
 
+"@counterfactual/types@0.0.17":
+  version "0.0.17"
+  resolved "https://registry.yarnpkg.com/@counterfactual/types/-/types-0.0.17.tgz#a697f79138d55638fa40e48e71b56878f53d7f63"
+  integrity sha512-kLRE+fTLz4t5zUzKLM/UYc/+5TBS4pS546kEyExoLM3yKYC+THfU5y/ISTJZChANyiR96fSwIW+rB8f0HJQZaQ==
+
 "@csstools/convert-colors@^1.4.0":
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/@csstools/convert-colors/-/convert-colors-1.4.0.tgz#ad495dc41b12e75d588c6db8b9834f08fa131eb7"


### PR DESCRIPTION
## Description

The latest version of the node is using an old version of the NetworkContext type which declares depreciated contract names like `RootNonceRegistry` and `StateChannelTransaction`.

I've bumped the node's type to use 0.0.17 instead.

Everything builds properly after the version bump and most tests pass. The ones that don't pass seem to need postgres running locally (?!) because they fail w error: `connect ECONNREFUSED 127.0.0.1:5432` but I see no docs on how to config the expected postgres db so not gonna dig too deep into these issues

### Related issues

[Link here any issues relevant to this PR, using the GitHub `fixes/resolves/closes` keywords to close related issues automatically.]

- [ ] Deploy preview is functional
