### PR TITLE
[monorepo] replace SolidityABIEncoderV2Type with SolidityValueType

### DIFF
--- a/packages/apps/test/high-roller-app.spec.ts
+++ b/packages/apps/test/high-roller-app.spec.ts
@@ -1,7 +1,4 @@
-import {
-  SolidityABIEncoderV2Type,
-  TwoPartyFixedOutcome
-} from "@counterfactual/types";
+import { SolidityValueType, TwoPartyFixedOutcome } from "@counterfactual/types";
 import chai from "chai";
 import * as waffle from "ethereum-waffle";
 import { Contract } from "ethers";
@@ -72,11 +69,11 @@ function decodeBytesToAppState(encodedAppState: string): HighRollerAppState {
   return defaultAbiCoder.decode([rlpAppStateEncoding], encodedAppState)[0];
 }
 
-function encodeState(state: SolidityABIEncoderV2Type) {
+function encodeState(state: SolidityValueType) {
   return defaultAbiCoder.encode([rlpAppStateEncoding], [state]);
 }
 
-function encodeAction(state: SolidityABIEncoderV2Type) {
+function encodeAction(state: SolidityValueType) {
   return defaultAbiCoder.encode([rlpActionEncoding], [state]);
 }
 
@@ -84,8 +81,8 @@ describe("HighRollerApp", () => {
   let highRollerApp: Contract;
 
   async function computeStateTransition(
-    state: SolidityABIEncoderV2Type,
-    action: SolidityABIEncoderV2Type
+    state: SolidityValueType,
+    action: SolidityValueType
   ) {
     return await highRollerApp.functions.applyAction(
       encodeState(state),
@@ -93,7 +90,7 @@ describe("HighRollerApp", () => {
     );
   }
 
-  async function computeOutcome(state: SolidityABIEncoderV2Type) {
+  async function computeOutcome(state: SolidityValueType) {
     const [decodedResult] = defaultAbiCoder.decode(
       ["uint256"],
       await highRollerApp.functions.computeOutcome(encodeState(state))

--- a/packages/apps/test/nim.spec.ts
+++ b/packages/apps/test/nim.spec.ts
@@ -1,4 +1,4 @@
-import { SolidityABIEncoderV2Type } from "@counterfactual/types";
+import { SolidityValueType } from "@counterfactual/types";
 import chai from "chai";
 import * as waffle from "ethereum-waffle";
 import { Contract } from "ethers";
@@ -25,7 +25,7 @@ function decodeBytesToAppState(encodedAppState: string): NimAppState {
 describe("Nim", () => {
   let nim: Contract;
 
-  function encodeState(state: SolidityABIEncoderV2Type) {
+  function encodeState(state: SolidityValueType) {
     return defaultAbiCoder.encode(
       [
         `
@@ -39,7 +39,7 @@ describe("Nim", () => {
     );
   }
 
-  function encodeAction(state: SolidityABIEncoderV2Type) {
+  function encodeAction(state: SolidityValueType) {
     return defaultAbiCoder.encode(
       [
         `
@@ -54,8 +54,8 @@ describe("Nim", () => {
   }
 
   async function applyAction(
-    state: SolidityABIEncoderV2Type,
-    action: SolidityABIEncoderV2Type
+    state: SolidityValueType,
+    action: SolidityValueType
   ) {
     return await nim.functions.applyAction(
       encodeState(state),
@@ -63,7 +63,7 @@ describe("Nim", () => {
     );
   }
 
-  async function isStateTerminal(state: SolidityABIEncoderV2Type) {
+  async function isStateTerminal(state: SolidityValueType) {
     return await nim.functions.isStateTerminal(encodeState(state));
   }
 

--- a/packages/apps/test/tictactoe.spec.ts
+++ b/packages/apps/test/tictactoe.spec.ts
@@ -1,4 +1,4 @@
-import { SolidityABIEncoderV2Type } from "@counterfactual/types";
+import { SolidityValueType } from "@counterfactual/types";
 import chai from "chai";
 import * as waffle from "ethereum-waffle";
 import { Contract } from "ethers";
@@ -26,11 +26,11 @@ function decodeBytesToAppState(encodedAppState: string): TicTacToeAppState {
 describe("TicTacToeApp", () => {
   let ticTacToe: Contract;
 
-  async function computeOutcome(state: SolidityABIEncoderV2Type) {
+  async function computeOutcome(state: SolidityValueType) {
     return await ticTacToe.functions.computeOutcome(encodeState(state));
   }
 
-  function encodeState(state: SolidityABIEncoderV2Type) {
+  function encodeState(state: SolidityValueType) {
     return defaultAbiCoder.encode(
       [
         `
@@ -45,7 +45,7 @@ describe("TicTacToeApp", () => {
     );
   }
 
-  function encodeAction(state: SolidityABIEncoderV2Type) {
+  function encodeAction(state: SolidityValueType) {
     return defaultAbiCoder.encode(
       [
         `
@@ -65,8 +65,8 @@ describe("TicTacToeApp", () => {
   }
 
   async function applyAction(
-    state: SolidityABIEncoderV2Type,
-    action: SolidityABIEncoderV2Type
+    state: SolidityValueType,
+    action: SolidityValueType
   ) {
     return await ticTacToe.functions.applyAction(
       encodeState(state),

--- a/packages/apps/test/unidirectional-transfer-app.spec.ts
+++ b/packages/apps/test/unidirectional-transfer-app.spec.ts
@@ -1,4 +1,4 @@
-import { SolidityABIEncoderV2Type } from "@counterfactual/types";
+import { SolidityValueType } from "@counterfactual/types";
 import chai from "chai";
 import * as waffle from "ethereum-waffle";
 import { Contract } from "ethers";
@@ -72,25 +72,22 @@ const decodeAppState = (
     encodedAppState
   )[0];
 
-const encodeAppState = (state: SolidityABIEncoderV2Type) =>
+const encodeAppState = (state: SolidityValueType) =>
   defaultAbiCoder.encode([unidirectionalTransferAppStateEncoding], [state]);
 
-const encodeAppAction = (state: SolidityABIEncoderV2Type) =>
+const encodeAppAction = (state: SolidityValueType) =>
   defaultAbiCoder.encode([unidirectionalTransferAppActionEncoding], [state]);
 
 describe("UnidirectionalTransferApp", () => {
   let unidirectionalTransferApp: Contract;
 
-  const applyAction = (
-    state: SolidityABIEncoderV2Type,
-    action: SolidityABIEncoderV2Type
-  ) =>
+  const applyAction = (state: SolidityValueType, action: SolidityValueType) =>
     unidirectionalTransferApp.functions.applyAction(
       encodeAppState(state),
       encodeAppAction(action)
     );
 
-  const computeOutcome = (state: SolidityABIEncoderV2Type) =>
+  const computeOutcome = (state: SolidityValueType) =>
     unidirectionalTransferApp.functions.computeOutcome(encodeAppState(state));
 
   before(async () => {

--- a/packages/cf.js/src/app-factory.ts
+++ b/packages/cf.js/src/app-factory.ts
@@ -2,7 +2,7 @@ import {
   AppABIEncodings,
   Node,
   OutcomeType,
-  SolidityABIEncoderV2Type
+  SolidityValueType
 } from "@counterfactual/types";
 import { BigNumber, BigNumberish } from "ethers/utils";
 
@@ -63,7 +63,7 @@ export class AppFactory {
     /** Number of blocks until an on-chain submitted state is considered final */
     timeout: BigNumberish;
     /** Initial state of app instance */
-    initialState: SolidityABIEncoderV2Type;
+    initialState: SolidityValueType;
     /** The outcome type of the app instance */
     outcomeType: OutcomeType;
   }): Promise<string> {
@@ -111,7 +111,7 @@ export class AppFactory {
     /** Number of blocks until an on-chain submitted state is considered final */
     timeout: BigNumberish;
     /** Initial state of app instance */
-    initialState: SolidityABIEncoderV2Type;
+    initialState: SolidityValueType;
     /** List of intermediary peers to route installation through */
     intermediaries: string[];
   }): Promise<string> {

--- a/packages/cf.js/src/app-instance.ts
+++ b/packages/cf.js/src/app-instance.ts
@@ -4,7 +4,7 @@ import {
   AppInstanceJson,
   MultiAssetMultiPartyCoinTransferInterpreterParams,
   Node,
-  SolidityABIEncoderV2Type,
+  SolidityValueType,
   TwoPartyFixedOutcomeInterpreterParams
 } from "@counterfactual/types";
 import { BigNumber } from "ethers/utils";
@@ -86,7 +86,7 @@ export class AppInstance {
    * @async
    * @return JSON representation of latest state
    */
-  async getState(): Promise<SolidityABIEncoderV2Type> {
+  async getState(): Promise<SolidityValueType> {
     const response = await this.provider.callRawNodeMethod(
       Node.RpcMethodName.GET_STATE,
       {
@@ -106,9 +106,7 @@ export class AppInstance {
    * @param action Action to take
    * @return JSON representation of latest state after applying the action
    */
-  async takeAction(
-    action: SolidityABIEncoderV2Type
-  ): Promise<SolidityABIEncoderV2Type> {
+  async takeAction(action: SolidityValueType): Promise<SolidityValueType> {
     const response = await this.provider.callRawNodeMethod(
       Node.RpcMethodName.TAKE_ACTION,
       {

--- a/packages/cf.js/src/types/events.ts
+++ b/packages/cf.js/src/types/events.ts
@@ -1,4 +1,4 @@
-import { SolidityABIEncoderV2Type } from "@counterfactual/types";
+import { SolidityValueType } from "@counterfactual/types";
 
 import { AppInstance } from "../app-instance";
 
@@ -23,8 +23,8 @@ export type RejectInstallEventData = AppEventData;
 export type UninstallEventData = AppEventData;
 
 export type UpdateStateEventData = AppEventData & {
-  newState: SolidityABIEncoderV2Type;
-  action?: SolidityABIEncoderV2Type;
+  newState: SolidityValueType;
+  action?: SolidityValueType;
 };
 
 export type CreateMultisigEventData = {

--- a/packages/contracts/test/challenge-registry-dispute.spec.ts
+++ b/packages/contracts/test/challenge-registry-dispute.spec.ts
@@ -1,5 +1,5 @@
 import { utils } from "@counterfactual/cf.js";
-import { SolidityABIEncoderV2Type } from "@counterfactual/types";
+import { SolidityValueType } from "@counterfactual/types";
 import * as waffle from "ethereum-waffle";
 import { Contract, Wallet } from "ethers";
 import { HashZero } from "ethers/constants";
@@ -46,11 +46,11 @@ const ACTION = {
   increment: bigNumberify(2)
 };
 
-function encodeState(state: SolidityABIEncoderV2Type) {
+function encodeState(state: SolidityValueType) {
   return defaultAbiCoder.encode([`tuple(uint256 counter)`], [state]);
 }
 
-function encodeAction(action: SolidityABIEncoderV2Type) {
+function encodeAction(action: SolidityValueType) {
   return defaultAbiCoder.encode(
     [`tuple(uint8 actionType, uint256 increment)`],
     [action]

--- a/packages/dapp-high-roller/src/components/app-provider/app-provider.tsx
+++ b/packages/dapp-high-roller/src/components/app-provider/app-provider.tsx
@@ -114,7 +114,8 @@ export class AppProvider {
   }
 
   async onUpdateState({ data }: { data: Node.UpdateStateEventData }) {
-    const newState = (data as Node.UpdateStateEventData).newState;
+    const newState = (data as Node.UpdateStateEventData)
+      .newState as HighRollerAppState;
 
     const state = {
       ...newState,

--- a/packages/dapp-high-roller/src/data/mock-app-instance.ts
+++ b/packages/dapp-high-roller/src/data/mock-app-instance.ts
@@ -1,4 +1,4 @@
-import { SolidityABIEncoderV2Type } from "@counterfactual/types";
+import { SolidityValueType } from "@counterfactual/types";
 import { BigNumber } from "ethers/utils";
 
 import { AppABIEncodings, AppInstanceInfo, cf, Node } from "./types";
@@ -49,7 +49,7 @@ export class AppInstance {
    * @async
    * @return JSON representation of latest state
    */
-  async getState(): Promise<SolidityABIEncoderV2Type> {
+  async getState(): Promise<SolidityValueType> {
     const response = await this.provider.callRawNodeMethod(
       Node.MethodName.GET_STATE,
       {
@@ -69,9 +69,7 @@ export class AppInstance {
    * @param action Action to take
    * @return JSON representation of latest state after applying the action
    */
-  async takeAction(
-    action: SolidityABIEncoderV2Type
-  ): Promise<SolidityABIEncoderV2Type> {
+  async takeAction(action: SolidityValueType): Promise<SolidityValueType> {
     const response = await this.provider.callRawNodeMethod(
       Node.MethodName.TAKE_ACTION,
       {

--- a/packages/dapp-high-roller/src/data/types.ts
+++ b/packages/dapp-high-roller/src/data/types.ts
@@ -1,4 +1,4 @@
-import { SolidityABIEncoderV2Type } from "@counterfactual/types";
+import { SolidityValueType } from "@counterfactual/types";
 import { BigNumber, BigNumberish } from "ethers/utils";
 
 import { GameState, HighRollerAppState } from "./game-types";
@@ -90,7 +90,7 @@ export namespace Node {
     initiatorDeposit: BigNumber;
     responderDeposit: BigNumber;
     timeout: BigNumber;
-    initialState: SolidityABIEncoderV2Type;
+    initialState: SolidityValueType;
   };
   export type ProposeInstallResult = {
     appInstanceId: string;
@@ -122,7 +122,7 @@ export namespace Node {
     appInstanceId: string;
   };
   export type GetStateResult = {
-    state: SolidityABIEncoderV2Type;
+    state: SolidityValueType;
   };
 
   export type GetAppInstanceDetailsParams = {
@@ -134,10 +134,10 @@ export namespace Node {
 
   export type TakeActionParams = {
     appInstanceId: string;
-    action: SolidityABIEncoderV2Type;
+    action: SolidityValueType;
   };
   export type TakeActionResult = {
-    newState: SolidityABIEncoderV2Type;
+    newState: SolidityValueType;
   };
 
   export type UninstallParams = {
@@ -194,8 +194,8 @@ export namespace Node {
   };
   export type UpdateStateEventData = {
     appInstanceId: string;
-    newState: SolidityABIEncoderV2Type;
-    action?: SolidityABIEncoderV2Type;
+    newState: SolidityValueType;
+    action?: SolidityValueType;
   };
   export type UninstallEventData = {
     appInstance: AppInstanceInfo;
@@ -256,13 +256,13 @@ export namespace cf {
       proposedToIdentifier: string;
       initiatorDeposit: BigNumberish;
       responderDeposit: BigNumberish;
-      initialState: SolidityABIEncoderV2Type;
+      initialState: SolidityValueType;
     }): Promise<string>;
     proposeInstallVirtual(parameters: {
       proposedToIdentifier: string;
       initiatorDeposit: BigNumberish;
       responderDeposit: BigNumberish;
-      initialState: SolidityABIEncoderV2Type;
+      initialState: SolidityValueType;
       intermediaries: string[];
       timeout: number;
     }): Promise<string>;

--- a/packages/node/README.md
+++ b/packages/node/README.md
@@ -249,7 +249,7 @@ Params:
 
 - `appInstanceId: string`
   - ID of the app instance for which to take action
-- `action:`[`SolidityABIEncoderV2Type`](#data-type-appaction)
+- `action:`[`SolidityValueType`](#data-type-appaction)
   - Action to take on the current state
 
 Result:
@@ -427,7 +427,7 @@ Data:
 - `appInstanceId: string`
   - ID of app instance whose app state was updated
 - `newState:`[`AppState`](#data-type-appstate)
-- `action?:`[`SolidityABIEncoderV2Type`](#data-type-appaction)
+- `action?:`[`SolidityValueType`](#data-type-appaction)
   - Optional action that was taken to advance from the old state to the new state
 
 ### Event: `uninstallEvent`
@@ -501,7 +501,7 @@ An instance of an installed app.
 - Plain Old Javascript Object representation of the state of an app instance.
 - ABI encoded/decoded using the `stateEncoding` field on the instance's [`AppABIEncodings`](#data-type-appabiencodings).
 
-### Data Type: `SolidityABIEncoderV2Type`
+### Data Type: `SolidityValueType`
 
 - Plain Old Javascript Object representation of the action of an app instance.
 - ABI encoded/decoded using the `actionEncoding` field on the instance's [`AppABIEncodings`](#data-type-appabiencodings).

--- a/packages/node/src/machine/types.ts
+++ b/packages/node/src/machine/types.ts
@@ -2,7 +2,7 @@ import {
   AppInterface,
   NetworkContext,
   OutcomeType,
-  SolidityABIEncoderV2Type
+  SolidityValueType
 } from "@counterfactual/types";
 import { BaseProvider } from "ethers/providers";
 import { BigNumber, Signature } from "ethers/utils";
@@ -53,7 +53,7 @@ export type UpdateParams = {
   responderXpub: string;
   multisigAddress: string;
   appIdentityHash: string;
-  newState: SolidityABIEncoderV2Type;
+  newState: SolidityValueType;
 };
 
 export type TakeActionParams = {
@@ -61,7 +61,7 @@ export type TakeActionParams = {
   responderXpub: string;
   multisigAddress: string;
   appIdentityHash: string;
-  action: SolidityABIEncoderV2Type;
+  action: SolidityValueType;
 };
 
 export type WithdrawParams = {
@@ -82,7 +82,7 @@ export type InstallParams = {
   initiatorBalanceDecrement: BigNumber;
   responderBalanceDecrement: BigNumber;
   participants: string[];
-  initialState: SolidityABIEncoderV2Type;
+  initialState: SolidityValueType;
   appInterface: AppInterface;
   defaultTimeout: number;
 
@@ -103,7 +103,7 @@ export type InstallVirtualAppParams = {
   intermediaryXpub: string;
   defaultTimeout: number;
   appInterface: AppInterface;
-  initialState: SolidityABIEncoderV2Type;
+  initialState: SolidityValueType;
 
   // initiator and respondor must fund the installed virtual app with the same
   // token type `tokenAddress`, but may use different amounts

--- a/packages/node/src/methods/app-instance/take-action/controller.ts
+++ b/packages/node/src/methods/app-instance/take-action/controller.ts
@@ -1,4 +1,4 @@
-import { Node, SolidityABIEncoderV2Type } from "@counterfactual/types";
+import { Node, SolidityValueType } from "@counterfactual/types";
 import { INVALID_ARGUMENT } from "ethers/errors";
 import Queue from "p-queue";
 import { jsonRpcMethod } from "rpc-server";
@@ -113,7 +113,7 @@ async function runTakeActionProtocol(
   instructionExecutor: InstructionExecutor,
   initiatorXpub: string,
   responderXpub: string,
-  action: SolidityABIEncoderV2Type
+  action: SolidityValueType
 ) {
   const stateChannel = await store.getChannelFromAppInstanceID(appIdentityHash);
 

--- a/packages/node/src/methods/app-instance/update-state/controller.ts
+++ b/packages/node/src/methods/app-instance/update-state/controller.ts
@@ -1,4 +1,4 @@
-import { Node, SolidityABIEncoderV2Type } from "@counterfactual/types";
+import { Node, SolidityValueType } from "@counterfactual/types";
 import { INVALID_ARGUMENT } from "ethers/errors";
 import Queue from "p-queue";
 
@@ -87,7 +87,7 @@ async function runUpdateStateProtocol(
   instructionExecutor: InstructionExecutor,
   initiatorXpub: string,
   responderXpub: string,
-  newState: SolidityABIEncoderV2Type
+  newState: SolidityValueType
 ) {
   const stateChannel = await store.getChannelFromAppInstanceID(appIdentityHash);
 

--- a/packages/node/src/methods/state-channel/deposit/operation.ts
+++ b/packages/node/src/methods/state-channel/deposit/operation.ts
@@ -6,7 +6,7 @@ import {
   NetworkContext,
   Node,
   OutcomeType,
-  SolidityABIEncoderV2Type
+  SolidityValueType
 } from "@counterfactual/types";
 import { Contract } from "ethers";
 import { Zero } from "ethers/constants";
@@ -28,7 +28,7 @@ import { DEPOSIT_FAILED } from "../../errors";
 const DEPOSIT_RETRY_COUNT = 3;
 
 interface DepositContext {
-  initialState: SolidityABIEncoderV2Type;
+  initialState: SolidityValueType;
   appInterface: AppInterface;
 }
 

--- a/packages/node/src/models/app-instance.ts
+++ b/packages/node/src/models/app-instance.ts
@@ -8,7 +8,7 @@ import {
   OutcomeType,
   SingleAssetTwoPartyCoinTransferInterpreterParams,
   singleAssetTwoPartyCoinTransferInterpreterParamsEncoding,
-  SolidityABIEncoderV2Type,
+  SolidityValueType,
   TwoPartyFixedOutcomeInterpreterParams,
   twoPartyFixedOutcomeInterpreterParamsEncoding,
   virtualAppAgreementEncoding
@@ -284,7 +284,7 @@ export class AppInstance {
   }
 
   public setState(
-    newState: SolidityABIEncoderV2Type,
+    newState: SolidityValueType,
     timeout: number = this.defaultTimeout
   ) {
     try {
@@ -312,7 +312,7 @@ Attempted to setState on an app with an invalid state object.
   }
 
   public async computeOutcome(
-    state: SolidityABIEncoderV2Type,
+    state: SolidityValueType,
     provider: BaseProvider
   ): Promise<string> {
     return this.toEthersContract(provider).functions.computeOutcome(
@@ -327,10 +327,10 @@ Attempted to setState on an app with an invalid state object.
   }
 
   public async computeStateTransition(
-    action: SolidityABIEncoderV2Type,
+    action: SolidityValueType,
     provider: BaseProvider
-  ): Promise<SolidityABIEncoderV2Type> {
-    const ret: SolidityABIEncoderV2Type = {};
+  ): Promise<SolidityValueType> {
+    const ret: SolidityValueType = {};
 
     const computedNextState = this.decodeAppState(
       await this.toEthersContract(provider).functions.applyAction(
@@ -348,23 +348,21 @@ Attempted to setState on an app with an invalid state object.
     return ret;
   }
 
-  public encodeAction(action: SolidityABIEncoderV2Type) {
+  public encodeAction(action: SolidityValueType) {
     return defaultAbiCoder.encode(
       [this.appInterface.actionEncoding!],
       [action]
     );
   }
 
-  public encodeState(state: SolidityABIEncoderV2Type) {
+  public encodeState(state: SolidityValueType) {
     return defaultAbiCoder.encode([this.appInterface.stateEncoding], [state]);
   }
 
-  public decodeAppState(
-    encodedSolidityABIEncoderV2Type: string
-  ): SolidityABIEncoderV2Type {
+  public decodeAppState(encodedSolidityValueType: string): SolidityValueType {
     return defaultAbiCoder.decode(
       [this.appInterface.stateEncoding],
-      encodedSolidityABIEncoderV2Type
+      encodedSolidityValueType
     )[0];
   }
 

--- a/packages/node/src/models/proposed-app-instance-info.ts
+++ b/packages/node/src/models/proposed-app-instance-info.ts
@@ -1,7 +1,7 @@
 import {
   AppABIEncodings,
   OutcomeType,
-  SolidityABIEncoderV2Type
+  SolidityValueType
 } from "@counterfactual/types";
 import { BigNumber, bigNumberify, BigNumberish } from "ethers/utils";
 
@@ -16,7 +16,7 @@ export interface IAppInstanceProposal {
   responderDeposit: BigNumberish;
   responderDepositTokenAddress: string;
   timeout: BigNumberish;
-  initialState: SolidityABIEncoderV2Type;
+  initialState: SolidityValueType;
   proposedByIdentifier: string;
   proposedToIdentifier: string;
   intermediaries?: string[];
@@ -32,7 +32,7 @@ export interface AppInstanceProposalJSON {
   responderDeposit: { _hex: string };
   responderDepositTokenAddress: string;
   timeout: { _hex: string };
-  initialState: SolidityABIEncoderV2Type;
+  initialState: SolidityValueType;
   proposedByIdentifier: string;
   proposedToIdentifier: string;
   intermediaries?: string[];
@@ -58,7 +58,7 @@ export class AppInstanceProposal {
   responderDeposit: BigNumber;
   responderDepositTokenAddress: string;
   timeout: BigNumber;
-  initialState: SolidityABIEncoderV2Type;
+  initialState: SolidityValueType;
   proposedByIdentifier: string;
   proposedToIdentifier: string;
   intermediaries?: string[];

--- a/packages/node/src/models/state-channel.ts
+++ b/packages/node/src/models/state-channel.ts
@@ -1,7 +1,4 @@
-import {
-  AppInstanceJson,
-  SolidityABIEncoderV2Type
-} from "@counterfactual/types";
+import { AppInstanceJson, SolidityValueType } from "@counterfactual/types";
 import { BigNumber, bigNumberify } from "ethers/utils";
 
 import {
@@ -384,10 +381,7 @@ export class StateChannel {
     });
   }
 
-  public setState(
-    appInstanceIdentityHash: string,
-    state: SolidityABIEncoderV2Type
-  ) {
+  public setState(appInstanceIdentityHash: string, state: SolidityValueType) {
     const appInstance = this.getAppInstance(appInstanceIdentityHash);
 
     const appInstances = new Map<string, AppInstance>(

--- a/packages/node/src/store.ts
+++ b/packages/node/src/store.ts
@@ -1,8 +1,4 @@
-import {
-  NetworkContext,
-  Node,
-  SolidityABIEncoderV2Type
-} from "@counterfactual/types";
+import { NetworkContext, Node, SolidityValueType } from "@counterfactual/types";
 import { solidityKeccak256 } from "ethers/utils";
 
 import {
@@ -140,7 +136,7 @@ export class Store {
    */
   public async saveAppInstanceState(
     appInstanceId: string,
-    newState: SolidityABIEncoderV2Type
+    newState: SolidityValueType
   ) {
     const channel = await this.getChannelFromAppInstanceID(appInstanceId);
     const updatedChannel = await channel.setState(appInstanceId, newState);

--- a/packages/node/test/integration/tic-tac-toe.ts
+++ b/packages/node/test/integration/tic-tac-toe.ts
@@ -1,7 +1,4 @@
-import {
-  AppABIEncodings,
-  SolidityABIEncoderV2Type
-} from "@counterfactual/types";
+import { AppABIEncodings } from "@counterfactual/types";
 
 export const tttAbiEncodings: AppABIEncodings = {
   stateEncoding: `
@@ -33,7 +30,7 @@ export const validAction = {
   }
 };
 
-export function initialEmptyTTTState(): SolidityABIEncoderV2Type {
+export function initialEmptyTTTState() {
   return {
     versionNumber: 0,
     winner: 0,

--- a/packages/node/test/integration/utils.ts
+++ b/packages/node/test/integration/utils.ts
@@ -7,7 +7,7 @@ import {
   ContractABI,
   Node as NodeTypes,
   OutcomeType,
-  SolidityABIEncoderV2Type
+  SolidityValueType
 } from "@counterfactual/types";
 import { Contract, Wallet } from "ethers";
 import { One, Zero } from "ethers/constants";
@@ -37,7 +37,7 @@ import { initialEmptyTTTState, tttAbiEncodings } from "./tic-tac-toe";
 interface AppContext {
   appDefinition: string;
   abiEncodings: AppABIEncodings;
-  initialState: SolidityABIEncoderV2Type;
+  initialState: SolidityValueType;
 }
 
 /**
@@ -216,7 +216,7 @@ export function makeAppProposalRequest(
   proposedToIdentifier: string,
   appDefinition: string,
   abiEncodings: AppABIEncodings,
-  initialState: SolidityABIEncoderV2Type,
+  initialState: SolidityValueType,
   initiatorDeposit: BigNumber = Zero,
   initiatorDepositTokenAddress: string = CONVENTION_FOR_ETH_TOKEN_ADDRESS,
   responderDeposit: BigNumber = Zero,
@@ -261,7 +261,7 @@ export function makeVirtualProposalRequest(
   intermediaries: string[],
   appDefinition: string,
   abiEncodings: AppABIEncodings,
-  initialState: SolidityABIEncoderV2Type = {},
+  initialState: SolidityValueType = {},
   initiatorDeposit: BigNumber = Zero,
   initiatorDepositTokenAddress = CONVENTION_FOR_ETH_TOKEN_ADDRESS,
   responderDeposit: BigNumber = Zero,
@@ -433,7 +433,7 @@ export async function installApp(
   nodeA: Node,
   nodeB: Node,
   appDefinition: string,
-  initialState?: SolidityABIEncoderV2Type,
+  initialState?: SolidityValueType,
   initiatorDeposit: BigNumber = Zero,
   initiatorDepositTokenAddress: string = CONVENTION_FOR_ETH_TOKEN_ADDRESS,
   responderDeposit: BigNumber = Zero,
@@ -492,7 +492,7 @@ export async function installVirtualApp(
   nodeB: Node,
   nodeC: Node,
   appDefinition: string,
-  initialState?: SolidityABIEncoderV2Type
+  initialState?: SolidityValueType
 ): Promise<string> {
   return new Promise(async resolve => {
     nodeA.on(
@@ -549,7 +549,7 @@ export async function confirmAppInstanceInstallation(
 export async function getState(
   nodeA: Node,
   appInstanceId: string
-): Promise<SolidityABIEncoderV2Type> {
+): Promise<SolidityValueType> {
   const getStateReq = generateGetStateRequest(appInstanceId);
   const getStateResult = await nodeA.rpcRouter.dispatch(getStateReq);
   return (getStateResult.result.result as NodeTypes.GetStateResult).state;
@@ -560,7 +560,7 @@ export async function makeVirtualProposal(
   nodeC: Node,
   nodeB: Node,
   appDefinition: string,
-  initialState?: SolidityABIEncoderV2Type
+  initialState?: SolidityValueType
 ): Promise<{
   appInstanceId: string;
   params: NodeTypes.ProposeInstallVirtualParams;
@@ -617,7 +617,7 @@ export async function makeVirtualProposeCall(
   nodeC: Node,
   nodeB: Node,
   appDefinition: string,
-  initialState?: SolidityABIEncoderV2Type
+  initialState?: SolidityValueType
 ): Promise<{
   appInstanceId: string;
   params: NodeTypes.ProposeInstallVirtualParams;
@@ -647,7 +647,7 @@ export async function makeProposeCall(
   nodeA: Node,
   nodeB: Node,
   appDefinition: string,
-  initialState?: SolidityABIEncoderV2Type,
+  initialState?: SolidityValueType,
   initiatorDeposit: BigNumber = Zero,
   initiatorDepositTokenAddress: string = CONVENTION_FOR_ETH_TOKEN_ADDRESS,
   responderDeposit: BigNumber = Zero,
@@ -727,10 +727,10 @@ export async function transferERC20Tokens(
 
 export function getAppContext(
   appDefinition: string,
-  initialState?: SolidityABIEncoderV2Type
+  initialState?: SolidityValueType
 ): AppContext {
   let abiEncodings: AppABIEncodings;
-  let initialAppState: SolidityABIEncoderV2Type;
+  let initialAppState: SolidityValueType;
 
   switch (appDefinition) {
     case (global["networkContext"] as NetworkContextForTestSuite).TicTacToeApp:

--- a/packages/node/test/unit/utils.ts
+++ b/packages/node/test/unit/utils.ts
@@ -1,7 +1,7 @@
 import {
   AppABIEncodings,
   OutcomeType,
-  SolidityABIEncoderV2Type
+  SolidityValueType
 } from "@counterfactual/types";
 import { Wallet } from "ethers";
 import { AddressZero, One, Zero } from "ethers/constants";
@@ -35,7 +35,7 @@ export function createAppInstanceProposalForTest(appInstanceId: string) {
       initialState: {
         foo: AddressZero,
         bar: 0
-      } as SolidityABIEncoderV2Type,
+      } as SolidityValueType,
       outcomeType: OutcomeType.TWO_PARTY_FIXED_OUTCOME,
       initiatorDepositTokenAddress: CONVENTION_FOR_ETH_TOKEN_ADDRESS,
       responderDepositTokenAddress: CONVENTION_FOR_ETH_TOKEN_ADDRESS

--- a/packages/specs/source/protocols/install-virtual-app.md
+++ b/packages/specs/source/protocols/install-virtual-app.md
@@ -44,16 +44,16 @@ keccak256(
 
 ## The `InstallVirtualAppParams` type
 
-| Field                        | type                       | description                                           |
-| ---------------------------- | -------------------------- | ----------------------------------------------------- |
-| `initiatorXpub`             | `xpub`                     | xpub of `initiator`                                  |
-| `responderXpub`             | `xpub`                     | xpub of `responder`                                  |
-| `intermediaryXpub`           | `xpub`                     | xpub of `intermediary`                                |
-| `defaultTimeout`             | `uint256`                  | Timeout in case of challenge                          |
-| `appInterface`               | `AppInterface`             | The interface of the virtual app being installed      |
-| `initialState`               | `SolidityValueType` | The initial state of the virtual app                  |
-| `initiatorBalanceDecrement` | `uint256`                  | `initiator`'s deposit into the installed application |
-| `responderBalanceDecrement` | `uint256`                  | `responder`'s deposit into the installed application |
+|            Field            |        type         |                     description                      |
+| --------------------------- | ------------------- | ---------------------------------------------------- |
+| `initiatorXpub`             | `xpub`              | xpub of `initiator`                                  |
+| `responderXpub`             | `xpub`              | xpub of `responder`                                  |
+| `intermediaryXpub`          | `xpub`              | xpub of `intermediary`                               |
+| `defaultTimeout`            | `uint256`           | Timeout in case of challenge                         |
+| `appInterface`              | `AppInterface`      | The interface of the virtual app being installed     |
+| `initialState`              | `SolidityValueType` | The initial state of the virtual app                 |
+| `initiatorBalanceDecrement` | `uint256`           | `initiator`'s deposit into the installed application |
+| `responderBalanceDecrement` | `uint256`           | `responder`'s deposit into the installed application |
 
 ## Messages
 
@@ -63,81 +63,81 @@ keccak256(
 
 ### M1 - Initiator signs AB VirtualAppAgreement
 
-| Field        | Type                      | Description             |
-| ------------ | ------------------------- | ----------------------- |
-| `protocol`   | `string`                  | `"install-virtual-app"` |
-| `params`     | `InstallVirtualAppParams` |                         |
-| `toXpub`     | `address`                 | `intermediaryXpub`   |
-| `seq`        | `number`                  | `1`                     |
-| `signature`  | `signature`               | Initiating signature on   AB VirtualAppAgreement      |
+|    Field    |           Type            |                   Description                    |
+| ----------- | ------------------------- | ------------------------------------------------ |
+| `protocol`  | `string`                  | `"install-virtual-app"`                          |
+| `params`    | `InstallVirtualAppParams` |                                                  |
+| `toXpub`    | `address`                 | `intermediaryXpub`                               |
+| `seq`       | `number`                  | `1`                                              |
+| `signature` | `signature`               | Initiating signature on   AB VirtualAppAgreement |
 
 ### M2 - Intermediary signs IB VirtualAppAgreement
 
-| Field        | Description                   |
-| ------------ | ----------------------------- |
-| `protocol`   | `"install-virtual-app"`       |
-| `params`     | `InstallVirtualAppParams`     |
-| `toXpub`     | `responderXpub`           |
-| `seq`        | `2`                           |
-| `signature`  | Intermediary signature on IB VirtualAppAgreement|
+|    Field    |                   Description                    |
+| ----------- | ------------------------------------------------ |
+| `protocol`  | `"install-virtual-app"`                          |
+| `params`    | `InstallVirtualAppParams`                        |
+| `toXpub`    | `responderXpub`                                  |
+| `seq`       | `2`                                              |
+| `signature` | Intermediary signature on IB VirtualAppAgreement |
 
 
 ### M3 - Responding signs IB VirtualAppAgreement and IB FreeBalanceActivation
 
-| Field        | Description             |
-| ------------ | ----------------------- |
-| `protocol`   | `"install-virtual-app"` |
-| `toXpub`     | `intermediaryXpub`   |
-| `seq`        | `-1`                    |
-| `signature`  | Responding signature on IB VirtualAppAgreement|
-| `signature2`  | Responding signature on IB FreeBalanceActivation|
+|    Field     |                   Description                    |
+| ------------ | ------------------------------------------------ |
+| `protocol`   | `"install-virtual-app"`                          |
+| `toXpub`     | `intermediaryXpub`                               |
+| `seq`        | `-1`                                             |
+| `signature`  | Responding signature on IB VirtualAppAgreement   |
+| `signature2` | Responding signature on IB FreeBalanceActivation |
 
 ### M4 - Intermediary signs AB VirtualAppAgreement and AI FreeBalanceActivation
 
-| Field       | Description             |
-| ----------- | ----------------------- |
-| `protocol`  | `"install-virtual-app"` |
-| `toXpub`    | `initiatorXpub`     |
-| `seq`       | `-1`                    |
-| `signature`  | Intermediary signature on AB VirtualAppAgreement|
-| `signature2`  | Intermediary signature on AI FreeBalanceActivation|
+|    Field     |                    Description                     |
+| ------------ | -------------------------------------------------- |
+| `protocol`   | `"install-virtual-app"`                            |
+| `toXpub`     | `initiatorXpub`                                    |
+| `seq`        | `-1`                                               |
+| `signature`  | Intermediary signature on AB VirtualAppAgreement   |
+| `signature2` | Intermediary signature on AI FreeBalanceActivation |
 
 ### M5 - Initiating signs AI FreeBalanceActivation and AB VirtualApp SetState
 
-| Field        | Description             |
-| ------------ | ----------------------- |
-| `protocol`   | `"install-virtual-app"` |
-| `toXpub`     | `intermediaryXpub`        |
-| `seq`        | `-1`                    |
-| `signature`  | Initiating signature on AI FreeBalanceActivation |
-| `signature2`  | Initiating signature on AIB TimeLockedPassThrough SetState |
-| `signature3`  | Initiating signature on AB VirtualApp SetState |
+|    Field     |                        Description                         |
+| ------------ | ---------------------------------------------------------- |
+| `protocol`   | `"install-virtual-app"`                                    |
+| `toXpub`     | `intermediaryXpub`                                         |
+| `seq`        | `-1`                                                       |
+| `signature`  | Initiating signature on AI FreeBalanceActivation           |
+| `signature2` | Initiating signature on AIB TimeLockedPassThrough SetState |
+| `signature3` | Initiating signature on AB VirtualApp SetState             |
 
 
 ### M6 - Intermediary signs IB FreeBalanceActivation and AB VirtualApp SetState
 
 Note that in this message the intermediary is *forwarding* the initiator's signature on the AB VirtualApp SetState commitment.
 
-| Field        | Description             |
-| ------------ | ----------------------- |
-| `protocol`   | `"install-virtual-app"` |
-| `toXpub`     | `responderXpub`        |
-| `seq`        | `-1`                    |
-| `signature`  | Intermediary signature on IB FreeBalanceActivation|
-| `signature2`  | Intermediary signature on AB VirtualApp SetState |
-| `signature3`  | Initiating signature on AIB TimeLockedPassThrough SetState |
-| `signature4`  | Initiating signature on AB VirtualApp SetState |
+|    Field     |                        Description                         |
+| ------------ | ---------------------------------------------------------- |
+| `protocol`   | `"install-virtual-app"`                                    |
+| `toXpub`     | `responderXpub`                                            |
+| `seq`        | `-1`                                                       |
+| `signature`  | Intermediary signature on IB FreeBalanceActivation         |
+| `signature2` | Intermediary signature on AB VirtualApp SetState           |
+| `signature3` | Initiating signature on AIB TimeLockedPassThrough SetState |
+| `signature4` | Initiating signature on AB VirtualApp SetState             |
 
 
 ### M7 - Responding signs AB VirtualApp SetState
 
-| Field        | Description             |
-| ------------ | ----------------------- |
-| `protocol`   | `"install-virtual-app"` |
-| `toXpub`     | `intermediaryXpub`        |
-| `seq`        | `-1`                    |
+|    Field     |                        Description                         |
+| ------------ | ---------------------------------------------------------- |
+| `protocol`   | `"install-virtual-app"`                                    |
+| `toXpub`     | `intermediaryXpub`                                         |
+| `seq`        | `-1`                                                       |
 | `signature`  | Responding signature on AIB TimeLockedPassThrough SetState |
-| `signature2`  | Responding signature on AB VirtualApp SetState|
+| `signature2` | Responding signature on AB VirtualApp SetState             |
 
 
 
@@ -145,11 +145,11 @@ Note that in this message the intermediary is *forwarding* the initiator's signa
 
 Note that in this message the intermediary is *forwarding* the responder's signature on the AB VirtualApp SetState commitment.
 
-| Field        | Description             |
-| ------------ | ----------------------- |
-| `protocol`   | `"install-virtual-app"` |
-| `toXpub`     | `initiatorXpub`        |
-| `seq`        | `-1`                    |
-| `signature`  | Intermediary signature on AB VirtualApp SetState |
-| `signature2`  | Responding signature on AB VirtualApp SetState |
-| `signature3`  | Responding signature on AIB TimeLockedPassThrough SetState |
+|    Field     |                        Description                         |
+| ------------ | ---------------------------------------------------------- |
+| `protocol`   | `"install-virtual-app"`                                    |
+| `toXpub`     | `initiatorXpub`                                            |
+| `seq`        | `-1`                                                       |
+| `signature`  | Intermediary signature on AB VirtualApp SetState           |
+| `signature2` | Responding signature on AB VirtualApp SetState             |
+| `signature3` | Responding signature on AIB TimeLockedPassThrough SetState |

--- a/packages/specs/source/protocols/install-virtual-app.md
+++ b/packages/specs/source/protocols/install-virtual-app.md
@@ -51,7 +51,7 @@ keccak256(
 | `intermediaryXpub`           | `xpub`                     | xpub of `intermediary`                                |
 | `defaultTimeout`             | `uint256`                  | Timeout in case of challenge                          |
 | `appInterface`               | `AppInterface`             | The interface of the virtual app being installed      |
-| `initialState`               | `SolidityABIEncoderV2Type` | The initial state of the virtual app                  |
+| `initialState`               | `SolidityValueType` | The initial state of the virtual app                  |
 | `initiatorBalanceDecrement` | `uint256`                  | `initiator`'s deposit into the installed application |
 | `responderBalanceDecrement` | `uint256`                  | `responder`'s deposit into the installed application |
 

--- a/packages/types/src/data-types.ts
+++ b/packages/types/src/data-types.ts
@@ -1,7 +1,7 @@
 // https://github.com/counterfactual/monorepo/blob/master/packages/cf.js/API_REFERENCE.md#data-types
 import { BigNumber } from "ethers/utils";
 
-import { AppInterface, SolidityABIEncoderV2Type } from ".";
+import { AppInterface, SolidityValueType } from ".";
 
 export type TwoPartyFixedOutcomeInterpreterParams = {
   // Derived from:
@@ -62,7 +62,7 @@ export type AppInstanceJson = {
   appInterface: AppInterface;
   isVirtualApp: boolean;
   appSeqNo: number;
-  latestState: SolidityABIEncoderV2Type;
+  latestState: SolidityValueType;
   latestVersionNumber: number;
   latestTimeout: number;
 

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -26,7 +26,7 @@ import {
   ABIEncoding,
   Address,
   ContractABI,
-  SolidityABIEncoderV2Type
+  SolidityValueType
 } from "./simple-types";
 
 export interface NetworkContext {
@@ -80,7 +80,7 @@ export {
   multiAssetMultiPartyCoinTransferInterpreterParamsEncoding,
   singleAssetTwoPartyCoinTransferInterpreterParamsEncoding,
   ContractABI,
-  SolidityABIEncoderV2Type,
+  SolidityValueType,
   INodeProvider,
   IRpcNodeProvider,
   Node,

--- a/packages/types/src/node.ts
+++ b/packages/types/src/node.ts
@@ -7,7 +7,7 @@ import {
   AppInstanceJson,
   AppInstanceProposal
 } from "./data-types";
-import { SolidityABIEncoderV2Type } from "./simple-types";
+import { SolidityValueType } from "./simple-types";
 
 export interface INodeProvider {
   onMessage(callback: (message: Node.Message) => void);
@@ -229,7 +229,7 @@ export namespace Node {
   };
 
   export type GetStateResult = {
-    state: SolidityABIEncoderV2Type;
+    state: SolidityValueType;
   };
 
   export type InstallParams = {
@@ -254,7 +254,7 @@ export namespace Node {
     responderDeposit: BigNumber;
     responderDepositTokenAddress?: string;
     timeout: BigNumber;
-    initialState: SolidityABIEncoderV2Type;
+    initialState: SolidityValueType;
     proposedToIdentifier: string;
     outcomeType: OutcomeType;
   };
@@ -277,11 +277,11 @@ export namespace Node {
 
   export type TakeActionParams = {
     appInstanceId: string;
-    action: SolidityABIEncoderV2Type;
+    action: SolidityValueType;
   };
 
   export type TakeActionResult = {
-    newState: SolidityABIEncoderV2Type;
+    newState: SolidityValueType;
   };
 
   export type UninstallParams = {
@@ -298,11 +298,11 @@ export namespace Node {
 
   export type UpdateStateParams = {
     appInstanceId: string;
-    newState: SolidityABIEncoderV2Type;
+    newState: SolidityValueType;
   };
 
   export type UpdateStateResult = {
-    newState: SolidityABIEncoderV2Type;
+    newState: SolidityValueType;
   };
 
   export type WithdrawParams = {
@@ -365,8 +365,8 @@ export namespace Node {
 
   export type UpdateStateEventData = {
     appInstanceId: string;
-    newState: SolidityABIEncoderV2Type;
-    action?: SolidityABIEncoderV2Type;
+    newState: SolidityValueType;
+    action?: SolidityValueType;
   };
 
   export type WithdrawEventData = {

--- a/packages/types/src/simple-types.ts
+++ b/packages/types/src/simple-types.ts
@@ -9,19 +9,16 @@ export type ContractABI = Array<string | ParamType> | string | Interface;
 
 export type SolidityPrimitiveType = string | BigNumberish | boolean;
 
-export type SolidityValueType =
-  | SolidityPrimitiveType
-  | SolidityABIEncoderV2Struct
-  | SolidityABIEncoderV2SArray;
-
 // The application-specific state of an app instance, to be interpreted by the
 // app developer. We just treat it as an opaque blob; however since we pass this
 // around in protocol messages and include this in transaction data in challenges,
 // we impose some restrictions on the type; they must be serializable both as
 // JSON and as solidity structs.
-export type SolidityABIEncoderV2Type =
+export type SolidityValueType =
+  | SolidityPrimitiveType
   | SolidityABIEncoderV2Struct
   | SolidityABIEncoderV2SArray;
+
 
 type SolidityABIEncoderV2Struct = {
   [x: string]: SolidityValueType;


### PR DESCRIPTION
This allows app states to be primitive types (e.g. numbers)