### PR TITLE
[node] Update protocol message handling to queue on different topics

### DIFF
--- a/packages/chain/package.json
+++ b/packages/chain/package.json
@@ -10,7 +10,7 @@
   },
   "scripts": {
     "build": "tsc -b .",
-    "build:contracts": "cd ../contracts && yarn build && cd - && tsc -b . && rollup -c",
+    "build:contracts": "cd ../contracts && yarn build && cd - && tsc -b .",
     "test": "jest --setupFiles dotenv-extended/config --runInBand --bail --forceExit",
     "test:coverage": "jest --runInBand --detectOpenHandles --bail --coverage",
     "lint:fix": "tslint -c tslint.json -p . --fix",

--- a/packages/node/src/utils.ts
+++ b/packages/node/src/utils.ts
@@ -16,7 +16,7 @@ import { NO_CHANNEL_BETWEEN_NODES } from "./methods/errors";
 import { StateChannel } from "./models";
 import { Store } from "./store";
 
-export function hashOfOrderedPublicIdentifiers(addresses: Address[]): string {
+export function hashOfOrderedPublicIdentifiers(addresses: string[]): string {
   return hashMessage(addresses.sort().join(""));
 }
 


### PR DESCRIPTION
This replaces a global queue topic `instructionExecutorCoreQueue` with topics relevant to the protocol being executed.