### PR TITLE
[node] add explicit outcomeType

### DIFF
--- a/packages/cf.js/test/app-factory.spec.ts
+++ b/packages/cf.js/test/app-factory.spec.ts
@@ -65,7 +65,7 @@ describe("CF.js AppFactory", () => {
         initiatorDeposit: expectedDeposit,
         timeout: "100",
         initialState: expectedState,
-        outcomeType: OutcomeType.COIN_TRANSFER
+        outcomeType: OutcomeType.TWO_PARTY_FIXED_OUTCOME
       });
 
       expect(appInstanceId).toBe(expectedAppInstanceId);
@@ -120,7 +120,7 @@ describe("CF.js AppFactory", () => {
           initiatorDeposit: "$%GARBAGE$%",
           timeout: "100",
           initialState: { val: "4000" },
-          outcomeType: OutcomeType.COIN_TRANSFER
+          outcomeType: OutcomeType.TWO_PARTY_FIXED_OUTCOME
         });
         done.fail("Expected an error for invalid initiatorDeposit");
       } catch (e) {

--- a/packages/node/src/machine/types.ts
+++ b/packages/node/src/machine/types.ts
@@ -109,6 +109,8 @@ export type InstallVirtualAppParams = {
   initiatorBalanceDecrement: BigNumber;
   responderBalanceDecrement: BigNumber;
   tokenAddress: string;
+
+  outcomeType: OutcomeType;
 };
 
 export type UninstallVirtualAppParams = {

--- a/packages/node/src/methods/app-instance/install-virtual/operation.ts
+++ b/packages/node/src/methods/app-instance/install-virtual/operation.ts
@@ -40,7 +40,8 @@ export async function installVirtual(
         initialState: proposal.initialState,
         initiatorBalanceDecrement: proposal.initiatorDeposit,
         responderBalanceDecrement: proposal.responderDeposit,
-        tokenAddress: CONVENTION_FOR_ETH_TOKEN_ADDRESS
+        tokenAddress: CONVENTION_FOR_ETH_TOKEN_ADDRESS,
+        outcomeType: proposal.outcomeType
       }
     );
   } catch (e) {

--- a/packages/node/src/methods/state-channel/deposit/operation.ts
+++ b/packages/node/src/methods/state-channel/deposit/operation.ts
@@ -75,7 +75,7 @@ export async function installBalanceRefundApp(
     appInterface: depositContext.appInterface,
     // this is the block-time equivalent of 7 days
     defaultTimeout: 1008,
-    outcomeType: OutcomeType.COIN_TRANSFER,
+    outcomeType: OutcomeType.REFUND_OUTCOME_TYPE,
     initiatorDepositTokenAddress: tokenAddress!, // params object is mutated in caller
     responderDepositTokenAddress: CONVENTION_FOR_ETH_TOKEN_ADDRESS
   };

--- a/packages/node/src/models/app-instance.ts
+++ b/packages/node/src/models/app-instance.ts
@@ -4,6 +4,7 @@ import {
   AppInstanceJson,
   AppInterface,
   CoinTransferInterpreterParams,
+  OutcomeType,
   SolidityABIEncoderV2Type,
   TwoPartyFixedOutcomeInterpreterParams
 } from "@counterfactual/types";
@@ -51,7 +52,6 @@ import { appIdentityToHash } from "../ethereum/utils/app-identity";
  *           and the amount that is to be distributed for an app
  *           where the interpreter type is TWO_PARTY_FIXED_OUTCOME
  */
-// TODO: dont forget dependnecy versionNumber docstring
 export class AppInstance {
   private readonly json: AppInstanceJson;
 
@@ -65,6 +65,7 @@ export class AppInstance {
     latestState: any,
     latestVersionNumber: number,
     latestTimeout: number,
+    outcomeType: OutcomeType,
     twoPartyOutcomeInterpreterParams?: TwoPartyFixedOutcomeInterpreterParams,
     coinTransferInterpreterParams?: CoinTransferInterpreterParams
   ) {
@@ -79,6 +80,7 @@ export class AppInstance {
       latestVersionNumber,
       latestTimeout,
       identityHash: AddressZero,
+      outcomeType: outcomeType,
       twoPartyOutcomeInterpreterParams: twoPartyOutcomeInterpreterParams
         ? {
             playerAddrs: twoPartyOutcomeInterpreterParams.playerAddrs,
@@ -120,6 +122,7 @@ export class AppInstance {
       latestState,
       json.latestVersionNumber,
       json.latestTimeout,
+      json.outcomeType,
       json.twoPartyOutcomeInterpreterParams
         ? {
             playerAddrs: json.twoPartyOutcomeInterpreterParams.playerAddrs,

--- a/packages/node/src/models/free-balance.ts
+++ b/packages/node/src/models/free-balance.ts
@@ -1,3 +1,4 @@
+import { OutcomeType } from "@counterfactual/types";
 import { AddressZero, MaxUint256, Zero } from "ethers/constants";
 import { BigNumber, bigNumberify } from "ethers/utils";
 
@@ -88,6 +89,7 @@ export function createFreeBalance(
     serializeFreeBalanceState(initialState),
     0,
     HARD_CODED_ASSUMPTIONS.freeBalanceInitialStateTimeout,
+    OutcomeType.FREE_BALANCE_OUTCOME_TYPE,
     undefined,
     // FIXME: refactor how the interpreter parameters get plumbed through
     { limit: [MaxUint256], tokens: [CONVENTION_FOR_ETH_TOKEN_ADDRESS] }

--- a/packages/node/src/models/proposed-app-instance-info.ts
+++ b/packages/node/src/models/proposed-app-instance-info.ts
@@ -137,6 +137,7 @@ export class AppInstanceProposal {
       bigNumberify(this.timeout).toNumber(),
       // the below two arguments are not currently used in app identity
       // computation
+      -1,
       undefined,
       // this is not relevant here as it gets set properly later in the context
       // of the channel during an install, and it's not used to calculate

--- a/packages/node/src/protocol/install-virtual-app.ts
+++ b/packages/node/src/protocol/install-virtual-app.ts
@@ -819,7 +819,8 @@ function constructVirtualAppInstance(
     appInterface,
     initialState,
     initiatorBalanceDecrement,
-    responderBalanceDecrement
+    responderBalanceDecrement,
+    outcomeType
   } = params;
 
   const seqNo = stateChannelThatWrapsVirtualApp.numInstalledApps;
@@ -842,8 +843,8 @@ function constructVirtualAppInstance(
     /* initialState */ initialState,
     /* versionNumber */ 0,
     /* latestTimeout */ defaultTimeout,
-    /* twoPartyOutcomeInterpreterParams */
-    {
+    /* outcomeType */ outcomeType,
+    /* twoPartyOutcomeInterpreterParams */ {
       playerAddrs: [initiatorAddress, responderAddress],
       amount: bigNumberify(initiatorBalanceDecrement).add(
         responderBalanceDecrement

--- a/packages/node/src/protocol/install.ts
+++ b/packages/node/src/protocol/install.ts
@@ -325,6 +325,7 @@ function computeStateChannelTransition(
     /* latestState */ initialState,
     /* latestVersionNumber */ 0,
     /* defaultTimeout */ defaultTimeout,
+    /* outcomeType */ outcomeType,
     /* twoPartyOutcomeInterpreterParams */ twoPartyOutcomeInterpreterParams,
     /* coinTransferInterpreterParams */ coinTransferInterpreterParams
   );

--- a/packages/node/src/protocol/install.ts
+++ b/packages/node/src/protocol/install.ts
@@ -398,7 +398,7 @@ function computeInterpreterParameters(
     | undefined;
 
   switch (outcomeType) {
-    case OutcomeType.COIN_TRANSFER: {
+    case OutcomeType.REFUND_OUTCOME_TYPE: {
       const limit: BigNumber[] = [];
       const tokens: string[] = [];
 
@@ -465,7 +465,7 @@ function constructConditionalTransactionData(
   let interpreterParams: string;
 
   switch (outcomeType) {
-    case OutcomeType.COIN_TRANSFER: {
+    case OutcomeType.REFUND_OUTCOME_TYPE: {
       interpreterAddress = network.CoinTransferInterpreter;
       interpreterParams = defaultAbiCoder.encode(
         [coinTransferInterpreterParamsStateEncoding],

--- a/packages/node/src/protocol/utils/get-outcome-increments.ts
+++ b/packages/node/src/protocol/utils/get-outcome-increments.ts
@@ -85,7 +85,7 @@ export async function computeTokenIndexedFreeBalanceIncrements(
   }
 
   switch (outcomeType) {
-    case OutcomeType.COIN_TRANSFER: {
+    case OutcomeType.REFUND_OUTCOME_TYPE: {
       // FIXME:
       // https://github.com/counterfactual/monorepo/issues/1371
 

--- a/packages/node/src/protocol/utils/get-outcome-increments.ts
+++ b/packages/node/src/protocol/utils/get-outcome-increments.ts
@@ -51,6 +51,15 @@ function anyNonzeroValues(map: TokenIndexedCoinTransferMap): Boolean {
   return false;
 }
 
+const wait = (ms: number) => new Promise(r => setTimeout(r, ms));
+
+// todo(xuanji): rename appInstanceId to identityHash
+/**
+ * Get the outcome of the app instance given, decode it according
+ * to the outcome type stored in the app instance model, and return
+ * a value uniformly across outcome type and whether the app is virtual
+ * or direct. This return value must not contain the intermediary.
+ */
 export async function computeTokenIndexedFreeBalanceIncrements(
   networkContext: NetworkContext,
   stateChannel: StateChannel,
@@ -69,14 +78,10 @@ export async function computeTokenIndexedFreeBalanceIncrements(
     appInstance.encodedLatestState
   );
 
-  // Temporary, better solution is to add outcomeType to AppInstance model
-  let outcomeType: OutcomeType | undefined;
-  if (typeof appInstance.coinTransferInterpreterParams !== "undefined") {
-    outcomeType = OutcomeType.COIN_TRANSFER;
-  } else if (
-    typeof appInstance.twoPartyOutcomeInterpreterParams !== "undefined"
-  ) {
-    outcomeType = OutcomeType.TWO_PARTY_FIXED_OUTCOME;
+  const outcomeType = appInstance.toJson().outcomeType;
+
+  if (outcomeType === undefined) {
+    throw new Error("undefined outcomeType in appInstance");
   }
 
   switch (outcomeType) {
@@ -86,7 +91,8 @@ export async function computeTokenIndexedFreeBalanceIncrements(
 
       let attempts = 1;
 
-      const wait = (ms: number) => new Promise(r => setTimeout(r, ms));
+      // todo(xuanji): factor out retryUntil function
+
       while (1) {
         outcome = await appDefinition.functions.computeOutcome(
           appInstance.encodedLatestState
@@ -112,6 +118,12 @@ export async function computeTokenIndexedFreeBalanceIncrements(
     }
     case OutcomeType.TWO_PARTY_FIXED_OUTCOME: {
       const [decoded] = defaultAbiCoder.decode(["uint256"], outcome);
+
+      if (appInstance.twoPartyOutcomeInterpreterParams === undefined) {
+        throw new Error(
+          "app instance outcome type set to two party outcome, but twoPartyOutcomeInterpreterParams not defined"
+        );
+      }
 
       const total = appInstance.twoPartyOutcomeInterpreterParams!.amount;
 

--- a/packages/node/src/protocol/withdraw.ts
+++ b/packages/node/src/protocol/withdraw.ts
@@ -521,7 +521,7 @@ function addRefundAppToStateChannel(
     },
     0,
     defaultTimeout,
-    OutcomeType.COIN_TRANSFER,
+    OutcomeType.REFUND_OUTCOME_TYPE,
     undefined,
     { tokens: [tokenAddress], limit: [MaxUint256] }
   );

--- a/packages/node/src/protocol/withdraw.ts
+++ b/packages/node/src/protocol/withdraw.ts
@@ -1,7 +1,8 @@
 import {
   coinBalanceRefundStateEncoding,
   coinTransferInterpreterParamsStateEncoding,
-  NetworkContext
+  NetworkContext,
+  OutcomeType
 } from "@counterfactual/types";
 import { MaxUint256 } from "ethers/constants";
 import { BigNumber, defaultAbiCoder } from "ethers/utils";
@@ -520,6 +521,7 @@ function addRefundAppToStateChannel(
     },
     0,
     defaultTimeout,
+    OutcomeType.COIN_TRANSFER,
     undefined,
     { tokens: [tokenAddress], limit: [MaxUint256] }
   );

--- a/packages/node/test/machine/integration/install-then-set-state.spec.ts
+++ b/packages/node/test/machine/integration/install-then-set-state.spec.ts
@@ -6,7 +6,8 @@ import ProxyFactory from "@counterfactual/contracts/build/ProxyFactory.json";
 import {
   CoinTransferInterpreterParams,
   coinTransferInterpreterParamsStateEncoding,
-  NetworkContext
+  NetworkContext,
+  OutcomeType
 } from "@counterfactual/types";
 import { Contract, Wallet } from "ethers";
 import { WeiPerEther, Zero } from "ethers/constants";
@@ -139,6 +140,7 @@ describe("Scenario: install AppInstance, set state, put on-chain", () => {
         ],
         0,
         stateChannel.freeBalance.timeout, // Re-use ETH FreeBalance timeout
+        OutcomeType.COIN_TRANSFER,
         undefined,
         {
           // total limit of ETH and ERC20 token that can be transferred

--- a/packages/node/test/machine/integration/install-then-set-state.spec.ts
+++ b/packages/node/test/machine/integration/install-then-set-state.spec.ts
@@ -140,7 +140,7 @@ describe("Scenario: install AppInstance, set state, put on-chain", () => {
         ],
         0,
         stateChannel.freeBalance.timeout, // Re-use ETH FreeBalance timeout
-        OutcomeType.COIN_TRANSFER,
+        OutcomeType.FREE_BALANCE_OUTCOME_TYPE,
         undefined,
         {
           // total limit of ETH and ERC20 token that can be transferred

--- a/packages/node/test/machine/integration/install-virtual.spec.ts
+++ b/packages/node/test/machine/integration/install-virtual.spec.ts
@@ -4,6 +4,7 @@ import DolphinCoin from "@counterfactual/contracts/build/DolphinCoin.json";
 import MinimumViableMultisig from "@counterfactual/contracts/build/MinimumViableMultisig.json";
 import ProxyFactory from "@counterfactual/contracts/build/ProxyFactory.json";
 import TwoPartyFixedOutcomeApp from "@counterfactual/contracts/build/TwoPartyFixedOutcomeApp.json";
+import { OutcomeType } from "@counterfactual/types";
 import { Contract, ContractFactory, Wallet } from "ethers";
 import { AddressZero, Zero } from "ethers/constants";
 import { JsonRpcProvider } from "ethers/providers";
@@ -161,6 +162,7 @@ function createTargetAppInstance(stateChannel: StateChannel) {
     2, // latest state
     1, // latest versionNumber
     0, // latest timeout
+    /* outcomeType */ OutcomeType.TWO_PARTY_FIXED_OUTCOME,
     {
       playerAddrs: [AddressZero, AddressZero],
       amount: Zero

--- a/packages/node/test/machine/integration/protocols.spec.ts
+++ b/packages/node/test/machine/integration/protocols.spec.ts
@@ -146,7 +146,8 @@ describe("Three mininodes", () => {
         },
         initiatorBalanceDecrement: bigNumberify(0),
         responderBalanceDecrement: bigNumberify(0),
-        tokenAddress: CONVENTION_FOR_ETH_TOKEN_ADDRESS
+        tokenAddress: CONVENTION_FOR_ETH_TOKEN_ADDRESS,
+        outcomeType: OutcomeType.TWO_PARTY_FIXED_OUTCOME
       }
     );
     await mininodeA.ie.initiateProtocol(
@@ -167,7 +168,8 @@ describe("Three mininodes", () => {
         },
         initiatorBalanceDecrement: bigNumberify(0),
         responderBalanceDecrement: bigNumberify(0),
-        tokenAddress: CONVENTION_FOR_ETH_TOKEN_ADDRESS
+        tokenAddress: CONVENTION_FOR_ETH_TOKEN_ADDRESS,
+        outcomeType: OutcomeType.TWO_PARTY_FIXED_OUTCOME
       }
     );
 

--- a/packages/node/test/machine/integration/virtual-app-set-state-commitment.spec.ts
+++ b/packages/node/test/machine/integration/virtual-app-set-state-commitment.spec.ts
@@ -1,5 +1,5 @@
 import ChallengeRegistry from "@counterfactual/contracts/build/ChallengeRegistry.json";
-import { NetworkContext } from "@counterfactual/types";
+import { NetworkContext, OutcomeType } from "@counterfactual/types";
 import * as chai from "chai";
 import { randomBytes } from "crypto";
 import * as matchers from "ethereum-waffle/dist/matchers/matchers";
@@ -89,6 +89,7 @@ beforeEach(() => {
     /* latestState */ { foo: AddressZero, bar: bigNumberify(0) },
     /* latestVersionNumber */ 10,
     /* latestTimeout */ 10,
+    /* outcomeType */ OutcomeType.TWO_PARTY_FIXED_OUTCOME,
     /* twoPartyOutcomeInterpreterParams */ {
       playerAddrs: [AddressZero, AddressZero],
       amount: Zero

--- a/packages/node/test/machine/unit/ethereum/virtual-app-set-state-commitment.spec.ts
+++ b/packages/node/test/machine/unit/ethereum/virtual-app-set-state-commitment.spec.ts
@@ -1,4 +1,5 @@
 import ChallengeRegistry from "@counterfactual/contracts/build/ChallengeRegistry.json";
+import { OutcomeType } from "@counterfactual/types";
 import { AddressZero, HashZero, Zero } from "ethers/constants";
 import {
   bigNumberify,
@@ -45,6 +46,7 @@ describe("Virtual App Set State Commitment", () => {
     { foo: AddressZero, bar: 0 },
     0,
     Math.ceil(1000 * Math.random()),
+    OutcomeType.TWO_PARTY_FIXED_OUTCOME,
     {
       playerAddrs: [AddressZero, AddressZero],
       amount: Zero

--- a/packages/node/test/machine/unit/models/app-instance/app-instance.spec.ts
+++ b/packages/node/test/machine/unit/models/app-instance/app-instance.spec.ts
@@ -1,3 +1,4 @@
+import { OutcomeType } from "@counterfactual/types";
 import { AddressZero, Zero } from "ethers/constants";
 import { getAddress, hexlify, randomBytes } from "ethers/utils";
 
@@ -23,8 +24,9 @@ describe("AppInstance", () => {
       false,
       Math.ceil(Math.random() * 2e10),
       { foo: getAddress(hexlify(randomBytes(20))), bar: 0 },
-      999, // <------ versionNumber
+      /* versionNumber */ 999,
       Math.ceil(1000 * Math.random()),
+      OutcomeType.TWO_PARTY_FIXED_OUTCOME,
       {
         playerAddrs: [AddressZero, AddressZero],
         amount: Zero

--- a/packages/node/test/unit/utils.ts
+++ b/packages/node/test/unit/utils.ts
@@ -36,7 +36,7 @@ export function createAppInstanceProposalForTest(appInstanceId: string) {
         foo: AddressZero,
         bar: 0
       } as SolidityABIEncoderV2Type,
-      outcomeType: OutcomeType.COIN_TRANSFER,
+      outcomeType: OutcomeType.TWO_PARTY_FIXED_OUTCOME,
       initiatorDepositTokenAddress: CONVENTION_FOR_ETH_TOKEN_ADDRESS,
       responderDepositTokenAddress: CONVENTION_FOR_ETH_TOKEN_ADDRESS
     },

--- a/packages/node/test/unit/utils.ts
+++ b/packages/node/test/unit/utils.ts
@@ -69,6 +69,7 @@ export function createAppInstanceForTest(stateChannel?: StateChannel) {
     /* latestState */ { foo: AddressZero, bar: bigNumberify(0) },
     /* latestVersionNumber */ 0,
     /* latestTimeout */ Math.ceil(1000 * Math.random()),
+    /* outcomeType */ OutcomeType.TWO_PARTY_FIXED_OUTCOME,
     /* twoPartyOutcomeInterpreterParams */ {
       playerAddrs: [AddressZero, AddressZero],
       amount: Zero

--- a/packages/types/src/data-types.ts
+++ b/packages/types/src/data-types.ts
@@ -37,6 +37,8 @@ export type AppInstanceJson = {
   latestVersionNumber: number;
   latestTimeout: number;
 
+  outcomeType: number;
+
   /**
    * Interpreter-related Fields
    */
@@ -103,7 +105,8 @@ export type AppABIEncodings = {
 // Interpreter.sol::OutcomeType
 export enum OutcomeType {
   TWO_PARTY_FIXED_OUTCOME = 0,
-  COIN_TRANSFER = 1
+  COIN_TRANSFER = 1,
+  FREE_BALANCE_OUTCOME_TYPE = 2
 }
 
 // TwoPartyFixedOutcome.sol::Outcome

--- a/packages/types/src/data-types.ts
+++ b/packages/types/src/data-types.ts
@@ -102,11 +102,23 @@ export type AppABIEncodings = {
   actionEncoding: ABIEncoding | undefined;
 };
 
-// Interpreter.sol::OutcomeType
 export enum OutcomeType {
   TWO_PARTY_FIXED_OUTCOME = 0,
-  COIN_TRANSFER = 1,
-  FREE_BALANCE_OUTCOME_TYPE = 2
+
+  // CoinTransfer
+  // Since no apps currently use this outcome
+  // type, do not use it in the node 
+  COIN_TRANSFER_DO_NOT_USE = 1,
+
+  // tuple(address[], CoinTransfer[][], bytes32[])
+  FREE_BALANCE_OUTCOME_TYPE = 2,
+
+  // CoinTransfer[1][1]
+  REFUND_OUTCOME_TYPE = 3,
+
+  // CoinTransfer[2]
+  SINGLE_ASSET_TWO_PARTY_COIN_TRANSFER
+
 }
 
 // TwoPartyFixedOutcome.sol::Outcome

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,7 +4,7 @@
     "emitDecoratorMetadata": true,
     "experimentalDecorators": true,
     "noImplicitAny": false,
-    "noUnusedLocals": false,
+    "noUnusedLocals": true,
     "noImplicitReturns": true,
     "noLib": false,
     "removeComments": true,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,7 +4,7 @@
     "emitDecoratorMetadata": true,
     "experimentalDecorators": true,
     "noImplicitAny": false,
-    "noUnusedLocals": true,
+    "noUnusedLocals": false,
     "noImplicitReturns": true,
     "noLib": false,
     "removeComments": true,


### PR DESCRIPTION
- add an explicit `outcomeType` field to the app instance model
- split up the `COIN_TRANSFER` outcome type to accurately reflect actual outcome types