### PR TITLE
[node] introduce initiateProtocol

### DIFF
--- a/packages/node/src/events/install/controller.ts
+++ b/packages/node/src/events/install/controller.ts
@@ -8,12 +8,9 @@ import { InstallMessage } from "../../types";
  *
  * NOTE: The following code is mostly just a copy of the code from the
  *       methods/intall/operations.ts::install method with the exception
- *       of the lack of a runInstallProtocol call. This is because this is
+ *       of the lack of a initiateProtocol<Protocol.Install> call. This is because this is
  *       the counterparty end of the install protocol which runs _after_
  *       the _runProtocolWithMessage_ call finishes and saves the result.
- *
- *       Future iterations of this code will simply be a middleware hook on
- *       the _STATE TRANSITION COMMIT_ opcode.
  */
 export default async function installEventController(
   requestHandler: RequestHandler,

--- a/packages/node/src/methods/app-instance/install-virtual/operation.ts
+++ b/packages/node/src/methods/app-instance/install-virtual/operation.ts
@@ -1,6 +1,6 @@
 import { AppInstanceInfo, Node } from "@counterfactual/types";
 
-import { InstructionExecutor } from "../../../machine";
+import { InstructionExecutor, Protocol } from "../../../machine";
 import { StateChannel } from "../../../models";
 import { CONVENTION_FOR_ETH_TOKEN_ADDRESS } from "../../../models/free-balance";
 import { Store } from "../../../store";
@@ -25,7 +25,8 @@ export async function installVirtual(
   let updatedStateChannelsMap: Map<string, StateChannel>;
 
   try {
-    updatedStateChannelsMap = await instructionExecutor.runInstallVirtualAppProtocol(
+    updatedStateChannelsMap = await instructionExecutor.initiateProtocol(
+      Protocol.InstallVirtualApp,
       new Map(Object.entries(await store.getAllChannels())),
       {
         initiatingXpub: appInstanceInfo.proposedToIdentifier,

--- a/packages/node/src/methods/app-instance/install/operation.ts
+++ b/packages/node/src/methods/app-instance/install/operation.ts
@@ -1,6 +1,6 @@
 import { Node } from "@counterfactual/types";
 
-import { InstructionExecutor } from "../../../machine";
+import { InstructionExecutor, Protocol } from "../../../machine";
 import { ProposedAppInstanceInfo, StateChannel } from "../../../models";
 import { CONVENTION_FOR_ETH_TOKEN_ADDRESS } from "../../../models/free-balance";
 import { Store } from "../../../store";
@@ -21,7 +21,8 @@ export async function install(
 
   const stateChannel = await store.getChannelFromAppInstanceID(appInstanceId);
 
-  const stateChannelsMap = await instructionExecutor.runInstallProtocol(
+  const stateChannelsMap = await instructionExecutor.initiateProtocol(
+    Protocol.Install,
     new Map<string, StateChannel>([
       // TODO: (architectural decision) Should this use `getAllChannels` or
       //       is this good enough? InstallProtocol only operates on a single

--- a/packages/node/src/methods/app-instance/take-action/controller.ts
+++ b/packages/node/src/methods/app-instance/take-action/controller.ts
@@ -3,7 +3,7 @@ import { INVALID_ARGUMENT } from "ethers/errors";
 import Queue from "p-queue";
 import { jsonRpcMethod } from "rpc-server";
 
-import { InstructionExecutor } from "../../../machine";
+import { InstructionExecutor, Protocol } from "../../../machine";
 import { StateChannel } from "../../../models";
 import { RequestHandler } from "../../../request-handler";
 import { Store } from "../../../store";
@@ -120,7 +120,8 @@ async function runTakeActionProtocol(
   let stateChannelsMap: Map<string, StateChannel>;
 
   try {
-    stateChannelsMap = await instructionExecutor.runTakeActionProtocol(
+    stateChannelsMap = await instructionExecutor.initiateProtocol(
+      Protocol.TakeAction,
       new Map<string, StateChannel>([
         [stateChannel.multisigAddress, stateChannel]
       ]),

--- a/packages/node/src/methods/app-instance/uninstall-virtual/operation.ts
+++ b/packages/node/src/methods/app-instance/uninstall-virtual/operation.ts
@@ -1,4 +1,4 @@
-import { InstructionExecutor } from "../../../machine";
+import { InstructionExecutor, Protocol } from "../../../machine";
 import { Store } from "../../../store";
 
 export async function uninstallAppInstanceFromChannel(
@@ -15,7 +15,8 @@ export async function uninstallAppInstanceFromChannel(
 
   const currentChannels = new Map(Object.entries(await store.getAllChannels()));
 
-  const stateChannelsMap = await instructionExecutor.runUninstallVirtualAppProtocol(
+  const stateChannelsMap = await instructionExecutor.initiateProtocol(
+    Protocol.UninstallVirtualApp,
     currentChannels,
     {
       initiatingXpub,

--- a/packages/node/src/methods/app-instance/uninstall/operation.ts
+++ b/packages/node/src/methods/app-instance/uninstall/operation.ts
@@ -1,4 +1,4 @@
-import { InstructionExecutor } from "../../../machine";
+import { InstructionExecutor, Protocol } from "../../../machine";
 import { StateChannel } from "../../../models";
 import { Store } from "../../../store";
 
@@ -13,7 +13,8 @@ export async function uninstallAppInstanceFromChannel(
 
   const appInstance = stateChannel.getAppInstance(appInstanceId);
 
-  const stateChannelsMap = await instructionExecutor.runUninstallProtocol(
+  const stateChannelsMap = await instructionExecutor.initiateProtocol(
+    Protocol.Uninstall,
     new Map(Object.entries(await store.getAllChannels())),
     {
       initiatingXpub,

--- a/packages/node/src/methods/app-instance/update-state/controller.ts
+++ b/packages/node/src/methods/app-instance/update-state/controller.ts
@@ -2,7 +2,7 @@ import { Node, SolidityABIEncoderV2Type } from "@counterfactual/types";
 import { INVALID_ARGUMENT } from "ethers/errors";
 import Queue from "p-queue";
 
-import { InstructionExecutor } from "../../../machine";
+import { InstructionExecutor, Protocol } from "../../../machine";
 import { StateChannel } from "../../../models";
 import { RequestHandler } from "../../../request-handler";
 import { Store } from "../../../store";
@@ -91,7 +91,8 @@ async function runUpdateStateProtocol(
 ) {
   const stateChannel = await store.getChannelFromAppInstanceID(appIdentityHash);
 
-  const stateChannelsMap = await instructionExecutor.runUpdateProtocol(
+  const stateChannelsMap = await instructionExecutor.initiateProtocol(
+    Protocol.Update,
     new Map<string, StateChannel>([
       [stateChannel.multisigAddress, stateChannel]
     ]),

--- a/packages/node/src/methods/state-channel/deposit/operation.ts
+++ b/packages/node/src/methods/state-channel/deposit/operation.ts
@@ -16,7 +16,7 @@ import {
 } from "ethers/providers";
 import { bigNumberify } from "ethers/utils";
 
-import { InstallParams, xkeyKthAddress } from "../../../machine";
+import { InstallParams, Protocol, xkeyKthAddress } from "../../../machine";
 import { StateChannel } from "../../../models";
 import { CONVENTION_FOR_ETH_TOKEN_ADDRESS } from "../../../models/free-balance";
 import { RequestHandler } from "../../../request-handler";
@@ -78,7 +78,8 @@ export async function installBalanceRefundApp(
     tokenAddress: tokenAddress! // params object is mutated in caller
   };
 
-  const updatedStateChannelsMap = await instructionExecutor.runInstallProtocol(
+  const updatedStateChannelsMap = await instructionExecutor.initiateProtocol(
+    Protocol.Install,
     stateChannelsMap,
     installParams
   );
@@ -168,7 +169,8 @@ export async function uninstallBalanceRefundApp(
 
   const refundApp = stateChannel.getAppInstanceOfKind(CoinBalanceRefundApp);
 
-  const stateChannelsMap = await instructionExecutor.runUninstallProtocol(
+  const stateChannelsMap = await instructionExecutor.initiateProtocol(
+    Protocol.Uninstall,
     // https://github.com/counterfactual/monorepo/issues/747
     new Map<string, StateChannel>([
       [stateChannel.multisigAddress, stateChannel]

--- a/packages/node/src/methods/state-channel/withdraw/operation.ts
+++ b/packages/node/src/methods/state-channel/withdraw/operation.ts
@@ -1,5 +1,6 @@
 import { Node } from "@counterfactual/types";
 
+import { Protocol } from "../../../machine";
 import { CONVENTION_FOR_ETH_TOKEN_ADDRESS } from "../../../models/free-balance";
 import { RequestHandler } from "../../../request-handler";
 import { getPeersAddressFromChannel } from "../../../utils";
@@ -21,8 +22,9 @@ export async function runWithdrawProtocol(
 
   const stateChannel = await store.getStateChannel(multisigAddress);
 
-  const stateChannelsMap = await instructionExecutor.runWithdrawProtocol(
-    stateChannel,
+  const stateChannelsMap = await instructionExecutor.initiateProtocol(
+    Protocol.Withdraw,
+    new Map([[stateChannel.multisigAddress, stateChannel]]),
     {
       amount,
       tokenAddress,

--- a/packages/node/test/machine/integration/install-then-set-state.spec.ts
+++ b/packages/node/test/machine/integration/install-then-set-state.spec.ts
@@ -45,6 +45,7 @@ let appRegistry: Contract;
 expect.extend({ toBeEq });
 
 beforeAll(async () => {
+  jest.setTimeout(10000);
   [provider, wallet, {}] = await connectToGanache();
 
   network = global["networkContext"];

--- a/packages/node/test/machine/integration/protocols.spec.ts
+++ b/packages/node/test/machine/integration/protocols.spec.ts
@@ -7,6 +7,7 @@ import { bigNumberify } from "ethers/utils";
 
 import {
   computeUniqueIdentifierForStateChannelThatWrapsVirtualApp,
+  Protocol,
   xkeyKthAddress
 } from "../../../src/machine";
 import { sortAddresses } from "../../../src/machine/xkeys";
@@ -76,7 +77,7 @@ describe("Three mininodes", () => {
       xkeyKthAddress(mininodeB.xpub, 1)
     ]);
 
-    await mininodeA.ie.runInstallProtocol(mininodeA.scm, {
+    await mininodeA.ie.initiateProtocol(Protocol.Install, mininodeA.scm, {
       signingKeys,
       initiatingXpub: mininodeA.xpub,
       respondingXpub: mininodeB.xpub,
@@ -102,7 +103,7 @@ describe("Three mininodes", () => {
       return key !== mininodeA.scm.get(multisigAB)!.freeBalance.identityHash;
     });
 
-    await mininodeA.ie.runUninstallProtocol(mininodeA.scm, {
+    await mininodeA.ie.initiateProtocol(Protocol.Uninstall, mininodeA.scm, {
       appIdentityHash: key,
       initiatingXpub: mininodeA.xpub,
       respondingXpub: mininodeB.xpub,
@@ -126,23 +127,48 @@ describe("Three mininodes", () => {
     expect(mininodeB.scm.size).toBe(2);
     expect(mininodeC.scm.size).toBe(1);
 
-    await mininodeA.ie.runInstallVirtualAppProtocol(mininodeA.scm, {
-      initiatingXpub: mininodeA.xpub,
-      intermediaryXpub: mininodeB.xpub,
-      respondingXpub: mininodeC.xpub,
-      defaultTimeout: 100,
-      appInterface: {
-        addr: appDefinition.address,
-        stateEncoding: "tuple(uint256 counter)",
-        actionEncoding: "tuple(uint8 actionType, uint256 increment)"
-      },
-      initialState: {
-        counter: 0
-      },
-      initiatingBalanceDecrement: bigNumberify(0),
-      respondingBalanceDecrement: bigNumberify(0),
-      tokenAddress: CONVENTION_FOR_ETH_TOKEN_ADDRESS
-    });
+    await mininodeA.ie.initiateProtocol(
+      Protocol.InstallVirtualApp,
+      mininodeA.scm,
+      {
+        initiatingXpub: mininodeA.xpub,
+        intermediaryXpub: mininodeB.xpub,
+        respondingXpub: mininodeC.xpub,
+        defaultTimeout: 100,
+        appInterface: {
+          addr: appDefinition.address,
+          stateEncoding: "tuple(uint256 counter)",
+          actionEncoding: "tuple(uint8 actionType, uint256 increment)"
+        },
+        initialState: {
+          counter: 0
+        },
+        initiatingBalanceDecrement: bigNumberify(0),
+        respondingBalanceDecrement: bigNumberify(0),
+        tokenAddress: CONVENTION_FOR_ETH_TOKEN_ADDRESS
+      }
+    );
+    await mininodeA.ie.initiateProtocol(
+      Protocol.InstallVirtualApp,
+      mininodeA.scm,
+      {
+        initiatingXpub: mininodeA.xpub,
+        intermediaryXpub: mininodeB.xpub,
+        respondingXpub: mininodeC.xpub,
+        defaultTimeout: 100,
+        appInterface: {
+          addr: appDefinition.address,
+          stateEncoding: "tuple(uint256 counter)",
+          actionEncoding: "tuple(uint8 actionType, uint256 increment)"
+        },
+        initialState: {
+          counter: 0
+        },
+        initiatingBalanceDecrement: bigNumberify(0),
+        respondingBalanceDecrement: bigNumberify(0),
+        tokenAddress: CONVENTION_FOR_ETH_TOKEN_ADDRESS
+      }
+    );
 
     expect(mininodeA.scm.size).toBe(2);
 
@@ -159,7 +185,7 @@ describe("Three mininodes", () => {
 
     expect(appInstance.isVirtualApp);
 
-    await mininodeA.ie.runUpdateProtocol(mininodeA.scm, {
+    await mininodeA.ie.initiateProtocol(Protocol.Update, mininodeA.scm, {
       initiatingXpub: mininodeA.xpub,
       respondingXpub: mininodeC.xpub,
       multisigAddress: unqiueIdentifierForStateChannelWrappingVirtualApp,
@@ -169,7 +195,7 @@ describe("Three mininodes", () => {
       }
     });
 
-    await mininodeA.ie.runTakeActionProtocol(mininodeA.scm, {
+    await mininodeA.ie.initiateProtocol(Protocol.TakeAction, mininodeA.scm, {
       initiatingXpub: mininodeA.xpub,
       respondingXpub: mininodeC.xpub,
       multisigAddress: unqiueIdentifierForStateChannelWrappingVirtualApp,
@@ -180,14 +206,18 @@ describe("Three mininodes", () => {
       }
     });
 
-    await mininodeA.ie.runUninstallVirtualAppProtocol(mininodeA.scm, {
-      initiatingXpub: mininodeA.xpub,
-      intermediaryXpub: mininodeB.xpub,
-      respondingXpub: mininodeC.xpub,
-      targetAppIdentityHash: appInstance.identityHash,
-      targetAppState: {
-        counter: 2
+    await mininodeA.ie.initiateProtocol(
+      Protocol.UninstallVirtualApp,
+      mininodeA.scm,
+      {
+        initiatingXpub: mininodeA.xpub,
+        intermediaryXpub: mininodeB.xpub,
+        respondingXpub: mininodeC.xpub,
+        targetAppIdentityHash: appInstance.identityHash,
+        targetAppState: {
+          counter: 2
+        }
       }
-    });
+    );
   });
 });

--- a/packages/node/test/machine/integration/virtual-app-install.spec.ts
+++ b/packages/node/test/machine/integration/virtual-app-install.spec.ts
@@ -60,6 +60,7 @@ let appRegistry: Contract;
 expect.extend({ toBeEq });
 
 beforeAll(async () => {
+  jest.setTimeout(10000);
   [provider, wallet, {}] = await connectToGanache();
 
   network = global["networkContext"];

--- a/packages/node/test/unit/install.spec.ts
+++ b/packages/node/test/unit/install.spec.ts
@@ -12,6 +12,7 @@ import {
 } from "../../src";
 import {
   InstructionExecutor,
+  Protocol,
   xkeysToSortedKthAddresses
 } from "../../src/machine";
 import { install } from "../../src/methods/app-instance/install/operation";
@@ -131,7 +132,11 @@ describe("Can handle correct & incorrect installs", () => {
     // and just returns a basic <string, StateChannel> map with the
     // expected multisigAddress in it.
     when(
-      mockedInstructionExecutor.runInstallProtocol(anything(), anything())
+      mockedInstructionExecutor.initiateProtocol(
+        Protocol.Install,
+        anything(),
+        anything()
+      )
     ).thenResolve(new Map([[multisigAddress, stateChannel]]));
 
     // The AppInstanceInfo that's returned is the one that was installed, which


### PR DESCRIPTION
This PR introduces an `initiateProtocol` function that replaces the `run<ProtocolName>Protocol` functions, except for the `runSetupProtocol` function. `initiateProtocol` takes an additional argument specifying the protocol, and ensures that the params argument correspond to the protocol argument.