### PR TITLE
[Bots] fix: Use correct freeBalanceAddress after rename.

### DIFF
--- a/packages/high-roller-bot/package.json
+++ b/packages/high-roller-bot/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@counterfactual/high-roller-bot",
-  "version": "0.0.21",
+  "version": "0.0.22",
   "description": "A bot for the High Roller Playground dApp.",
   "author": "Counterfactual",
   "homepage": "https://github.com/counterfactual/monorepo",

--- a/packages/high-roller-bot/src/utils.ts
+++ b/packages/high-roller-bot/src/utils.ts
@@ -55,7 +55,7 @@ export async function deposit(
   amount: string,
   multisigAddress: string
 ) {
-  const myFreeBalanceAddress = node.ethFreeBalanceAddress;
+  const myFreeBalanceAddress = node.freeBalanceAddress;
 
   const preDepositBalances = await getFreeBalance(node, multisigAddress);
 

--- a/packages/tic-tac-toe-bot/package.json
+++ b/packages/tic-tac-toe-bot/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@counterfactual/tic-tac-toe-bot",
-  "version": "0.0.20",
+  "version": "0.0.21",
   "description": "A bot for the Tic Tac Toe Playground dApp.",
   "author": "Counterfactual",
   "homepage": "https://github.com/counterfactual/monorepo",

--- a/packages/tic-tac-toe-bot/src/utils.ts
+++ b/packages/tic-tac-toe-bot/src/utils.ts
@@ -55,7 +55,7 @@ export async function deposit(
   amount: string,
   multisigAddress: string
 ) {
-  const myFreeBalanceAddress = node.ethFreeBalanceAddress;
+  const myFreeBalanceAddress = node.freeBalanceAddress;
 
   const preDepositBalances = await getFreeBalance(node, multisigAddress);
 


### PR DESCRIPTION
# Description

`ethFreeBalanceAddress` was renamed to `freeBalanceAddress ` This broke the bots in a previous PR.

### Related issues

Broken by: #1984 

- [ ] Deploy preview is functional
