### PR TITLE
[greenboard] Prevents publishing @counterfactual/greenboard

### DIFF
--- a/packages/greenboard/package.json
+++ b/packages/greenboard/package.json
@@ -28,7 +28,8 @@
     "url": "git+https://github.com/counterfactual/monorepo.git"
   },
   "scripts": {
-    "start": "jest"
+    "start": "jest",
+    "publish": "echo This package does not need publishing."
   },
   "jest": {
     "roots": [


### PR DESCRIPTION
It doesn't make any sense to publish this as a package, so this PR adds a no-op script to prevent further unwanted publishing :)