### PR TITLE
Add declarationMap

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,6 +10,7 @@
     "noLib": false,
     "removeComments": true,
     "declaration": true,
+    "declarationMap": true,
     "forceConsistentCasingInFileNames": true,
     "moduleResolution": "node",
     "resolveJsonModule": true,


### PR DESCRIPTION
Allows "jump to source" for references, e.g., `@counterfactual/types`.