### PR TITLE
Remove  the `owner` property on an AppIdentity

### DIFF
--- a/packages/apps/package.json
+++ b/packages/apps/package.json
@@ -23,7 +23,7 @@
     "lint:ts": "tslint -c tslint.json -p ."
   },
   "devDependencies": {
-    "@counterfactual/contracts": "0.1.9",
+    "@counterfactual/contracts": "0.1.10",
     "@counterfactual/types": "0.0.25",
     "@types/chai": "4.1.7",
     "@types/mocha": "5.2.7",

--- a/packages/chain/package.json
+++ b/packages/chain/package.json
@@ -17,7 +17,7 @@
     "lint": "tslint -c tslint.json -p ."
   },
   "devDependencies": {
-    "@counterfactual/contracts": "0.1.9",
+    "@counterfactual/contracts": "0.1.10",
     "@counterfactual/types": "0.0.25",
     "ethers": "4.0.33",
     "ganache-core": "2.5.7",

--- a/packages/contracts/contracts/interpreters/TwoPartyFixedOutcomeETHInterpreter.sol
+++ b/packages/contracts/contracts/interpreters/TwoPartyFixedOutcomeETHInterpreter.sol
@@ -38,10 +38,10 @@ contract TwoPartyFixedOutcomeETHInterpreter is Interpreter {
       return;
     }
 
-    /* 
+    /*
     A functioning app should return SPLIT_AND_SEND_TO_BOTH_ADDRS
     to indicate that the committed asset should be split, hence by right
-    we can revert here if the outcome is something other than that, since we 
+    we can revert here if the outcome is something other than that, since we
     would have handled all cases; instead we choose to handle all other outcomes
     as if they were SPLIT.
     */

--- a/packages/contracts/contracts/libs/LibStateChannelApp.sol
+++ b/packages/contracts/contracts/libs/LibStateChannelApp.sol
@@ -15,7 +15,7 @@ contract LibStateChannelApp {
 
   // A minimal structure that uniquely identifies a single instance of an App
   struct AppIdentity {
-    address owner;
+    uint256 channelNonce;
     address[] participants;
     address appDefinition;
     uint256 defaultTimeout;

--- a/packages/contracts/contracts/mixins/MChallengeRegistryCore.sol
+++ b/packages/contracts/contracts/mixins/MChallengeRegistryCore.sol
@@ -23,7 +23,9 @@ contract MChallengeRegistryCore {
     pure
     returns (bytes32)
   {
-    return keccak256(abi.encode(appIdentity));
+    return keccak256(
+      abi.encode(appIdentity.channelNonce, appIdentity.participants)
+    );
   }
 
   /// @notice Compute a unique hash for the state of a channelized app instance

--- a/packages/contracts/contracts/mixins/MixinCancelChallenge.sol
+++ b/packages/contracts/contracts/mixins/MixinCancelChallenge.sol
@@ -45,12 +45,10 @@ contract MixinCancelChallenge is
       appIdentity.defaultTimeout
     );
 
-    if (msg.sender != appIdentity.owner) {
-      require(
-        verifySignatures(signatures, stateHash, appIdentity.participants),
-        "Invalid signatures"
-      );
-    }
+    require(
+      verifySignatures(signatures, stateHash, appIdentity.participants),
+      "Invalid signatures"
+    );
 
     challenge.finalizesAt = 0;
     challenge.status = ChallengeStatus.NO_CHALLENGE;

--- a/packages/contracts/contracts/mixins/MixinSetState.sol
+++ b/packages/contracts/contracts/mixins/MixinSetState.sol
@@ -48,16 +48,14 @@ contract MixinSetState is
       "setState was called on an app that has already been finalized"
     );
 
-    if (msg.sender != appIdentity.owner) {
-      require(
-        correctKeysSignedAppChallengeUpdate(
-          identityHash,
-          appIdentity.participants,
-          req
-        ),
-        "Call to setState included incorrectly signed state update"
-      );
-    }
+    require(
+      correctKeysSignedAppChallengeUpdate(
+        identityHash,
+        appIdentity.participants,
+        req
+      ),
+      "Call to setState included incorrectly signed state update"
+    );
 
     require(
       req.versionNumber > challenge.versionNumber,

--- a/packages/contracts/networks/3.json
+++ b/packages/contracts/networks/3.json
@@ -5,11 +5,6 @@
     "transactionHash": "0x0332f7d59738290d69c26650ea151278a50699a50d74a3ffc02e27466e7e6f19"
   },
   {
-    "contractName": "ChallengeRegistry",
-    "address": "0x627989FD5269ed3596515B25933695d320b831a9",
-    "transactionHash": "0xf38f094b86559748ee5c1a5b4f89bec5b055eb7436afad0097e95ac9355563a1"
-  },
-  {
     "contractName": "CoinBalanceRefundApp",
     "address": "0x62222411971c5a919a0F48bC4ea4eb615B6C1aFd",
     "transactionHash": "0xff2b147b8d9d83583ff9b6694da3fb31f7eee8910339b10ece218e1c3df4c911"
@@ -50,13 +45,23 @@
     "transactionHash": "0x5cccb5a68828ec2d394a7c9a4a71d1d99d680d501cedc2d06df73f3c4be0a32d"
   },
   {
-    "contractName": "TwoPartyFixedOutcomeETHInterpreter",
-    "address": "0x69CCa6b1880b63Ab39dE03aF07A60921B45A4864",
-    "transactionHash": "0x25698951b6f732802d4e1afd3fe810a90627c3a41cb0f7559d1cc5e9ab0769d1"
-  },
-  {
     "contractName": "TwoPartyFixedOutcomeFromVirtualAppETHInterpreter",
     "address": "0x29ed7F1f4A863B468dE1Fe6dC33F2A08AE530f5B",
     "transactionHash": "0x036280aa2ef9e6e7a5bb8eafb1bb8feac3fcbe74190010ba43d614d12a9ad409"
+  },
+  {
+    "contractName": "Migrations",
+    "address": "0xE668a1E6C205A799F964A138cA6Be63e05b47eaf",
+    "transactionHash": "0x06dbffe47396aa05bc1591babdf8a46342359d659e74c150084e978fa2a2e1e1"
+  },
+  {
+    "contractName": "ChallengeRegistry",
+    "address": "0x167f53654A45216ac62320646E66Be6B7887E101",
+    "transactionHash": "0xf72613601b80eea7efd6544fbf1cad692406b844cb1b25fc51289fb84c3a3414"
+  },
+  {
+    "contractName": "TwoPartyFixedOutcomeETHInterpreter",
+    "address": "0x08a40fBea3765e70fc44348Cb87256C48754ddDb",
+    "transactionHash": "0x10a4e8b4e69e79ef4db3e33a6b47763283a68f855477f57d885ba6540641c5db"
   }
 ]

--- a/packages/contracts/networks/4.json
+++ b/packages/contracts/networks/4.json
@@ -1,10 +1,5 @@
 [
   {
-    "contractName": "ChallengeRegistry",
-    "address": "0x8f21E9C998413B2E0BF7226BCF8b45fCE4D5a59e",
-    "transactionHash": "0xbcb9de221d48983f231584f8871d3c8f15b931c0e9cdabec4d15c425a00d150e"
-  },
-  {
     "contractName": "CoinBalanceRefundApp",
     "address": "0xA2502578c9b05e6A0B6801239BC0f98c8a6ea2E7",
     "transactionHash": "0x47c82666deadf8897269734b330f07458770fc93ab5a86eea753f1740f9c0c47"
@@ -45,13 +40,23 @@
     "transactionHash": "0x7fe06ed378dfe656d0329bca8f160492064d024038802cb40a49822baa781a60"
   },
   {
-    "contractName": "TwoPartyFixedOutcomeETHInterpreter",
-    "address": "0x0be6aB9CE60cb23bAfDA37A665747Dde5FEC9E40",
-    "transactionHash": "0xf7299207d107f7298c0b32ab642475b5279fe72e1cc8d4df38addcec580dcc10"
-  },
-  {
     "contractName": "TwoPartyFixedOutcomeFromVirtualAppETHInterpreter",
     "address": "0xab39f5aA1Bc1cB5442268b075f535c296aAee980",
     "transactionHash": "0x74f228bdd1a59c8ff06d203eb68793376f4a0d48147b03b6949f489cb5dabdae"
+  },
+  {
+    "contractName": "Migrations",
+    "address": "0xE668a1E6C205A799F964A138cA6Be63e05b47eaf",
+    "transactionHash": "0x06dbffe47396aa05bc1591babdf8a46342359d659e74c150084e978fa2a2e1e1"
+  },
+  {
+    "contractName": "ChallengeRegistry",
+    "address": "0x167f53654A45216ac62320646E66Be6B7887E101",
+    "transactionHash": "0xf72613601b80eea7efd6544fbf1cad692406b844cb1b25fc51289fb84c3a3414"
+  },
+  {
+    "contractName": "TwoPartyFixedOutcomeETHInterpreter",
+    "address": "0x08a40fBea3765e70fc44348Cb87256C48754ddDb",
+    "transactionHash": "0x10a4e8b4e69e79ef4db3e33a6b47763283a68f855477f57d885ba6540641c5db"
   }
 ]

--- a/packages/contracts/networks/42.json
+++ b/packages/contracts/networks/42.json
@@ -1,10 +1,5 @@
 [
   {
-    "contractName": "ChallengeRegistry",
-    "address": "0xa89DD00ED91A99e5419570d444B067Aa1e1C528D",
-    "transactionHash": "0x7eef7019a56bc96f6d8d0566fdaebc2dc7b9ab6b6bb6a20f1b5e6211387ede91"
-  },
-  {
     "contractName": "CoinBalanceRefundApp",
     "address": "0x403A258A91644B905EDDd1CD931ffcD49aC5f80D",
     "transactionHash": "0x246be58aa85d8a9ac25610bdc5eb7166cb78707f0362d9187e8d6d7c33e80db5"
@@ -45,13 +40,23 @@
     "transactionHash": "0xde7a76e301768399494a9f7dd319270b4e51e56ec73f88e22214a70a56ead409"
   },
   {
-    "contractName": "TwoPartyFixedOutcomeETHInterpreter",
-    "address": "0x9122C417F57469dc96B81Ed9b29f0839Cd93162c",
-    "transactionHash": "0x7ebafe1c504523569fdf81da7e9818799739664715e86cb93c32413332d40fdc"
-  },
-  {
     "contractName": "TwoPartyFixedOutcomeFromVirtualAppETHInterpreter",
     "address": "0x15b7EE87083e340B1F1e3d534Ad445B5c832c25C",
     "transactionHash": "0x00a8ab37766ad01cdd45f16f6b5fc1daf671422fe6977d7366d45e3ff0e6b728"
+  },
+  {
+    "contractName": "Migrations",
+    "address": "0x9a2AdA593637c7f404C3DA69Ee26e4B1E8CfC0Fd",
+    "transactionHash": "0x5b9168daa3a09730373d468cfc61dfef71b9f78130d49e2496d9b79cf1345ab9"
+  },
+  {
+    "contractName": "ChallengeRegistry",
+    "address": "0x100Db874AC77dc8ddad7421b6464e188A2F533D6",
+    "transactionHash": "0xbc1bb1ebe71d8ceaf6024da3b4b68e972af37b8570e7e508022dfb6a8f2ab0e3"
+  },
+  {
+    "contractName": "TwoPartyFixedOutcomeETHInterpreter",
+    "address": "0xC246CC977ee6DcE225E5708AaE2bEC3ba501b96a",
+    "transactionHash": "0xcdafa839955ee597834d0d6c1fcf44942abd5510f338b393fdd7cad0d2c85c5e"
   }
 ]

--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@counterfactual/contracts",
-  "version": "0.1.9",
+  "version": "0.1.10",
   "description": "Smart contracts for Counterfactual",
   "license": "MIT",
   "engines": {

--- a/packages/contracts/test/challenge-registry.spec.ts
+++ b/packages/contracts/test/challenge-registry.spec.ts
@@ -1,14 +1,29 @@
 import { utils } from "@counterfactual/cf.js";
 import * as waffle from "ethereum-waffle";
 import { Contract, Wallet } from "ethers";
-import { AddressZero, HashZero } from "ethers/constants";
+import { HashZero } from "ethers/constants";
 import { Web3Provider } from "ethers/providers";
-import { hexlify, keccak256, randomBytes, SigningKey } from "ethers/utils";
+import {
+  BigNumberish,
+  hexlify,
+  keccak256,
+  randomBytes,
+  SigningKey
+} from "ethers/utils";
 
 import ChallengeRegistry from "../build/ChallengeRegistry.json";
 
-import { AppInstance, computeAppChallengeHash, expect } from "./utils";
+import { AppIdentityTestClass, computeAppChallengeHash, expect } from "./utils";
 const { signaturesToBytesSortedBySignerAddress } = utils;
+
+type Challenge = {
+  status: 0 | 1 | 2;
+  latestSubmitter: string;
+  appStateHash: string;
+  challengeCounter: number;
+  finalizesAt: number;
+  versionNumber: number;
+};
 
 const ALICE =
   // 0xaeF082d339D227646DB914f0cA9fF02c8544F30b
@@ -28,25 +43,25 @@ const ONCHAIN_CHALLENGE_TIMEOUT = 30;
 describe("ChallengeRegistry", () => {
   let provider: Web3Provider;
   let wallet: Wallet;
-  let wallet2: Wallet;
+  let globalChannelNonce = 0;
 
   let appRegistry: Contract;
 
-  let setStateAsOwner: (versionNumber: number, appState?: string) => Promise<void>;
   let setStateWithSignatures: (
-    versionNumber: number,
-    appState?: string
+    versionNumber: BigNumberish,
+    appState?: string,
+    timeout?: number
   ) => Promise<void>;
   let cancelChallenge: () => Promise<void>;
   let sendSignedFinalizationToChain: () => Promise<any>;
-  let latestAppState: () => Promise<string>;
+  let getChallenge: () => Promise<Challenge>;
+  let latestAppStateHash: () => Promise<string>;
   let latestVersionNumber: () => Promise<number>;
   let isStateFinalized: () => Promise<boolean>;
 
   before(async () => {
     provider = waffle.createMockProvider();
     wallet = (await waffle.getWallets(provider))[0];
-    wallet2 = (await waffle.getWallets(provider))[1];
 
     appRegistry = await waffle.deployContract(wallet, ChallengeRegistry, [], {
       gasLimit: 6000000 // override default of 4 million
@@ -54,127 +69,79 @@ describe("ChallengeRegistry", () => {
   });
 
   beforeEach(async () => {
-    const appInstance = new AppInstance(
-      wallet.address,
+    const appIdentityTestObject = new AppIdentityTestClass(
       [ALICE.address, BOB.address],
       hexlify(randomBytes(20)),
-      10
+      10,
+      globalChannelNonce
     );
 
-    latestAppState = async () =>
-      (await appRegistry.functions.getAppChallenge(appInstance.identityHash))
-        .appStateHash;
+    globalChannelNonce += 1;
 
-    latestVersionNumber = async () =>
-      (await appRegistry.functions.getAppChallenge(appInstance.identityHash))
-        .versionNumber;
+    getChallenge = () =>
+      appRegistry.functions.getAppChallenge(appIdentityTestObject.identityHash);
+
+    latestAppStateHash = async () => (await getChallenge()).appStateHash;
+
+    latestVersionNumber = async () => (await getChallenge()).versionNumber;
 
     isStateFinalized = async () =>
-      await appRegistry.functions.isStateFinalized(appInstance.identityHash);
+      await appRegistry.functions.isStateFinalized(
+        appIdentityTestObject.identityHash
+      );
 
-    setStateAsOwner = (versionNumber: number, appState?: string) =>
-      appRegistry.functions.setState(appInstance.appIdentity, {
-        versionNumber,
-        appStateHash: appState || HashZero,
-        timeout: ONCHAIN_CHALLENGE_TIMEOUT,
-        signatures: HashZero
-      });
-
-    cancelChallenge = () =>
-      appRegistry.functions.cancelChallenge(appInstance.appIdentity, HashZero);
-
-    setStateWithSignatures = async (versionNumber: number, appState?: string) => {
-      const stateHash = keccak256(appState || HashZero);
+    cancelChallenge = async () => {
       const digest = computeAppChallengeHash(
-        appInstance.identityHash,
+        appIdentityTestObject.identityHash,
+        await latestAppStateHash(),
+        await latestVersionNumber(),
+        appIdentityTestObject.defaultTimeout
+      );
+
+      await appRegistry.functions.cancelChallenge(
+        appIdentityTestObject.appIdentity,
+        signaturesToBytesSortedBySignerAddress(
+          digest,
+          await new SigningKey(ALICE.privateKey).signDigest(digest),
+          await new SigningKey(BOB.privateKey).signDigest(digest)
+        )
+      );
+    };
+
+    setStateWithSignatures = async (
+      versionNumber: BigNumberish,
+      appState: string = HashZero,
+      timeout: number = ONCHAIN_CHALLENGE_TIMEOUT
+    ) => {
+      const stateHash = keccak256(appState);
+      const digest = computeAppChallengeHash(
+        appIdentityTestObject.identityHash,
         stateHash,
         versionNumber,
-        ONCHAIN_CHALLENGE_TIMEOUT
+        timeout
       );
-
-      const signer1 = new SigningKey(ALICE.privateKey);
-      const signature1 = await signer1.signDigest(digest);
-
-      const signer2 = new SigningKey(BOB.privateKey);
-      const signature2 = await signer2.signDigest(digest);
-
-      const bytes = signaturesToBytesSortedBySignerAddress(
-        digest,
-        signature1,
-        signature2
-      );
-
-      const data = appRegistry.interface.functions.setState.encode([
-        appInstance.appIdentity,
-        {
-          versionNumber,
-          appStateHash: stateHash,
-          timeout: ONCHAIN_CHALLENGE_TIMEOUT,
-          signatures: bytes
-        }
-      ]);
-
-      await wallet2.sendTransaction({
-        data,
-        to: appRegistry.address
+      await appRegistry.functions.setState(appIdentityTestObject.appIdentity, {
+        timeout,
+        versionNumber,
+        appStateHash: stateHash,
+        signatures: signaturesToBytesSortedBySignerAddress(
+          digest,
+          await new SigningKey(ALICE.privateKey).signDigest(digest),
+          await new SigningKey(BOB.privateKey).signDigest(digest)
+        )
       });
     };
 
     sendSignedFinalizationToChain = async () =>
-      appRegistry.functions.setState(appInstance.appIdentity, {
-        versionNumber: (await latestVersionNumber()) + 1,
-        appStateHash: await latestAppState(),
-        timeout: 0,
-        signatures: await wallet.signMessage(
-          computeAppChallengeHash(
-            appInstance.identityHash,
-            await latestAppState(),
-            await latestVersionNumber(),
-            0
-          )
-        )
-      });
+      await setStateWithSignatures(
+        (await latestVersionNumber()) + 1,
+        await latestAppStateHash(),
+        0
+      );
   });
 
   describe("updating app state", () => {
-    describe("with owner", () => {
-      it("should work with higher versionNumber", async () => {
-        expect(await latestVersionNumber()).to.eq(0);
-        await setStateAsOwner(1);
-        expect(await latestVersionNumber()).to.eq(1);
-      });
-
-      it("should work many times", async () => {
-        expect(await latestVersionNumber()).to.eq(0);
-        await setStateAsOwner(1);
-        expect(await latestVersionNumber()).to.eq(1);
-        await cancelChallenge();
-        await setStateAsOwner(2);
-        expect(await latestVersionNumber()).to.eq(2);
-        await cancelChallenge();
-        await setStateAsOwner(3);
-        expect(await latestVersionNumber()).to.eq(3);
-      });
-
-      it("should work with much higher versionNumber", async () => {
-        expect(await latestVersionNumber()).to.eq(0);
-        await setStateAsOwner(1000);
-        expect(await latestVersionNumber()).to.eq(1000);
-      });
-
-      it("shouldn't work with an equal versionNumber", async () => {
-        await expect(setStateAsOwner(0)).to.be.reverted;
-        expect(await latestVersionNumber()).to.eq(0);
-      });
-
-      it("shouldn't work with an lower versionNumber", async () => {
-        await setStateAsOwner(1);
-        await expect(setStateAsOwner(0)).to.be.reverted;
-        expect(await latestVersionNumber()).to.eq(1);
-      });
-    });
-
-    describe("with participants", async () => {
+    describe("with signing keys", async () => {
       it("should work with higher versionNumber", async () => {
         expect(await latestVersionNumber()).to.eq(0);
         await setStateWithSignatures(1);
@@ -224,7 +191,7 @@ describe("ChallengeRegistry", () => {
     it("should block updates after the timeout", async () => {
       expect(await isStateFinalized()).to.be.false;
 
-      await setStateAsOwner(1);
+      await setStateWithSignatures(1);
 
       for (const _ of Array(ONCHAIN_CHALLENGE_TIMEOUT + 1)) {
         await provider.send("evm_mine", []);
@@ -232,29 +199,17 @@ describe("ChallengeRegistry", () => {
 
       expect(await isStateFinalized()).to.be.true;
 
-      await expect(setStateAsOwner(2)).to.be.reverted;
+      await expect(setStateWithSignatures(2)).to.be.reverted;
 
       await expect(setStateWithSignatures(0)).to.be.reverted;
     });
   });
 
   it("is possible to call setState to put state on-chain", async () => {
-    // Setup AppInstance
-    const appInstance = new AppInstance(
-      wallet.address,
-      [ALICE.address, BOB.address],
-      AddressZero,
-      10
-    );
-
     // Tell the ChallengeRegistry to start timer
-    const stateHash = hexlify(randomBytes(32));
-    await appRegistry.functions.setState(appInstance.appIdentity, {
-      appStateHash: stateHash,
-      versionNumber: 1,
-      timeout: 10,
-      signatures: HashZero
-    });
+    const state = hexlify(randomBytes(32));
+
+    await setStateWithSignatures(1, state);
 
     // Verify the correct data was put on-chain
     const {
@@ -264,13 +219,15 @@ describe("ChallengeRegistry", () => {
       challengeCounter,
       finalizesAt,
       versionNumber
-    } = await appRegistry.functions.appChallenges(appInstance.identityHash);
+    } = await getChallenge();
 
     expect(status).to.be.eq(1);
     expect(latestSubmitter).to.be.eq(await wallet.getAddress());
-    expect(appStateHash).to.be.eq(stateHash);
+    expect(appStateHash).to.be.eq(keccak256(state));
     expect(challengeCounter).to.be.eq(1);
-    expect(finalizesAt).to.be.eq((await provider.getBlockNumber()) + 10);
+    expect(finalizesAt).to.be.eq(
+      (await provider.getBlockNumber()) + ONCHAIN_CHALLENGE_TIMEOUT
+    );
     expect(versionNumber).to.be.eq(1);
   });
 });

--- a/packages/contracts/test/utils/index.ts
+++ b/packages/contracts/test/utils/index.ts
@@ -1,7 +1,12 @@
 import { AppIdentity } from "@counterfactual/types";
 import * as chai from "chai";
 import { solidity } from "ethereum-waffle";
-import { defaultAbiCoder, keccak256, solidityPack } from "ethers/utils";
+import {
+  BigNumberish,
+  defaultAbiCoder,
+  keccak256,
+  solidityPack
+} from "ethers/utils";
 
 export const expect = chai.use(solidity).expect;
 
@@ -9,7 +14,7 @@ export const expect = chai.use(solidity).expect;
 export const computeAppChallengeHash = (
   id: string,
   appStateHash: string,
-  versionNumber: number,
+  versionNumber: BigNumberish,
   timeout: number
 ) =>
   keccak256(
@@ -33,41 +38,29 @@ export const computeActionHash = (
     )
   );
 
-export class AppInstance {
+export class AppIdentityTestClass {
   get identityHash(): string {
-    return this.hashOfEncoding();
+    return keccak256(
+      defaultAbiCoder.encode(
+        ["uint256", "address[]"],
+        [this.channelNonce, this.participants]
+      )
+    );
   }
 
   get appIdentity(): AppIdentity {
     return {
-      owner: this.owner,
       participants: this.participants,
       appDefinition: this.appDefinition,
-      defaultTimeout: this.defaultTimeout
+      defaultTimeout: this.defaultTimeout,
+      channelNonce: this.channelNonce
     };
   }
 
   constructor(
-    readonly owner: string,
     readonly participants: string[],
     readonly appDefinition: string,
-    readonly defaultTimeout: number
+    readonly defaultTimeout: number,
+    readonly channelNonce: number
   ) {}
-
-  // appIdentity
-  public hashOfEncoding(): string {
-    return keccak256(
-      defaultAbiCoder.encode(
-        [
-          `tuple(
-            address owner,
-            address[] participants,
-            address appDefinition,
-            uint256 defaultTimeout
-          )`
-        ],
-        [this.appIdentity]
-      )
-    );
-  }
 }

--- a/packages/high-roller-bot/package.json
+++ b/packages/high-roller-bot/package.json
@@ -33,7 +33,7 @@
   },
   "dependencies": {
     "@counterfactual/firebase-client": "0.0.3",
-    "@counterfactual/node": "0.2.24",
+    "@counterfactual/node": "0.2.25",
     "@counterfactual/types": "0.0.25",
     "eventemitter3": "^4.0.0"
   },

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@counterfactual/node",
-  "version": "0.2.24",
+  "version": "0.2.25",
   "main": "dist/index.js",
   "iife": "dist/index.iife.js",
   "types": "dist/src/index.d.ts",
@@ -50,7 +50,7 @@
   },
   "dependencies": {
     "@counterfactual/cf.js": "0.2.1",
-    "@counterfactual/contracts": "0.1.9",
+    "@counterfactual/contracts": "0.1.10",
     "@counterfactual/firebase-client": "0.0.3",
     "@counterfactual/types": "0.0.25",
     "ethers": "4.0.33",

--- a/packages/node/src/ethereum/utils/app-identity.ts
+++ b/packages/node/src/ethereum/utils/app-identity.ts
@@ -1,8 +1,11 @@
 import { AppIdentity } from "@counterfactual/types";
 import { defaultAbiCoder, keccak256 } from "ethers/utils";
 
-import { APP_IDENTITY } from "./encodings";
-
 export function appIdentityToHash(appIdentity: AppIdentity) {
-  return keccak256(defaultAbiCoder.encode([APP_IDENTITY], [appIdentity]));
+  return keccak256(
+    defaultAbiCoder.encode(
+      ["uint256", "address[]"],
+      [appIdentity.channelNonce, appIdentity.participants]
+    )
+  );
 }

--- a/packages/node/src/ethereum/utils/encodings.ts
+++ b/packages/node/src/ethereum/utils/encodings.ts
@@ -2,7 +2,6 @@
 //       these are not struct declarations but simply multi-line tuple encodings.
 export const APP_IDENTITY = `
   tuple(
-    address owner,
     address[] participants,
     address appDefinition,
     uint256 defaultTimeout

--- a/packages/node/src/models/app-instance.ts
+++ b/packages/node/src/models/app-instance.ts
@@ -19,8 +19,8 @@ import { appIdentityToHash } from "../ethereum/utils/app-identity";
 /**
  * Representation of an AppInstance.
  *
- * @property owner The address of the multisignature wallet on-chain for the
- *           state channel that hold the state this AppInstance controls.
+ * @property multisigAddress The address of the multisignature wallet on-chain for
+ *           the state channel that holds the state this AppInstance controls.
 
  * @property participants The sorted array of public keys used by the users of
  *           this AppInstance for which n-of-n consensus is needed on updates.
@@ -151,10 +151,10 @@ export class AppInstance {
   @Memoize()
   public get identity(): AppIdentity {
     return {
-      owner: this.json.multisigAddress,
       participants: this.json.participants,
       appDefinition: this.json.appInterface.addr,
-      defaultTimeout: this.json.defaultTimeout
+      defaultTimeout: this.json.defaultTimeout,
+      channelNonce: this.json.appSeqNo
     };
   }
 

--- a/packages/node/test/machine/unit/ethereum/set-state-commitment.spec.ts
+++ b/packages/node/test/machine/unit/ethereum/set-state-commitment.spec.ts
@@ -64,8 +64,16 @@ describe("Set State Commitment", () => {
     });
 
     it("should contain expected AppIdentity argument", () => {
-      const [owner, participants, appDefinition, defaultTimeout] = desc.args[0];
-      expect(owner).toBe(appInstance.identity.owner);
+      const [
+        channelNonce,
+        participants,
+        appDefinition,
+        defaultTimeout
+      ] = desc.args[0];
+
+      expect(channelNonce).toEqual(
+        bigNumberify(appInstance.identity.channelNonce)
+      );
       expect(participants).toEqual(appInstance.identity.participants);
       expect(appDefinition).toBe(appInstance.identity.appDefinition);
       expect(defaultTimeout).toEqual(

--- a/packages/simple-hub-server/package.json
+++ b/packages/simple-hub-server/package.json
@@ -38,7 +38,7 @@
   },
   "dependencies": {
     "@counterfactual/firebase-client": "0.0.3",
-    "@counterfactual/node": "0.2.24",
+    "@counterfactual/node": "0.2.25",
     "@counterfactual/types": "0.0.25",
     "@counterfactual/typescript-typings": "0.1.0",
     "@ebryn/jsonapi-ts": "0.1.17",

--- a/packages/specs/source/protocols/update.md
+++ b/packages/specs/source/protocols/update.md
@@ -23,14 +23,16 @@ Two users run the protocol. They are designated as `initiator` and `responder`.
 For the below messages, the digest that is signed is represented as the following (reference: computeAppChallengeHash)
 
 ```typescript
-appIdentityHash := keccak256(
+keccak256(
   ["bytes1", "bytes32", "uint256", "uint256", "bytes32"],
   [
     0x19,
-    keccak256(encode(
-      [address, address[], address, uint256 ],
-      [owner, participants, appDefinition, defaultTimeout]
-    )),
+    keccak256(                        //
+      abi.encode(                     //
+        [uint256, address[]],         // NOTE: This is the
+        [channelNonce, participants]  // appInstanceIdentityHash
+      )                               //
+    ),                                //
     0,
     TIMEOUT,
     appStateHash

--- a/packages/tic-tac-toe-bot/package.json
+++ b/packages/tic-tac-toe-bot/package.json
@@ -35,7 +35,7 @@
   "dependencies": {
     "@counterfactual/firebase-client": "0.0.3",
     "@counterfactual/dapp-tic-tac-toe": "0.1.2",
-    "@counterfactual/node": "0.2.24",
+    "@counterfactual/node": "0.2.25",
     "@counterfactual/types": "0.0.25",
     "eventemitter3": "^4.0.0"
   },

--- a/packages/types/src/app-instance.ts
+++ b/packages/types/src/app-instance.ts
@@ -1,5 +1,7 @@
+import { BigNumberish } from "ethers/utils";
+
 export type AppIdentity = {
-  owner: string;
+  channelNonce: BigNumberish;
   participants: string[];
   appDefinition: string;
   defaultTimeout: number;


### PR DESCRIPTION
The owner property is used for:

1. Added uniqueness on a per `StateChannel` basis of an `AppInstance`
2. Allowing `CALL`s made by a multisignature wallet to override the `signingKeys` property on the adjudicator

This PR removes the ability for both (1) and (2) at the moment.

This means uniqueness for an `AppInstance` is only obtained by unique `signingKeys`, `appDefinition`, and `defaultTimeout` as of the current state of this pull request. It becomes the clients responsibility to never install an `AppInstance` that re-uses all three variables.

Because there is a possibility that `signingKeys` _may_ want to be re-used (although not clear), a new field could be added to the `AppIdentity` called `nonce` or `uniqueKey` or something like this, but it's unclear if that is needed.