### PR TITLE
[contracts,node] Support virtual apps with CoinTransfer outcome type and single asset funding

### DIFF
--- a/packages/contracts/contracts/interpreters/CoinTransferFromVirtualAppInterpreter.sol
+++ b/packages/contracts/contracts/interpreters/CoinTransferFromVirtualAppInterpreter.sol
@@ -1,0 +1,59 @@
+pragma solidity 0.5.10;
+pragma experimental "ABIEncoderV2";
+
+import "openzeppelin-solidity/contracts/token/ERC20/ERC20.sol";
+
+import "../interfaces/Interpreter.sol";
+import "../libs/LibOutcome.sol";
+
+
+/// @notice 
+/// 
+/// Interprets a finalized AppInstance whose outcome is of type
+/// CoinTransfer. While CoinTransfer outcome contains `to` and `coinAddress`
+/// fields, those fields are *ignored* by this interpreter. Only the `amount`
+/// field is used.
+
+contract CoinTransferFromVirtualAppInterpreter is Interpreter {
+
+  struct Agreement {
+    uint256 capitalProvided;
+    uint256 expiryBlock;
+    address payable[2] beneficiaries;
+    address tokenAddress;
+  }
+
+  function interpretOutcomeAndExecuteEffect(
+    bytes calldata encodedOutcome,
+    bytes calldata params
+  )
+    external
+  {
+    LibOutcome.CoinTransfer memory outcome = abi.decode(
+      encodedOutcome,
+      (LibOutcome.CoinTransfer)
+    );
+
+    Agreement memory agreement = abi.decode(
+      params,
+      (Agreement)
+    );
+
+    require(
+      block.number < agreement.expiryBlock,
+      "Virtual App agreement has expired and is no longer valid."
+    );
+
+    ERC20(agreement.coinAddress).transfer(
+      agreement.beneficiaries[0],
+      outcome.amount
+    );
+    
+    ERC20(agreement.coinAddress).transfer(
+      agreement.beneficiaries[1],
+      agreement.capitalProvided - outcome.amount
+    ); 
+
+  }
+
+}

--- a/packages/node/jest.config.js
+++ b/packages/node/jest.config.js
@@ -32,6 +32,6 @@ module.exports = {
   "transform": {
     "^.+\\.tsx?$": "ts-jest"
   },
-  "verbose": false,
+  "verbose": true,
   "extraGlobals": ["Math"]
 }

--- a/packages/node/src/machine/types.ts
+++ b/packages/node/src/machine/types.ts
@@ -104,6 +104,9 @@ export type InstallVirtualAppParams = {
   initiatorBalanceDecrement: BigNumber;
   responderBalanceDecrement: BigNumber;
   tokenAddress: string;
+
+  // outcomeType returned by the app instance, as defined by the app definition `appInterface`
+  outcomeType: OutcomeType;
 };
 
 export type UninstallVirtualAppParams = {

--- a/packages/node/src/methods/app-instance/install-virtual/operation.ts
+++ b/packages/node/src/methods/app-instance/install-virtual/operation.ts
@@ -1,4 +1,4 @@
-import { AppInstanceProposal, Node } from "@counterfactual/types";
+import { AppInstanceProposal, Node, OutcomeType } from "@counterfactual/types";
 
 import { InstructionExecutor, Protocol } from "../../../machine";
 import { StateChannel } from "../../../models";
@@ -40,7 +40,9 @@ export async function installVirtual(
         initialState: proposal.initialState,
         initiatorBalanceDecrement: proposal.initiatorDeposit,
         responderBalanceDecrement: proposal.responderDeposit,
-        tokenAddress: CONVENTION_FOR_ETH_TOKEN_ADDRESS
+        tokenAddress: CONVENTION_FOR_ETH_TOKEN_ADDRESS,
+        // todo(xuanji): switch statement
+        outcomeType: OutcomeType.TWO_PARTY_FIXED_OUTCOME
       }
     );
   } catch (e) {

--- a/packages/node/test/machine/integration/protocols.spec.ts
+++ b/packages/node/test/machine/integration/protocols.spec.ts
@@ -146,7 +146,8 @@ describe("Three mininodes", () => {
         },
         initiatorBalanceDecrement: bigNumberify(0),
         responderBalanceDecrement: bigNumberify(0),
-        tokenAddress: CONVENTION_FOR_ETH_TOKEN_ADDRESS
+        tokenAddress: CONVENTION_FOR_ETH_TOKEN_ADDRESS,
+        outcomeType: OutcomeType.TWO_PARTY_FIXED_OUTCOME
       }
     );
     await mininodeA.ie.initiateProtocol(
@@ -167,7 +168,8 @@ describe("Three mininodes", () => {
         },
         initiatorBalanceDecrement: bigNumberify(0),
         responderBalanceDecrement: bigNumberify(0),
-        tokenAddress: CONVENTION_FOR_ETH_TOKEN_ADDRESS
+        tokenAddress: CONVENTION_FOR_ETH_TOKEN_ADDRESS,
+        outcomeType: OutcomeType.TWO_PARTY_FIXED_OUTCOME
       }
     );
 


### PR DESCRIPTION
This PR adds contract and client support for virtual apps with CoinTransfer outcome type and single asset ERC20 or ETH funding.