### PR TITLE
[contracts] remove CoinTransferParams

### DIFF
--- a/packages/contracts/contracts/ConditionalTransactionDelegateTarget.sol
+++ b/packages/contracts/contracts/ConditionalTransactionDelegateTarget.sol
@@ -3,6 +3,7 @@ pragma experimental "ABIEncoderV2";
 
 import "./ChallengeRegistry.sol";
 import "./libs/LibOutcome.sol";
+import "./interpreters/CoinTransferETHInterpreter.sol";
 
 
 /// @title ConditionalTransactionDelegateTarget
@@ -11,11 +12,6 @@ contract ConditionalTransactionDelegateTarget {
 
   address constant CONVENTION_FOR_ETH_TOKEN_ADDRESS = address(0x0);
   uint256 constant MAX_UINT256 = 2 ** 256 - 1;
-
-  struct CoinTransferParams {
-    uint256 limit;
-    address tokenAddress;
-  }
 
   struct FreeBalanceAppState {
     address[] tokens;
@@ -47,7 +43,7 @@ contract ConditionalTransactionDelegateTarget {
       "interpretOutcomeAndExecuteEffect(bytes,bytes)",
       abi.encode(outcome),
       abi.encode(
-        CoinTransferParams(
+        CoinTransferETHInterpreter.Params(
           // This is the `limit` param, which for the case of the
           // FreeBalance is set to the max amount.
           MAX_UINT256,


### PR DESCRIPTION
This PR replaces the `CoinTransferParams` struct defined in `ConditionalTransactionDelegateTarget.sol` and replaces it with the ``Params` struct from `CoinTransferETHInterpreter`. Reasons:

- `CoinTransfer` is an outcome type, not a param type
- The structs are the same