### PR TITLE
[node] More rigorous testing of the TwoPartyFixedOutcome

### DIFF
--- a/packages/node/test/integration/uninstall.spec.ts
+++ b/packages/node/test/integration/uninstall.spec.ts
@@ -1,39 +1,128 @@
+import { One, Two, Zero } from "ethers/constants";
+
 import { Node } from "../../src";
+import { CONVENTION_FOR_ETH_TOKEN_ADDRESS } from "../../src/models/free-balance";
 import { NODE_EVENTS, UninstallMessage } from "../../src/types";
+import { toBeEq } from "../machine/integration/bignumber-jest-matcher";
 
 import { setup, SetupContext } from "./setup";
 import {
+  collateralizeChannel,
   createChannel,
   generateUninstallRequest,
+  getFreeBalanceState,
   getInstalledAppInstances,
   installTTTApp
 } from "./utils";
+
+expect.extend({ toBeEq });
 
 describe("Node method follows spec - uninstall", () => {
   let nodeA: Node;
   let nodeB: Node;
 
-  beforeAll(async () => {
-    const context: SetupContext = await setup(global);
-    nodeA = context["A"].node;
-    nodeB = context["B"].node;
-  });
+  describe("Node A and B install apps of different outcome types, then uninstall them", () => {
+    let appInstanceId: string;
+    let multisigAddress: string;
+    const depositAmount = One;
+    let freeBalanceETH;
+    const initialState = {
+      versionNumber: 0,
+      winner: 2, // Hard-coded winner for test
+      board: [[0, 0, 0], [0, 0, 0], [0, 0, 0]]
+    };
 
-  describe("Node A and B install TTT, then uninstall it", () => {
-    it("sends proposal with non-null initial state", async done => {
-      const initialState = {
-        versionNumber: 0,
-        winner: 1, // Hard-coded winner for test
-        board: [[0, 0, 0], [0, 0, 0], [0, 0, 0]]
-      };
+    beforeEach(async () => {
+      const context: SetupContext = await setup(global);
+      nodeA = context["A"].node;
+      nodeB = context["B"].node;
 
-      await createChannel(nodeA, nodeB);
+      multisigAddress = await createChannel(nodeA, nodeB);
 
-      const appInstanceId = await installTTTApp(nodeA, nodeB, initialState);
+      freeBalanceETH = await getFreeBalanceState(nodeA, multisigAddress);
+      expect(freeBalanceETH[nodeA.freeBalanceAddress]).toBeEq(Zero);
+      expect(freeBalanceETH[nodeB.freeBalanceAddress]).toBeEq(Zero);
+
+      await collateralizeChannel(nodeA, nodeB, multisigAddress, depositAmount);
+
+      freeBalanceETH = await getFreeBalanceState(nodeA, multisigAddress);
+      expect(freeBalanceETH[nodeA.freeBalanceAddress]).toBeEq(depositAmount);
+      expect(freeBalanceETH[nodeB.freeBalanceAddress]).toBeEq(depositAmount);
+    });
+
+    it("installs an app with the TwoPartyFixedOutcome outcome and expects Node A to win total", async done => {
+      appInstanceId = await installTTTApp(
+        nodeA,
+        nodeB,
+        initialState,
+        depositAmount,
+        CONVENTION_FOR_ETH_TOKEN_ADDRESS,
+        depositAmount,
+        CONVENTION_FOR_ETH_TOKEN_ADDRESS
+      );
 
       nodeB.once(NODE_EVENTS.UNINSTALL, async (msg: UninstallMessage) => {
         expect(msg.data.appInstanceId).toBe(appInstanceId);
 
+        freeBalanceETH = await getFreeBalanceState(nodeA, multisigAddress);
+        expect(freeBalanceETH[nodeA.freeBalanceAddress]).toBeEq(Two);
+        expect(freeBalanceETH[nodeB.freeBalanceAddress]).toBeEq(Zero);
+        expect(await getInstalledAppInstances(nodeB)).toEqual([]);
+        done();
+      });
+
+      await nodeA.rpcRouter.dispatch(generateUninstallRequest(appInstanceId));
+
+      expect(await getInstalledAppInstances(nodeA)).toEqual([]);
+    });
+
+    it("installs an app with the TwoPartyFixedOutcome outcome and expects Node B to win total", async done => {
+      initialState.winner = 1;
+
+      const appInstanceId = await installTTTApp(
+        nodeA,
+        nodeB,
+        initialState,
+        depositAmount,
+        CONVENTION_FOR_ETH_TOKEN_ADDRESS,
+        depositAmount,
+        CONVENTION_FOR_ETH_TOKEN_ADDRESS
+      );
+
+      nodeB.once(NODE_EVENTS.UNINSTALL, async (msg: UninstallMessage) => {
+        expect(msg.data.appInstanceId).toBe(appInstanceId);
+
+        freeBalanceETH = await getFreeBalanceState(nodeA, multisigAddress);
+        expect(freeBalanceETH[nodeB.freeBalanceAddress]).toBeEq(Two);
+        expect(freeBalanceETH[nodeA.freeBalanceAddress]).toBeEq(Zero);
+        expect(await getInstalledAppInstances(nodeB)).toEqual([]);
+        done();
+      });
+
+      await nodeA.rpcRouter.dispatch(generateUninstallRequest(appInstanceId));
+
+      expect(await getInstalledAppInstances(nodeA)).toEqual([]);
+    });
+
+    it("installs an app with the TwoPartyFixedOutcome outcome and expects the funds to be split between the nodes", async done => {
+      initialState.winner = 3;
+
+      const appInstanceId = await installTTTApp(
+        nodeA,
+        nodeB,
+        initialState,
+        depositAmount,
+        CONVENTION_FOR_ETH_TOKEN_ADDRESS,
+        depositAmount,
+        CONVENTION_FOR_ETH_TOKEN_ADDRESS
+      );
+
+      nodeB.once(NODE_EVENTS.UNINSTALL, async (msg: UninstallMessage) => {
+        expect(msg.data.appInstanceId).toBe(appInstanceId);
+
+        freeBalanceETH = await getFreeBalanceState(nodeA, multisigAddress);
+        expect(freeBalanceETH[nodeA.freeBalanceAddress]).toBeEq(depositAmount);
+        expect(freeBalanceETH[nodeB.freeBalanceAddress]).toBeEq(depositAmount);
         expect(await getInstalledAppInstances(nodeB)).toEqual([]);
         done();
       });

--- a/packages/node/test/integration/uninstall.spec.ts
+++ b/packages/node/test/integration/uninstall.spec.ts
@@ -17,11 +17,11 @@ import {
 
 expect.extend({ toBeEq });
 
-describe("Node method follows spec - uninstall", () => {
+describe("Node A and B install apps of different outcome types, then uninstall them to test outcomes types and interpreters", () => {
   let nodeA: Node;
   let nodeB: Node;
 
-  describe("Node A and B install apps of different outcome types, then uninstall them", () => {
+  describe("Tests for different outcomes of the TwoPartyFixedOutcome type", () => {
     let appInstanceId: string;
     let multisigAddress: string;
     const depositAmount = One;

--- a/packages/node/test/integration/utils.ts
+++ b/packages/node/test/integration/utils.ts
@@ -434,7 +434,11 @@ export async function createChannel(nodeA: Node, nodeB: Node): Promise<string> {
 export async function installTTTApp(
   nodeA: Node,
   nodeB: Node,
-  initialState?: SolidityABIEncoderV2Type
+  initialState?: SolidityABIEncoderV2Type,
+  initiatorDeposit: BigNumber = Zero,
+  initiatorDepositTokenAddress: string = CONVENTION_FOR_ETH_TOKEN_ADDRESS,
+  responderDeposit: BigNumber = Zero,
+  responderDepositTokenAddress: string = CONVENTION_FOR_ETH_TOKEN_ADDRESS
 ): Promise<string> {
   const initialTTTState: SolidityABIEncoderV2Type = initialState
     ? initialState
@@ -445,7 +449,11 @@ export async function installTTTApp(
       nodeA.publicIdentifier,
       nodeB.publicIdentifier,
       (global["networkContext"] as NetworkContextForTestSuite).TicTacToeApp,
-      initialTTTState
+      initialTTTState,
+      initiatorDeposit,
+      initiatorDepositTokenAddress,
+      responderDeposit,
+      responderDepositTokenAddress
     );
 
     nodeB.on(NODE_EVENTS.PROPOSE_INSTALL, async (msg: ProposeMessage) => {


### PR DESCRIPTION
This adds tests for using the Node to exercise the different outcomes that are possible with the `TwoPartyFixedOutcome` outcome type.