### PR TITLE
[node] fix bug in handleMultiAssetMultiPartyCoinTransfer

### DIFF
--- a/packages/node/src/protocol/utils/get-outcome-increments.ts
+++ b/packages/node/src/protocol/utils/get-outcome-increments.ts
@@ -152,15 +152,12 @@ function handleMultiAssetMultiPartyCoinTransfer(
   );
 
   return interpreterParams.tokenAddresses.reduce(
-    (
-      tokenIndexedCoinTransferMap: TokenIndexedCoinTransferMap,
-      tokenAddress: string,
-      index: number
-    ) => {
-      return (tokenIndexedCoinTransferMap[
-        tokenAddress
-      ] = convertCoinTransfersToCoinTransfersMap(decodedTransfers[index]));
-    },
+    (acc, tokenAddress, index) => ({
+      ...acc,
+      [tokenAddress]: convertCoinTransfersToCoinTransfersMap(
+        decodedTransfers[index]
+      )
+    }),
     {}
   );
 }


### PR DESCRIPTION
This function was returning something that was not a `TokenIndexedCoinTransferMap`.

Tested in #2068