### PR TITLE
[node] [documentation] Fixes diagrams' readibility for Chrome extensions, links document from the README

### DIFF
--- a/packages/node/README.md
+++ b/packages/node/README.md
@@ -18,6 +18,8 @@ Some specific examples of this include:
 - storing state commitments (delegating to an arbitrary, possibly non-local service implementing a desired interface)
 - implementing a custom Write-Ahead-Log to tweak performance/security properties
 
+We have [some diagrams](./docs/diagram.md) explaining the Node's architecture and control flow.
+
 ## Apps and their OutcomeTypes
 
 Each application that is installed in a channel has an `OutcomeType` that defines when the app reaches a terminal state and is about to be uninstalled how the funds allocated to it will be distributed.

--- a/packages/node/docs/diagram.md
+++ b/packages/node/docs/diagram.md
@@ -38,7 +38,7 @@ graph LR
     storeServiceSet["set"]
   end
   
-  subgraph NodeController["NodeController (RPC)"]
+  subgraph "NodeController (RPC)"
     rpcExecute["executeMethod"]-->storeServiceSet
     dispatch-->rpcExecute
     callMethod-->rpcExecute
@@ -70,7 +70,7 @@ graph LR
     OP_SIGN-->signDigest
   end
   
-  subgraph EventController["NodeController (Event)"]
+  subgraph "NodeController (Event)"
     eventExecute["executeMethod"]-->storeServiceSet
     onReceivedMessage-->eventExecute
   end

--- a/packages/node/docs/diagram.md
+++ b/packages/node/docs/diagram.md
@@ -38,7 +38,7 @@ graph LR
     storeServiceSet["set"]
   end
   
-  subgraph "NodeController (RPC)"
+  subgraph NodeController_For_RPC
     rpcExecute["executeMethod"]-->storeServiceSet
     dispatch-->rpcExecute
     callMethod-->rpcExecute
@@ -70,7 +70,7 @@ graph LR
     OP_SIGN-->signDigest
   end
   
-  subgraph "NodeController (Event)"
+  subgraph NodeController_For_Events
     eventExecute["executeMethod"]-->storeServiceSet
     onReceivedMessage-->eventExecute
   end

--- a/packages/node/docs/diagram.md
+++ b/packages/node/docs/diagram.md
@@ -6,29 +6,14 @@ Ownership - arrows indicate "has a pointer to"
 
 ```mermaid
 graph LR
-
-
-
   subgraph Node
-
-
-
     InstructionExecutor
-
     MessagingService
-
     RpcRouter --> RequestHandler
-
     RequestHandler --> RpcRouter
-
     RequestHandler --> StoreService
-
     RequestHandler --> MessagingService
-
     RequestHandler --> InstructionExecutor
-
-    
-
 end
 ```
 
@@ -36,31 +21,29 @@ Control Flow - arrows mostly indicate "calls"
 
 ```mermaid
 graph LR
-
   subgraph MessagingService
     onReceive
     send
   end
-
+  
   subgraph RequestHandler
     callMethod
   end
-
+  
   subgraph RpcRouter
     dispatch
   end
-
+  
   subgraph StoreService
     storeServiceSet["set"]
   end
-
+  
   subgraph NodeController["NodeController (RPC)"]
     rpcExecute["executeMethod"]-->storeServiceSet
-
     dispatch-->rpcExecute
     callMethod-->rpcExecute
   end
-
+  
   subgraph Middleware
     IO_SEND_AND_WAIT
     IO_SEND
@@ -69,58 +52,42 @@ graph LR
     IO_SEND_AND_WAIT-->send
     IO_SEND-->send
   end
-
   subgraph Deferral
     ioSendDeferrals["resolve"]
     deferralCtor["constructor"]
   end
-
+  
   subgraph Signer
     signDigest["signingKey.signDigest"]
   end
-
+  
   subgraph Node
-
     onReceivedMessage
     onReceive-->onReceivedMessage
-
     onReceivedMessage-->ioSendDeferrals
-
     outgoing["Outgoing (EventEmitter)"]
     protocolMessageEventController-->|sends out events <br>after protocol finishes|outgoing
-
     OP_SIGN-->signDigest
-
   end
-
+  
   subgraph EventController["NodeController (Event)"]
-
     eventExecute["executeMethod"]-->storeServiceSet
     onReceivedMessage-->eventExecute
-
   end
-
+  
   subgraph InstructionExecutor
-
     initiateProtocol
-
     runProtocolWithMessage
     protocolMessageEventController-->runProtocolWithMessage
     rpcExecute-->initiateProtocol
-
     runProtocol
-
     initiateProtocol-->runProtocol
     runProtocolWithMessage-->runProtocol
-
     ioSendDeferrals-->|resume|runProtocol
-
     IO_SEND_AND_WAIT-->deferralCtor
-
     runProtocol-->IO_SEND_AND_WAIT
     runProtocol-->IO_SEND
     runProtocol-->OP_SIGN
     runProtocol-->WRITE_COMMITMENT
-
   end
 ```

--- a/packages/node/docs/diagram.md
+++ b/packages/node/docs/diagram.md
@@ -1,8 +1,14 @@
-Here are some diagrams to help you understand the node.
+## Diagrams
 
-If you are reading this on github.com, please use this Chrome extension to render the diagrams: https://chrome.google.com/webstore/detail/mermaid-diagrams/phfcghedmopjadpojhmmaffjmfiakfil
+These diagrams are available to help you understand the underlying architecture of the Node.
 
-Ownership - arrows indicate "has a pointer to"
+If you are reading this on GitHub, please use either of these Chrome extensions to render the diagrams: 
+
+- [mermaid-diagrams](https://chrome.google.com/webstore/detail/mermaid-diagrams/phfcghedmopjadpojhmmaffjmfiakfil)
+- [mermaid](https://chrome.google.com/webstore/detail/github-%20-mermaid/goiiopgdnkogdbjmncgedmgpoajilohe)
+
+### Ownership
+> arrows indicate "has a pointer to"
 
 ```mermaid
 graph LR
@@ -17,7 +23,8 @@ graph LR
 end
 ```
 
-Control Flow - arrows mostly indicate "calls"
+### Control Flow
+> arrows mostly indicate "calls"
 
 ```mermaid
 graph LR


### PR DESCRIPTION
The diagrams were broken with the proposed `mermaid-diagram` extension for Chrome due to whitespace and aliasing problems.

I added an extra extension called `mermaid` as a possible choice to read the diagrams and fixed some syntax errors.

Resolves #1993.


