### PR TITLE
[node] catch all failing IEs in mininode tests

### DIFF
--- a/packages/node/src/deferred.ts
+++ b/packages/node/src/deferred.ts
@@ -1,3 +1,6 @@
+// Wraps an internal promise and provide public methods to resolve/reject the
+// internal promise. The internal promise is also publicly available so it can
+// be await-ed on.
 export class Deferred<T> {
   private internalPromise: Promise<T>;
   private internalResolve!: (value?: T | PromiseLike<T>) => void;

--- a/packages/node/test/machine/integration/message-router.ts
+++ b/packages/node/test/machine/integration/message-router.ts
@@ -4,32 +4,47 @@ import { Opcode } from "../../../src/machine";
 import { MiniNode } from "./mininode";
 
 export class MessageRouter {
+  // mapping from a mininode's xpub to the mininode
   private nodesMap: Map<string, MiniNode>;
+
+  // mapping from a mininode's xpub to a promise representing the future value
+  // of an IO_SEND_AND_WAIT call. It is expected that the protocol is awaiting
+  // on this promise.
   private deferrals: Map<string, Deferred<any>>;
 
+  // when a message from a mininode causes a protocol to run in another node,
+  // a promise representing completion of the second protocol is added here.
+  private pendingPromises: Set<Promise<void>>;
+
   constructor(nodes: MiniNode[]) {
-    this.nodesMap = new Map<string, MiniNode>();
-    this.deferrals = new Map<string, Deferred<any>>();
+    this.nodesMap = new Map();
+    this.deferrals = new Map();
+    this.pendingPromises = new Set();
 
     for (const node of nodes) {
       this.nodesMap.set(node.xpub, node);
 
       node.ie.register(Opcode.IO_SEND, (args: [any]) => {
         const [message] = args;
-        this.routeMessage(message);
+        this.maybePush(this.routeMessage(message));
       });
       node.ie.register(Opcode.IO_SEND_AND_WAIT, async (args: [any]) => {
         const [message] = args;
         message.fromXpub = node.xpub;
 
         this.deferrals.set(node.xpub, new Deferred());
-        this.routeMessage(message);
+        this.maybePush(this.routeMessage(message));
         const ret = await this.deferrals.get(node.xpub)!.promise;
         this.deferrals.delete(node.xpub);
 
         return ret;
       });
     }
+  }
+
+  private maybePush(v: Promise<void> | null) {
+    if (v === null) return;
+    this.pendingPromises.add(v);
   }
 
   private routeMessage(message: any) {
@@ -44,14 +59,18 @@ export class MessageRouter {
       if (toNode === undefined) {
         throw new Error(`No node with xpub = ${toXpub} found`);
       }
-      toNode.dispatchMessage(message);
-      return;
+
+      // This returns a promise that resolves when runProtocolWithMessage
+      // finishes
+      return toNode.dispatchMessage(message);
     }
 
     deferred.resolve(message);
+    return null;
   }
 
-  public assertNoPending() {
+  public async waitAll() {
+    await Promise.all(this.pendingPromises);
     if (this.deferrals.size !== 0) {
       throw new Error("Pending IO_SEND_AND_WAIT deferrals detected");
     }

--- a/packages/node/test/machine/integration/protocols.spec.ts
+++ b/packages/node/test/machine/integration/protocols.spec.ts
@@ -39,7 +39,7 @@ beforeAll(async () => {
 });
 
 describe("Three mininodes", () => {
-  it("Can run all the protocols", async () => {
+  it("Can run all the protocols", async done => {
     const mininodeA = new MiniNode(network, provider);
     const mininodeB = new MiniNode(network, provider);
     const mininodeC = new MiniNode(network, provider);
@@ -64,9 +64,13 @@ describe("Three mininodes", () => {
       multisigAddress: multisigAB
     });
 
-    // todo: if nodeB/nodeC is still busy doing stuff, we should wait for it
+    // todo(xuanji): if nodeB/nodeC is still busy doing stuff, we should wait for it
 
-    mr.assertNoPending();
+    await mr.waitAll();
+
+    done();
+
+    // return;
 
     const participants = sortAddresses([
       xkeyKthAddress(mininodeA.xpub, 1),
@@ -107,7 +111,7 @@ describe("Three mininodes", () => {
       multisigAddress: multisigAB
     });
 
-    mr.assertNoPending();
+    await mr.waitAll();
 
     mininodeB.scm.set(
       multisigBC,
@@ -118,7 +122,7 @@ describe("Three mininodes", () => {
       })).get(multisigBC)!
     );
 
-    mr.assertNoPending();
+    await mr.waitAll();
 
     expect(mininodeA.scm.size).toBe(1);
     expect(mininodeB.scm.size).toBe(2);

--- a/packages/node/test/machine/integration/protocols.spec.ts
+++ b/packages/node/test/machine/integration/protocols.spec.ts
@@ -39,7 +39,7 @@ beforeAll(async () => {
 });
 
 describe("Three mininodes", () => {
-  it("Can run all the protocols", async done => {
+  it("Can run all the protocols", async () => {
     const mininodeA = new MiniNode(network, provider);
     const mininodeB = new MiniNode(network, provider);
     const mininodeC = new MiniNode(network, provider);
@@ -64,13 +64,7 @@ describe("Three mininodes", () => {
       multisigAddress: multisigAB
     });
 
-    // todo(xuanji): if nodeB/nodeC is still busy doing stuff, we should wait for it
-
-    await mr.waitAll();
-
-    done();
-
-    // return;
+    await mr.waitForAllPendingPromises();
 
     const participants = sortAddresses([
       xkeyKthAddress(mininodeA.xpub, 1),
@@ -111,7 +105,7 @@ describe("Three mininodes", () => {
       multisigAddress: multisigAB
     });
 
-    await mr.waitAll();
+    await mr.waitForAllPendingPromises();
 
     mininodeB.scm.set(
       multisigBC,
@@ -122,7 +116,7 @@ describe("Three mininodes", () => {
       })).get(multisigBC)!
     );
 
-    await mr.waitAll();
+    await mr.waitForAllPendingPromises();
 
     expect(mininodeA.scm.size).toBe(1);
     expect(mininodeB.scm.size).toBe(2);

--- a/packages/node/test/machine/integration/protocols2.spec.ts
+++ b/packages/node/test/machine/integration/protocols2.spec.ts
@@ -62,7 +62,7 @@ describe("Three mininodes", () => {
       multisigAddress: multisigAB
     });
 
-    await mr.waitAll();
+    await mr.waitForAllPendingPromises();
 
     // const signingKeys = sortAddresses([
     //   xkeyKthAddress(mininodeA.xpub, 1),
@@ -93,7 +93,7 @@ describe("Three mininodes", () => {
       actionEncoding: "tuple(uint8 actionType, uint256 amount)"
     };
 
-    await mr.waitAll();
+    await mr.waitForAllPendingPromises();
 
     mininodeB.scm.set(
       multisigBC,
@@ -104,7 +104,7 @@ describe("Three mininodes", () => {
       })).get(multisigBC)!
     );
 
-    await mr.waitAll();
+    await mr.waitForAllPendingPromises();
 
     expect(mininodeA.scm.size).toBe(1);
     expect(mininodeB.scm.size).toBe(2);

--- a/packages/node/test/machine/integration/protocols2.spec.ts
+++ b/packages/node/test/machine/integration/protocols2.spec.ts
@@ -5,7 +5,6 @@ import { Zero } from "ethers/constants";
 import { BaseProvider, JsonRpcProvider } from "ethers/providers";
 
 import { Protocol, xkeyKthAddress } from "../../../src/machine";
-// import { sortAddresses } from "../../../src/machine/xkeys";
 import { CONVENTION_FOR_ETH_TOKEN_ADDRESS } from "../../../src/models/free-balance";
 import { getCreate2MultisigAddress } from "../../../src/utils";
 
@@ -63,9 +62,7 @@ describe("Three mininodes", () => {
       multisigAddress: multisigAB
     });
 
-    // todo: if nodeB/nodeC is still busy doing stuff, we should wait for it
-
-    mr.assertNoPending();
+    await mr.waitAll();
 
     // const signingKeys = sortAddresses([
     //   xkeyKthAddress(mininodeA.xpub, 1),
@@ -96,7 +93,7 @@ describe("Three mininodes", () => {
       actionEncoding: "tuple(uint8 actionType, uint256 amount)"
     };
 
-    mr.assertNoPending();
+    await mr.waitAll();
 
     mininodeB.scm.set(
       multisigBC,
@@ -107,7 +104,7 @@ describe("Three mininodes", () => {
       })).get(multisigBC)!
     );
 
-    mr.assertNoPending();
+    await mr.waitAll();
 
     expect(mininodeA.scm.size).toBe(1);
     expect(mininodeB.scm.size).toBe(2);


### PR DESCRIPTION
Currently there is a bug in the mininode test harness. Spec files like `protocols.spec.ts` have a pointer to a single IE which they use to initiate protocols, and the outcome of the protocol initiated is awaited, hence errors are caught. However, initiating protocols causes other mininodes to receive messages and hence run protocols as well, but the spec file did not have a pointer to those outcomes. This bug can be reproduced by throwing an error after this line. https://github.com/counterfactual/monorepo/blob/aa3a7b5f28f1c1eb2a561b71cd9179f9b14b8dda/packages/node/src/protocol/setup.ts#L99

This PR fixes this bug.