### PR TITLE
[node] use builder pattern

### DIFF
--- a/packages/node/src/models/state-channel.ts
+++ b/packages/node/src/models/state-channel.ts
@@ -212,40 +212,66 @@ export class StateChannel {
     return topLevelKey;
   }
 
-  public addActiveAppAndIncrementFreeBalance(
-    activeApp: string,
-    tokenIndexedIncrements: TokenIndexedCoinTransferMap
-  ) {
+  private build(args: {
+    multisigAddress?: string;
+    userNeuteredExtendedKeys?: string[];
+    appInstances?: ReadonlyMap<string, AppInstance>;
+    singleAssetTwoPartyIntermediaryAgreements?: ReadonlyMap<
+      string,
+      SingleAssetTwoPartyIntermediaryAgreement
+    >;
+    freeBalanceAppInstance?: AppInstance;
+    monotonicNumInstalledApps?: number;
+    createdAt?: number;
+  }) {
+    return new StateChannel(
+      args.multisigAddress || this.multisigAddress,
+      args.userNeuteredExtendedKeys || this.userNeuteredExtendedKeys,
+      args.appInstances || this.appInstances,
+      args.singleAssetTwoPartyIntermediaryAgreements ||
+        this.singleAssetTwoPartyIntermediaryAgreements,
+      args.freeBalanceAppInstance || this.freeBalanceAppInstance,
+      args.monotonicNumInstalledApps || this.monotonicNumInstalledApps,
+      args.createdAt || this.createdAt
+    );
+  }
+
+  public incrementFreeBalance(increments: TokenIndexedCoinTransferMap) {
     const json = this.freeBalance.state as FreeBalanceStateJSON;
 
     const freeBalanceState = deserializeFreeBalanceState(json);
 
-    for (const tokenAddress of Object.keys(tokenIndexedIncrements)) {
+    for (const tokenAddress of Object.keys(increments)) {
       freeBalanceState.balancesIndexedByToken[tokenAddress] = Object.entries(
         merge(
           getBalancesFromFreeBalanceAppInstance(this.freeBalance, tokenAddress),
-          tokenIndexedIncrements[tokenAddress]
+          increments[tokenAddress]
         )
       ).map(([to, amount]) => ({ to, amount }));
     }
 
-    freeBalanceState.activeAppsMap[activeApp] = true;
-
-    return new StateChannel(
-      this.multisigAddress,
-      this.userNeuteredExtendedKeys,
-      this.appInstances,
-      this.singleAssetTwoPartyIntermediaryAgreements,
-      this.freeBalance.setState(serializeFreeBalanceState(freeBalanceState)),
-      this.monotonicNumInstalledApps,
-      this.createdAt
-    );
+    return this.build({
+      freeBalanceAppInstance: this.freeBalance.setState(
+        serializeFreeBalanceState(freeBalanceState)
+      )
+    });
   }
 
-  public removeActiveAppAndIncrementFreeBalance(
-    activeApp: string,
-    tokenIndexedIncrements: TokenIndexedCoinTransferMap
-  ) {
+  public addActiveApp(activeApp: string) {
+    const json = this.freeBalance.state as FreeBalanceStateJSON;
+
+    const freeBalanceState = deserializeFreeBalanceState(json);
+
+    freeBalanceState.activeAppsMap[activeApp] = true;
+
+    return this.build({
+      freeBalanceAppInstance: this.freeBalance.setState(
+        serializeFreeBalanceState(freeBalanceState)
+      )
+    });
+  }
+
+  public removeActiveApp(activeApp: string) {
     const json = this.freeBalance.state as FreeBalanceStateJSON;
 
     const freeBalanceState = deserializeFreeBalanceState(json);
@@ -258,36 +284,37 @@ export class StateChannel {
 
     delete freeBalanceState.activeAppsMap[activeApp];
 
-    for (const tokenAddress of Object.keys(tokenIndexedIncrements)) {
-      freeBalanceState.balancesIndexedByToken[tokenAddress] = Object.entries(
-        merge(
-          getBalancesFromFreeBalanceAppInstance(this.freeBalance, tokenAddress),
-          tokenIndexedIncrements[tokenAddress]
-        )
-      ).map(([to, amount]) => ({ to, amount }));
-    }
+    return this.build({
+      freeBalanceAppInstance: this.freeBalance.setState(
+        serializeFreeBalanceState(freeBalanceState)
+      )
+    });
+  }
 
-    return new StateChannel(
-      this.multisigAddress,
-      this.userNeuteredExtendedKeys,
-      this.appInstances,
-      this.singleAssetTwoPartyIntermediaryAgreements,
-      this.freeBalance.setState(serializeFreeBalanceState(freeBalanceState)),
-      this.monotonicNumInstalledApps,
-      this.createdAt
+  public addActiveAppAndIncrementFreeBalance(
+    activeApp: string,
+    tokenIndexedIncrements: TokenIndexedCoinTransferMap
+  ) {
+    return this.incrementFreeBalance(tokenIndexedIncrements).addActiveApp(
+      activeApp
+    );
+  }
+
+  public removeActiveAppAndIncrementFreeBalance(
+    activeApp: string,
+    tokenIndexedIncrements: TokenIndexedCoinTransferMap
+  ) {
+    return this.removeActiveApp(activeApp).incrementFreeBalance(
+      tokenIndexedIncrements
     );
   }
 
   public setFreeBalance(newState: FreeBalanceState) {
-    return new StateChannel(
-      this.multisigAddress,
-      this.userNeuteredExtendedKeys,
-      this.appInstances,
-      this.singleAssetTwoPartyIntermediaryAgreements,
-      this.freeBalance.setState(serializeFreeBalanceState(newState)),
-      this.monotonicNumInstalledApps,
-      this.createdAt
-    );
+    return this.build({
+      freeBalanceAppInstance: this.freeBalance.setState(
+        serializeFreeBalanceState(newState)
+      )
+    });
   }
 
   public static setupChannel(
@@ -339,15 +366,9 @@ export class StateChannel {
 
     appInstances.set(appInstance.identityHash, appInstance);
 
-    return new StateChannel(
-      this.multisigAddress,
-      this.userNeuteredExtendedKeys,
-      appInstances,
-      this.singleAssetTwoPartyIntermediaryAgreements,
-      this.freeBalanceAppInstance,
-      this.monotonicNumInstalledApps + 1,
-      this.createdAt
-    );
+    return this.build({
+      appInstances
+    });
   }
 
   public removeAppInstance(appInstanceId: string) {
@@ -357,15 +378,9 @@ export class StateChannel {
 
     appInstances.delete(appInstanceId);
 
-    return new StateChannel(
-      this.multisigAddress,
-      this.userNeuteredExtendedKeys,
-      appInstances,
-      this.singleAssetTwoPartyIntermediaryAgreements,
-      this.freeBalanceAppInstance,
-      this.monotonicNumInstalledApps,
-      this.createdAt
-    );
+    return this.build({
+      appInstances
+    });
   }
 
   public setState(
@@ -380,15 +395,9 @@ export class StateChannel {
 
     appInstances.set(appInstanceIdentityHash, appInstance.setState(state));
 
-    return new StateChannel(
-      this.multisigAddress,
-      this.userNeuteredExtendedKeys,
-      appInstances,
-      this.singleAssetTwoPartyIntermediaryAgreements,
-      this.freeBalanceAppInstance,
-      this.monotonicNumInstalledApps,
-      this.createdAt
-    );
+    return this.build({
+      appInstances
+    });
   }
 
   public addSingleAssetTwoPartyIntermediaryAgreement(
@@ -406,15 +415,9 @@ export class StateChannel {
 
     evaaInstances.set(targetIdentityHash, agreement);
 
-    return new StateChannel(
-      this.multisigAddress,
-      this.userNeuteredExtendedKeys,
-      this.appInstances,
-      evaaInstances,
-      this.freeBalanceAppInstance,
-      this.monotonicNumInstalledApps + 1,
-      this.createdAt
-    ).addActiveAppAndIncrementFreeBalance(targetIdentityHash, {
+    return this.build({
+      singleAssetTwoPartyIntermediaryAgreements: evaaInstances
+    }).addActiveAppAndIncrementFreeBalance(targetIdentityHash, {
       [tokenAddress]: flip(decrements)
     });
   }
@@ -435,15 +438,9 @@ export class StateChannel {
       );
     }
 
-    return new StateChannel(
-      this.multisigAddress,
-      this.userNeuteredExtendedKeys,
-      this.appInstances,
-      singleAssetTwoPartyIntermediaryAgreements,
-      this.freeBalanceAppInstance,
-      this.monotonicNumInstalledApps,
-      this.createdAt
-    ).removeActiveAppAndIncrementFreeBalance(targetIdentityHash, {
+    return this.build({
+      singleAssetTwoPartyIntermediaryAgreements
+    }).removeActiveAppAndIncrementFreeBalance(targetIdentityHash, {
       [tokenAddress]: increments
     });
   }
@@ -477,15 +474,10 @@ export class StateChannel {
 
     appInstances.set(appInstance.identityHash, appInstance);
 
-    return new StateChannel(
-      this.multisigAddress,
-      this.userNeuteredExtendedKeys,
+    return this.build({
       appInstances,
-      this.singleAssetTwoPartyIntermediaryAgreements,
-      this.freeBalanceAppInstance,
-      this.monotonicNumInstalledApps + 1,
-      this.createdAt
-    ).addActiveAppAndIncrementFreeBalance(
+      monotonicNumInstalledApps: this.monotonicNumInstalledApps + 1
+    }).addActiveAppAndIncrementFreeBalance(
       appInstance.identityHash,
       flipTokenIndexedBalances(tokenIndexedDecrements)
     );
@@ -513,15 +505,9 @@ export class StateChannel {
       );
     }
 
-    return new StateChannel(
-      this.multisigAddress,
-      this.userNeuteredExtendedKeys,
-      appInstances,
-      this.singleAssetTwoPartyIntermediaryAgreements,
-      this.freeBalanceAppInstance,
-      this.monotonicNumInstalledApps,
-      this.createdAt
-    ).removeActiveAppAndIncrementFreeBalance(
+    return this.build({
+      appInstances
+    }).removeActiveAppAndIncrementFreeBalance(
       appInstanceIdentityHash,
       tokenIndexedIncrements
     );

--- a/packages/node/src/models/state-channel.ts
+++ b/packages/node/src/models/state-channel.ts
@@ -367,7 +367,8 @@ export class StateChannel {
     appInstances.set(appInstance.identityHash, appInstance);
 
     return this.build({
-      appInstances
+      appInstances,
+      monotonicNumInstalledApps: this.monotonicNumInstalledApps + 1
     });
   }
 


### PR DESCRIPTION
This PR creates a `build` method on StateChannel that returns a new copy with selected fields overridden. It also splits out the functions `removeActiveApp` and `incrementFreeBalance`.