### PR TITLE
[node] Remove nofiyCounterparty param

### DIFF
--- a/packages/apps/package.json
+++ b/packages/apps/package.json
@@ -24,7 +24,7 @@
   },
   "devDependencies": {
     "@counterfactual/contracts": "0.1.8",
-    "@counterfactual/types": "0.0.24",
+    "@counterfactual/types": "0.0.25",
     "@types/chai": "4.1.7",
     "@types/mocha": "5.2.7",
     "chai": "4.2.0",

--- a/packages/cf-wallet.js/package.json
+++ b/packages/cf-wallet.js/package.json
@@ -34,7 +34,7 @@
   },
   "dependencies": {
     "@counterfactual/node-provider": "0.1.2",
-    "@counterfactual/types": "0.0.24",
+    "@counterfactual/types": "0.0.25",
     "ethers": "4.0.33",
     "eventemitter3": "^4.0.0",
     "global": "^4.3.2",

--- a/packages/cf-wallet.js/package.json
+++ b/packages/cf-wallet.js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@counterfactual/cf-wallet.js",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "The bridge between web applications and Counterfactual wallets.",
   "types": "dist/src/index.d.ts",
   "main": "dist/index.js",

--- a/packages/cf-wallet.js/src/provider.ts
+++ b/packages/cf-wallet.js/src/provider.ts
@@ -308,9 +308,7 @@ export class Provider {
                 type: EventType.ERROR,
                 data: {
                   errorName: "unexpected_message_type",
-                  message: `Unexpected response type. Expected ${methodName}, got ${
-                    response.result.type
-                  }`
+                  message: `Unexpected response type. Expected ${methodName}, got ${response.result.type}`
                 }
               },
               requestId

--- a/packages/cf-wallet.js/src/provider.ts
+++ b/packages/cf-wallet.js/src/provider.ts
@@ -158,17 +158,11 @@ export class Provider {
    *
    * @param multisigAddress string of the state channel multisig
    * @param amount BigNumber representing the deposit's value
-   * @param notifyCounterparty Boolean
    */
-  async deposit(
-    multisigAddress: string,
-    amount: BigNumber,
-    notifyCounterparty: boolean = true
-  ) {
+  async deposit(multisigAddress: string, amount: BigNumber) {
     await this.callRawNodeMethod(Node.RpcMethodName.DEPOSIT, {
       multisigAddress,
-      amount,
-      notifyCounterparty
+      amount
     });
   }
 
@@ -314,7 +308,9 @@ export class Provider {
                 type: EventType.ERROR,
                 data: {
                   errorName: "unexpected_message_type",
-                  message: `Unexpected response type. Expected ${methodName}, got ${response.result.type}`
+                  message: `Unexpected response type. Expected ${methodName}, got ${
+                    response.result.type
+                  }`
                 }
               },
               requestId

--- a/packages/cf.js/package.json
+++ b/packages/cf.js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@counterfactual/cf.js",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "description": "The bridge between web applications and Counterfactual wallets.",
   "types": "dist/src/index.d.ts",
   "main": "dist/index.js",

--- a/packages/cf.js/package.json
+++ b/packages/cf.js/package.json
@@ -34,7 +34,7 @@
   },
   "dependencies": {
     "@counterfactual/node-provider": "0.1.2",
-    "@counterfactual/types": "0.0.24",
+    "@counterfactual/types": "0.0.25",
     "ethers": "4.0.33",
     "eventemitter3": "^4.0.0",
     "rpc-server": "0.0.1"

--- a/packages/chain/package.json
+++ b/packages/chain/package.json
@@ -18,7 +18,7 @@
   },
   "devDependencies": {
     "@counterfactual/contracts": "0.1.8",
-    "@counterfactual/types": "0.0.24",
+    "@counterfactual/types": "0.0.25",
     "ethers": "4.0.33",
     "ganache-core": "2.5.7",
     "truffle": "5.0.27",

--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -31,7 +31,7 @@
     "solidity"
   ],
   "devDependencies": {
-    "@counterfactual/types": "0.0.24",
+    "@counterfactual/types": "0.0.25",
     "@counterfactual/typescript-typings": "0.1.0",
     "@types/chai": "4.1.7",
     "@types/node": "12.6.2",

--- a/packages/firebase-client/package.json
+++ b/packages/firebase-client/package.json
@@ -16,7 +16,7 @@
     "lint": "tslint -c tslint.json -p ."
   },
   "devDependencies": {
-    "@counterfactual/types": "0.0.24",
+    "@counterfactual/types": "0.0.25",
     "@firebase/app-types": "0.4.0",
     "@firebase/util": "0.2.22",
     "@types/firebase": "3.2.1",

--- a/packages/high-roller-bot/package.json
+++ b/packages/high-roller-bot/package.json
@@ -33,8 +33,8 @@
   },
   "dependencies": {
     "@counterfactual/firebase-client": "0.0.3",
-    "@counterfactual/node": "0.2.21",
-    "@counterfactual/types": "0.0.24",
+    "@counterfactual/node": "0.2.22",
+    "@counterfactual/types": "0.0.25",
     "eventemitter3": "^4.0.0"
   },
   "devDependencies": {

--- a/packages/high-roller-bot/src/utils.ts
+++ b/packages/high-roller-bot/src/utils.ts
@@ -358,7 +358,7 @@ export type APIResourceType =
   | "app";
 
 export type APIResourceRelationships = {
-  [key in APIResourceType]?: APIDataContainer
+  [key in APIResourceType]?: APIDataContainer;
 };
 
 export type APIDataContainer<T = APIResourceAttributes> = {

--- a/packages/high-roller-bot/src/utils.ts
+++ b/packages/high-roller-bot/src/utils.ts
@@ -78,8 +78,7 @@ export async function deposit(
       requestId: generateUUID(),
       params: {
         multisigAddress,
-        amount: parseEther(amount),
-        notifyCounterparty: true
+        amount: parseEther(amount)
       } as NodeTypes.DepositParams
     });
 
@@ -359,7 +358,7 @@ export type APIResourceType =
   | "app";
 
 export type APIResourceRelationships = {
-  [key in APIResourceType]?: APIDataContainer;
+  [key in APIResourceType]?: APIDataContainer
 };
 
 export type APIDataContainer<T = APIResourceAttributes> = {

--- a/packages/node-provider/package.json
+++ b/packages/node-provider/package.json
@@ -21,7 +21,7 @@
     "postinstall": "patch-package"
   },
   "devDependencies": {
-    "@counterfactual/types": "0.0.24",
+    "@counterfactual/types": "0.0.25",
     "@types/jest": "24.0.12",
     "@types/node": "12.6.2",
     "jest": "24.8.0",

--- a/packages/node/README.md
+++ b/packages/node/README.md
@@ -18,6 +18,12 @@ Some specific examples of this include:
 - storing state commitments (delegating to an arbitrary, possibly non-local service implementing a desired interface)
 - implementing a custom Write-Ahead-Log to tweak performance/security properties
 
+## Note:
+
+Any consumer of the Node should set up a handler for the event `DEPOSIT_CONFIRMED` so as to define how this Node behaves when a counter party has initiated a deposit and is asking this Node to make a counter deposit and collateralize the channel. The parameters passed with this event correspond to the same ones used by the initiator, tha is `DepositParams` (as defined in the `@counterfactual/types packages`).
+
+If no such handler is defined, an error is thrown `Recent depositConfirmedEvent which has no event handler` indicating the Node does not know how to handle a counter deposit request.
+
 # Node API
 
 ## Message Format

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@counterfactual/node",
-  "version": "0.2.21",
+  "version": "0.2.22",
   "main": "dist/index.js",
   "iife": "dist/index.iife.js",
   "types": "dist/src/index.d.ts",
@@ -52,7 +52,7 @@
     "@counterfactual/cf.js": "0.2.1",
     "@counterfactual/contracts": "0.1.8",
     "@counterfactual/firebase-client": "0.0.3",
-    "@counterfactual/types": "0.0.24",
+    "@counterfactual/types": "0.0.25",
     "ethers": "4.0.33",
     "eventemitter3": "^4.0.0",
     "loglevel": "^1.6.1",

--- a/packages/node/src/methods/state-channel/deposit/operation.ts
+++ b/packages/node/src/methods/state-channel/deposit/operation.ts
@@ -25,6 +25,8 @@ import { NODE_EVENTS } from "../../../types";
 import { getPeersAddressFromChannel } from "../../../utils";
 import { DEPOSIT_FAILED } from "../../errors";
 
+const DEPOSIT_RETRY_COUNT = 3;
+
 interface DepositContext {
   initialState: SolidityABIEncoderV2Type;
   appInterface: AppInterface;
@@ -92,7 +94,7 @@ export async function installBalanceRefundApp(
 export async function makeDeposit(
   requestHandler: RequestHandler,
   params: Node.DepositParams
-): Promise<boolean> {
+): Promise<void> {
   const { multisigAddress, amount, tokenAddress } = params;
   const { provider, blocksNeededForConfirmation, outgoing } = requestHandler;
 
@@ -107,7 +109,7 @@ export async function makeDeposit(
 
   let txResponse: TransactionResponse;
 
-  let retryCount = 3;
+  let retryCount = DEPOSIT_RETRY_COUNT;
   while (retryCount > 0) {
     try {
       if (tokenAddress === CONVENTION_FOR_ETH_TOKEN_ADDRESS) {
@@ -124,14 +126,16 @@ export async function makeDeposit(
       if (e.toString().includes("reject") || e.toString().includes("denied")) {
         outgoing.emit(NODE_EVENTS.DEPOSIT_FAILED, e);
         console.error(`${DEPOSIT_FAILED}: ${e}`);
-        return false;
       }
 
       retryCount -= 1;
 
       if (retryCount === 0) {
+        outgoing.emit(
+          NODE_EVENTS.DEPOSIT_FAILED,
+          `Could not deposit after ${DEPOSIT_RETRY_COUNT} attempts`
+        );
         console.error(`${DEPOSIT_FAILED}: ${e}`);
-        return false;
       }
     }
   }
@@ -143,7 +147,7 @@ export async function makeDeposit(
 
   await txResponse!.wait(blocksNeededForConfirmation);
 
-  return true;
+  outgoing.emit(NODE_EVENTS.DEPOSIT_CONFIRMED);
 }
 
 export async function uninstallBalanceRefundApp(

--- a/packages/node/src/methods/state-channel/deposit/operation.ts
+++ b/packages/node/src/methods/state-channel/deposit/operation.ts
@@ -21,7 +21,7 @@ import { InstallParams, Protocol, xkeyKthAddress } from "../../../machine";
 import { StateChannel } from "../../../models";
 import { CONVENTION_FOR_ETH_TOKEN_ADDRESS } from "../../../models/free-balance";
 import { RequestHandler } from "../../../request-handler";
-import { NODE_EVENTS, DepositConfirmationMessage } from "../../../types";
+import { NODE_EVENTS } from "../../../types";
 import { getPeersAddressFromChannel } from "../../../utils";
 import { DEPOSIT_FAILED } from "../../errors";
 
@@ -146,19 +146,6 @@ export async function makeDeposit(
   });
 
   await txResponse!.wait(blocksNeededForConfirmation);
-
-  const { messagingService, publicIdentifier, store } = requestHandler;
-  const [peerAddress] = await getPeersAddressFromChannel(
-    publicIdentifier,
-    store,
-    multisigAddress
-  );
-
-  await messagingService.send(peerAddress, {
-    from: publicIdentifier,
-    type: NODE_EVENTS.DEPOSIT_CONFIRMED,
-    data: params
-  } as DepositConfirmationMessage);
 }
 
 export async function uninstallBalanceRefundApp(

--- a/packages/node/src/node.ts
+++ b/packages/node/src/node.ts
@@ -340,8 +340,13 @@ export class Node {
       isExpectingResponse(msg as NodeMessageWrappedProtocolMessage)
     ) {
       await this.handleIoSendDeferral(msg as NodeMessageWrappedProtocolMessage);
-    } else {
+    } else if (
+      isProtocolMessage(msg as NodeMessageWrappedProtocolMessage) &&
+      this.requestHandler.isLegacyEvent(msg.type)
+    ) {
       await this.requestHandler.callEvent(msg.type, msg);
+    } else {
+      await this.rpcRouter.emit(msg.type, msg);
     }
   }
 

--- a/packages/node/src/request-handler.ts
+++ b/packages/node/src/request-handler.ts
@@ -106,7 +106,7 @@ export class RequestHandler {
     const controllerExecutionMethod = this.events.get(event);
     const controllerCount = this.router.eventListenerCount(event);
 
-    if (!controllerExecutionMethod || controllerCount === 0) {
+    if (!controllerExecutionMethod && controllerCount === 0) {
       throw new Error(`Recent ${event} which has no event handler`);
     }
 
@@ -114,6 +114,10 @@ export class RequestHandler {
       await controllerExecutionMethod(this, msg);
     }
     this.router.emit(event, msg);
+  }
+
+  public async isLegacyEvent(event: NodeEvents) {
+    return this.events.has(event);
   }
 
   public getShardedQueue(shardKey: string): Queue {

--- a/packages/node/src/request-handler.ts
+++ b/packages/node/src/request-handler.ts
@@ -104,12 +104,16 @@ export class RequestHandler {
    */
   public async callEvent(event: NodeEvents, msg: Node.NodeMessage) {
     const controllerExecutionMethod = this.events.get(event);
+    const controllerCount = this.router.eventListenerCount(event);
 
-    if (!controllerExecutionMethod) {
+    if (!controllerExecutionMethod || controllerCount === 0) {
       throw new Error(`Recent ${event} which has no event handler`);
     }
 
-    await controllerExecutionMethod(this, msg);
+    if (controllerExecutionMethod) {
+      await controllerExecutionMethod(this, msg);
+    }
+    this.router.emit(event, msg);
   }
 
   public getShardedQueue(shardKey: string): Queue {

--- a/packages/node/src/rpc-router.ts
+++ b/packages/node/src/rpc-router.ts
@@ -72,4 +72,8 @@ export default class RpcRouter extends Router {
 
     this.requestHandler[emitter].emit(event, eventData.result);
   }
+
+  eventListenerCount(event: string): number {
+    return this.requestHandler.outgoing.listenerCount(event);
+  }
 }

--- a/packages/node/test/integration/secure-deposit.spec.ts
+++ b/packages/node/test/integration/secure-deposit.spec.ts
@@ -27,7 +27,7 @@ describe("Node method follows spec - deposit", () => {
     provider = new JsonRpcProvider(global["ganacheURL"]);
   });
 
-  it.only("has the right balance for both parties after deposits", async done => {
+  it("has the right balance for both parties after deposits", async done => {
     const multisigAddress = await createChannel(nodeA, nodeB);
     const depositReq = makeDepositRequest(multisigAddress, One);
 

--- a/packages/playground/package.json
+++ b/packages/playground/package.json
@@ -18,7 +18,7 @@
   },
   "dependencies": {
     "@counterfactual/types": "0.2.18",
-    "@counterfactual/types": "0.0.24",
+    "@counterfactual/types": "0.0.25",
     "@stencil/core": "0.18.1-0",
     "@stencil/router": "0.3.3",
     "@stencil/sass": "0.1.1",

--- a/packages/postgresql-node-connector/package.json
+++ b/packages/postgresql-node-connector/package.json
@@ -17,7 +17,7 @@
     "lint": "tslint -c tslint.json -p ."
   },
   "dependencies": {
-    "@counterfactual/types": "0.0.24",
+    "@counterfactual/types": "0.0.25",
     "pg": "7.11.0",
     "reflect-metadata": "0.1.13",
     "typeorm": "0.2.18"

--- a/packages/simple-hub-server/package.json
+++ b/packages/simple-hub-server/package.json
@@ -38,8 +38,8 @@
   },
   "dependencies": {
     "@counterfactual/firebase-client": "0.0.3",
-    "@counterfactual/node": "0.2.21",
-    "@counterfactual/types": "0.0.24",
+    "@counterfactual/node": "0.2.22",
+    "@counterfactual/types": "0.0.25",
     "@counterfactual/typescript-typings": "0.1.0",
     "@ebryn/jsonapi-ts": "0.1.17",
     "@koa/cors": "^3.0.0",

--- a/packages/tic-tac-toe-bot/package.json
+++ b/packages/tic-tac-toe-bot/package.json
@@ -35,8 +35,8 @@
   "dependencies": {
     "@counterfactual/firebase-client": "0.0.3",
     "@counterfactual/dapp-tic-tac-toe": "0.1.2",
-    "@counterfactual/node": "0.2.21",
-    "@counterfactual/types": "0.0.24",
+    "@counterfactual/node": "0.2.22",
+    "@counterfactual/types": "0.0.25",
     "eventemitter3": "^4.0.0"
   },
   "devDependencies": {

--- a/packages/tic-tac-toe-bot/src/utils.ts
+++ b/packages/tic-tac-toe-bot/src/utils.ts
@@ -78,8 +78,7 @@ export async function deposit(
       requestId: generateUUID(),
       params: {
         multisigAddress,
-        amount: parseEther(amount),
-        notifyCounterparty: true
+        amount: parseEther(amount)
       } as NodeTypes.DepositParams
     });
 

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@counterfactual/types",
-  "version": "0.0.24",
+  "version": "0.0.25",
   "description": "TypeScript typings for common Counterfactual types",
   "main": "dist/index.js",
   "module": "dist/index.esm.js",

--- a/packages/types/src/node.ts
+++ b/packages/types/src/node.ts
@@ -167,7 +167,6 @@ export namespace Node {
     multisigAddress: string;
     amount: BigNumber;
     tokenAddress?: string;
-    notifyCounterparty?: boolean;
   };
 
   export type DepositResult = {


### PR DESCRIPTION
This removes the `notifyCounterparty` parameter on the deposit API and explicitly expects the Node consumer to setup a handler attached to the `DEPOSIT_CONFIRMED` event.