### PR TITLE
[monorepo] [wallet-ui] Adds new run-scripts and lint-scripts for Wallet UI

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,9 @@
     "lint": "lerna run lint --parallel --no-bail",
     "lint:fix": "lerna run lint:fix --parallel --no-bail",
     "run:playground": "lerna run start --parallel --scope=**/playground --scope=**/simple-hub-server --scope=**/dapp-high-roller --scope=**/dapp-tic-tac-toe",
+    "run:wallet": "lerna run start --parallel --scope=**/simple-hub-server --scope=**/wallet-ui",
+    "run:dapps": "lerna run start --parallel --scope=**/dapp-high-roller --scope=**/dapp-tic-tac-toe",
+    "run:bots": "lerna run start --parallel --scope=**/high-roller-bot --scope=**/tic-tac-toe-bot",
     "publish": "lerna publish --yes from-package patch",
     "postinstall": "patch-package"
   },

--- a/packages/wallet-ui/package.json
+++ b/packages/wallet-ui/package.json
@@ -17,7 +17,9 @@
     "build": "react-scripts build",
     "test": "CI=true react-scripts test",
     "test:coverage": "CI=true react-scripts test --coverage",
-    "eject": "react-scripts eject"
+    "eject": "react-scripts eject",
+    "lint": "tslint -c tslint.json -p .",
+    "lint:fix": "tslint -c tslint.json -p . --fix"
   },
   "jest": {
     "collectCoverageFrom": [

--- a/packages/wallet-ui/src/store/channels/channels.mock.ts
+++ b/packages/wallet-ui/src/store/channels/channels.mock.ts
@@ -1,6 +1,12 @@
 import { Action } from "redux";
 import { ThunkAction } from "redux-thunk";
-import { ActionType, ApplicationState, ChannelsMap, ChannelsState, StoreAction } from "../types";
+import {
+  ActionType,
+  ApplicationState,
+  ChannelsMap,
+  ChannelsState,
+  StoreAction
+} from "../types";
 
 export const initialState = {
   channels: {} as ChannelsMap

--- a/packages/wallet-ui/src/store/user/user.mock.ts
+++ b/packages/wallet-ui/src/store/user/user.mock.ts
@@ -4,7 +4,11 @@ import { History } from "history";
 import { Action } from "redux";
 import { ThunkAction } from "redux-thunk";
 import { RoutePath } from "../../types";
-import { buildSignatureMessageForLogin, getUserFromStoredToken, storeTokenFromUser } from "../../utils/counterfactual";
+import {
+  buildSignatureMessageForLogin,
+  getUserFromStoredToken,
+  storeTokenFromUser
+} from "../../utils/counterfactual";
 import PlaygroundAPIClient from "../../utils/hub-api-client";
 import { ActionType, ApplicationState, User } from "../types";
 import { dispatchError, UserAddTransition } from "./user";

--- a/packages/wallet-ui/src/store/user/user.ts
+++ b/packages/wallet-ui/src/store/user/user.ts
@@ -4,9 +4,22 @@ import { History } from "history";
 import { Action } from "redux";
 import { ThunkAction, ThunkDispatch } from "redux-thunk";
 import { RoutePath } from "../../types";
-import { buildRegistrationSignaturePayload, buildSignatureMessageForLogin, forMultisig, getNodeAddress, getUserFromStoredToken, storeTokenFromUser } from "../../utils/counterfactual";
+import {
+  buildRegistrationSignaturePayload,
+  buildSignatureMessageForLogin,
+  forMultisig,
+  getNodeAddress,
+  getUserFromStoredToken,
+  storeTokenFromUser
+} from "../../utils/counterfactual";
 import Hub, { ErrorDetail } from "../../utils/hub-api-client";
-import { ActionType, ApplicationState, StoreAction, User, UserState } from "../types";
+import {
+  ActionType,
+  ApplicationState,
+  StoreAction,
+  User,
+  UserState
+} from "../types";
 
 export const initialState = {
   user: {},

--- a/packages/wallet-ui/src/store/wallet/wallet.ts
+++ b/packages/wallet-ui/src/store/wallet/wallet.ts
@@ -4,9 +4,19 @@ import { History } from "history";
 import { Action } from "redux";
 import { ThunkAction } from "redux-thunk";
 import { RoutePath } from "../../types";
-import { forFunds, requestDeposit, requestWithdraw } from "../../utils/counterfactual";
+import {
+  forFunds,
+  requestDeposit,
+  requestWithdraw
+} from "../../utils/counterfactual";
 import log from "../../utils/log";
-import { ActionType, ApplicationState, Deposit, StoreAction, WalletState } from "../types";
+import {
+  ActionType,
+  ApplicationState,
+  Deposit,
+  StoreAction,
+  WalletState
+} from "../types";
 
 export const initialState = {
   ethAddress: "",
@@ -126,7 +136,7 @@ export const withdraw = (
     // 1. Ask Metamask to do the withdraw. !
     dispatch({ type: WalletWithdrawTransition.CheckWallet });
     const response = await requestWithdraw(transaction); // IMPLEMENT THIS!
-    log('withdraw response', response)
+    log("withdraw response", response);
 
     // 2. Wait until the withdraw is completed in both sides. !
     dispatch({ type: WalletWithdrawTransition.WaitForFunds });

--- a/packages/wallet-ui/src/utils/counterfactual.ts
+++ b/packages/wallet-ui/src/utils/counterfactual.ts
@@ -1,4 +1,9 @@
-import { bigNumberify, BigNumberish, computeAddress, parseEther } from "ethers/utils";
+import {
+  bigNumberify,
+  BigNumberish,
+  computeAddress,
+  parseEther
+} from "ethers/utils";
 import { fromExtendedKey, HDNode } from "ethers/utils/hdnode";
 import { BalanceRequest, Deposit, User } from "../store/types";
 import { CounterfactualEvent, CounterfactualMethod } from "../types";

--- a/packages/wallet-ui/src/utils/testSelector.ts
+++ b/packages/wallet-ui/src/utils/testSelector.ts
@@ -1,3 +1,3 @@
 export function testSelector(name: string): string {
-  return `[data-test-selector='${name}']`
+  return `[data-test-selector='${name}']`;
 }


### PR DESCRIPTION
### New scripts for the monorepo

```sh
# Runs the Wallet UI and the Hub Server.
yarn run:wallet

# Runs the example dApps.
yarn run:dapps

# Runs the bots for the example dApps
yarn run:bots
```

### New scripts for `wallet-ui`

```sh
# Lints the project.
yarn lint

# Fixes any linting issues.
yarn lint:fix
```

Resolves #2027.
Resolves #2028.
