### PR TITLE
[types] remove TWO_PARTY_DYNAMIC_OUTCOME

### DIFF
--- a/packages/types/src/data-types.ts
+++ b/packages/types/src/data-types.ts
@@ -94,8 +94,7 @@ export type AppABIEncodings = {
 // Interpreter.sol::OutcomeType
 export enum OutcomeType {
   TWO_PARTY_FIXED_OUTCOME = 0,
-  TWO_PARTY_DYNAMIC_OUTCOME = 1,
-  COIN_TRANSFER = 2
+  COIN_TRANSFER = 1
 }
 
 // TwoPartyFixedOutcome.sol::Outcome


### PR DESCRIPTION
This type was added together with the solidity enum field, but the later was eventually deleted