### PR TITLE
Handle asymmetric event emission + better concurrency handling

### DIFF
--- a/packages/high-roller-bot/package.json
+++ b/packages/high-roller-bot/package.json
@@ -33,7 +33,7 @@
   },
   "dependencies": {
     "@counterfactual/firebase-client": "0.0.3",
-    "@counterfactual/node": "0.2.37",
+    "@counterfactual/node": "0.2.38",
     "@counterfactual/types": "0.0.29",
     "eventemitter3": "^4.0.0"
   },

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@counterfactual/node",
-  "version": "0.2.37",
+  "version": "0.2.38",
   "main": "dist/index.js",
   "iife": "dist/index.iife.js",
   "types": "dist/src/index.d.ts",

--- a/packages/node/src/message-handling/handle-protocol-message.ts
+++ b/packages/node/src/message-handling/handle-protocol-message.ts
@@ -152,26 +152,36 @@ function getOutgoingEventDataFromProtocol(
   }
 }
 
-const getStateUpdateEventData = (
+function getStateUpdateEventData(
   { appIdentityHash: appInstanceId }: TakeActionParams | UpdateParams,
   newState: SolidityValueType
-) => ({ newState, appInstanceId });
+) {
+  return { newState, appInstanceId };
+}
 
-const getUninstallVirtualAppEventData = ({
+function getUninstallVirtualAppEventData({
   intermediaryXpub: intermediaryIdentifier,
   targetAppIdentityHash: appInstanceId
-}: UninstallVirtualAppParams) => ({ appInstanceId, intermediaryIdentifier });
+}: UninstallVirtualAppParams) {
+  return { appInstanceId, intermediaryIdentifier };
+}
 
-const getUninstallEventData = ({
+function getUninstallEventData({
   appIdentityHash: appInstanceId
-}: UninstallParams) => ({ appInstanceId });
+}: UninstallParams) {
+  return { appInstanceId };
+}
 
-const getWithdrawEventData = ({ amount }: WithdrawParams) => amount;
+function getWithdrawEventData({ amount }: WithdrawParams) {
+  return amount;
+}
 
-const getSetupEventData = (
+function getSetupEventData(
   { initiatorXpub: counterpartyXpub, multisigAddress }: SetupParams,
   owners: string[]
-) => ({ multisigAddress, owners, counterpartyXpub });
+) {
+  return { multisigAddress, owners, counterpartyXpub };
+}
 
 /**
  * Produces an array of queues that the client must halt execution on

--- a/packages/node/src/message-handling/handle-protocol-message.ts
+++ b/packages/node/src/message-handling/handle-protocol-message.ts
@@ -55,14 +55,14 @@ export async function handleReceivedProtocolMessage(
   const postProtocolStateChannelsMap = await executeFunctionWithinQueues(
     queueNames.map(requestHandler.getShardedQueue.bind(requestHandler)),
     async () => {
-      const ret = await instructionExecutor.runProtocolWithMessage(
+      const stateChannelsMap = await instructionExecutor.runProtocolWithMessage(
         data,
         preProtocolStateChannelsMap
       );
 
-      ret.forEach(store.saveStateChannel.bind(store));
+      stateChannelsMap.forEach(store.saveStateChannel.bind(store));
 
-      return ret;
+      return stateChannelsMap;
     }
   );
 

--- a/packages/node/src/message-handling/handle-protocol-message.ts
+++ b/packages/node/src/message-handling/handle-protocol-message.ts
@@ -60,7 +60,9 @@ export async function handleReceivedProtocolMessage(
         preProtocolStateChannelsMap
       );
 
-      stateChannelsMap.forEach(store.saveStateChannel.bind(store));
+      for (const stateChannel of stateChannelsMap.values()) {
+        await store.saveStateChannel(stateChannel);
+      }
 
       return stateChannelsMap;
     }

--- a/packages/node/src/message-handling/handle-protocol-message.ts
+++ b/packages/node/src/message-handling/handle-protocol-message.ts
@@ -247,6 +247,12 @@ async function getQueueNamesListByProtocolName(
         ];
       }
 
+    // NOTE: This file is only reachable if a protocol message is sent
+    // from an initiator to an intermediary, an intermediary to
+    // a responder, or an initiator to a responder. It is never possible
+    // for the publicIdentifier to be the initiatorXpub, so we ignore
+    // that case.
+
     default:
       throw new Error(
         `handleReceivedProtocolMessage received invalid protocol message: ${protocol}`

--- a/packages/node/src/message-handling/handle-protocol-message.ts
+++ b/packages/node/src/message-handling/handle-protocol-message.ts
@@ -1,4 +1,8 @@
+import { SolidityValueType } from "@counterfactual/types";
+
 import {
+  InstallParams,
+  InstallVirtualAppParams,
   Protocol,
   SetupParams,
   TakeActionParams,
@@ -7,17 +11,14 @@ import {
   UpdateParams,
   WithdrawParams
 } from "../machine";
+import { ProtocolParameters } from "../machine/types";
+import { executeFunctionWithinQueues } from "../methods/queued-execution";
 import { StateChannel } from "../models";
+import { UNASSIGNED_SEQ_NO } from "../protocol/utils/signature-forwarder";
 import { RequestHandler } from "../request-handler";
-import {
-  CreateChannelMessage,
-  NODE_EVENTS,
-  NodeMessageWrappedProtocolMessage,
-  UninstallMessage,
-  UninstallVirtualMessage,
-  UpdateStateMessage,
-  WithdrawMessage
-} from "../types";
+import RpcRouter from "../rpc-router";
+import { Store } from "../store";
+import { NODE_EVENTS, NodeMessageWrappedProtocolMessage } from "../types";
 import { bigNumberifyJson, hashOfOrderedPublicIdentifiers } from "../utils";
 
 /**
@@ -36,134 +37,211 @@ export async function handleReceivedProtocolMessage(
     router
   } = requestHandler;
 
-  const deserializedMsg = bigNumberifyJson(msg);
-
-  const { data } = deserializedMsg;
+  const { data } = bigNumberifyJson(msg) as NodeMessageWrappedProtocolMessage;
 
   const { protocol, seq, params } = data;
 
-  if (seq === -1) return;
+  if (seq === UNASSIGNED_SEQ_NO) return;
 
-  let stateChannelsMap;
-  let uninstallMsg;
+  const preProtocolStateChannelsMap = await store.getStateChannelsMap();
 
-  if (protocol === Protocol.UninstallVirtualApp) {
-    const {
-      initiatorXpub,
-      intermediaryXpub,
-      responderXpub,
-      targetAppIdentityHash
-    } = params as UninstallVirtualAppParams;
+  const queueNames = await getQueueNamesListByProtocolName(
+    protocol,
+    params,
+    store,
+    requestHandler
+  );
 
-    let channelWithIntermediary = await store.getMultisigAddressFromOwnersHash(
-      hashOfOrderedPublicIdentifiers([initiatorXpub, intermediaryXpub])
-    );
-
-    if (channelWithIntermediary === null) {
-      channelWithIntermediary = await store.getMultisigAddressFromOwnersHash(
-        hashOfOrderedPublicIdentifiers([responderXpub, intermediaryXpub])
-      );
-    }
-
-    await requestHandler
-      .getShardedQueue(channelWithIntermediary)
-      .add(async () => {
-        stateChannelsMap = await instructionExecutor.runProtocolWithMessage(
-          data,
-          await store.getStateChannelsMap()
-        );
-
-        stateChannelsMap.forEach(
-          async stateChannel => await store.saveStateChannel(stateChannel)
-        );
-      });
-
-    uninstallMsg = {
-      from: publicIdentifier,
-      type: NODE_EVENTS.UNINSTALL_VIRTUAL,
-      data: {
-        appInstanceId: targetAppIdentityHash,
-        intermediaryIdentifier: intermediaryXpub
-      }
-    } as UninstallVirtualMessage;
-
-    await router.emit(uninstallMsg.type, uninstallMsg, "outgoing");
-  } else {
-    const { multisigAddress } = params as
-      | UninstallParams
-      | WithdrawParams
-      | SetupParams
-      | TakeActionParams
-      | UpdateParams;
-
-    await requestHandler.getShardedQueue(multisigAddress).add(async () => {
-      stateChannelsMap = await instructionExecutor.runProtocolWithMessage(
+  const postProtocolStateChannelsMap = await executeFunctionWithinQueues(
+    queueNames.map(requestHandler.getShardedQueue.bind(requestHandler)),
+    async () => {
+      const ret = await instructionExecutor.runProtocolWithMessage(
         data,
-        await store.getStateChannelsMap()
+        preProtocolStateChannelsMap
       );
 
-      stateChannelsMap.forEach(
-        async stateChannel => await store.saveStateChannel(stateChannel)
-      );
-    });
+      ret.forEach(store.saveStateChannel.bind(store));
 
-    switch (protocol) {
-      case Protocol.Uninstall:
-        uninstallMsg = {
-          from: publicIdentifier,
-          type: NODE_EVENTS.UNINSTALL,
-          data: {
-            appInstanceId: (params as UninstallParams).appIdentityHash
-          }
-        } as UninstallMessage;
-
-        await router.emit(uninstallMsg.type, uninstallMsg, "outgoing");
-        break;
-
-      case Protocol.Withdraw:
-        const withdrawMsg: WithdrawMessage = {
-          from: publicIdentifier,
-          type: NODE_EVENTS.WITHDRAWAL_CONFIRMED,
-          data: {
-            amount: (params as WithdrawParams).amount
-          }
-        };
-
-        await router.emit(withdrawMsg.type, withdrawMsg, "outgoing");
-        break;
-
-      case Protocol.Setup:
-        const { initiatorXpub } = params as SetupParams;
-        const setupMsg: CreateChannelMessage = {
-          from: publicIdentifier,
-          type: NODE_EVENTS.CREATE_CHANNEL,
-          data: {
-            multisigAddress,
-            owners: (stateChannelsMap.get(multisigAddress) as StateChannel)
-              .multisigOwners,
-            counterpartyXpub: initiatorXpub
-          }
-        };
-
-        await router.emit(setupMsg.type, setupMsg, "outgoing");
-        break;
-
-      case Protocol.TakeAction:
-      case Protocol.Update:
-        const { appIdentityHash } = params as TakeActionParams;
-
-        const sc = stateChannelsMap.get(multisigAddress) as StateChannel;
-
-        const updateMsg: UpdateStateMessage = {
-          from: publicIdentifier,
-          type: NODE_EVENTS.UPDATE_STATE,
-          data: {
-            newState: sc.getAppInstance(appIdentityHash).state,
-            appInstanceId: appIdentityHash
-          }
-        };
-
-        await router.emit(updateMsg.type, updateMsg, "outgoing");
+      return ret;
     }
+  );
+
+  const outgoingEventData = getOutgoingEventDataFromProtocol(
+    protocol,
+    params,
+    publicIdentifier,
+    postProtocolStateChannelsMap
+  );
+
+  if (outgoingEventData) {
+    await emitOutgoingNodeMessage(router, outgoingEventData);
+  }
+}
+
+function emitOutgoingNodeMessage(router: RpcRouter, msg: object) {
+  return router.emit(msg["type"], msg, "outgoing");
+}
+
+function getOutgoingEventDataFromProtocol(
+  protocol: string,
+  params: ProtocolParameters,
+  publicIdentifier: string,
+  stateChannelsMap: Map<string, StateChannel>
+) {
+  const baseEvent = { from: publicIdentifier };
+
+  switch (protocol) {
+    case Protocol.Install:
+      // TODO: Have to take an InstallParams object and somehow compute the
+      //       appInstanceIdentityHash from it and then emit an event with
+      //       that value inside of it.
+      return;
+    case Protocol.Uninstall:
+      return {
+        ...baseEvent,
+        type: NODE_EVENTS.UNINSTALL,
+        data: getUninstallEventData(params as UninstallParams)
+      };
+    case Protocol.Setup:
+      return {
+        ...baseEvent,
+        type: NODE_EVENTS.CREATE_CHANNEL,
+        data: getSetupEventData(
+          params as SetupParams,
+          stateChannelsMap.get((params as SetupParams).multisigAddress)!
+            .multisigOwners
+        )
+      };
+    case Protocol.Withdraw:
+      return {
+        ...baseEvent,
+        type: NODE_EVENTS.WITHDRAWAL_CONFIRMED,
+        data: getWithdrawEventData(params as WithdrawParams)
+      };
+    case Protocol.TakeAction:
+    case Protocol.Update:
+      return {
+        ...baseEvent,
+        type: NODE_EVENTS.UPDATE_STATE,
+        data: getStateUpdateEventData(
+          params as UpdateParams,
+          stateChannelsMap
+            .get((params as TakeActionParams | UpdateParams).multisigAddress)!
+            .getAppInstance(
+              (params as TakeActionParams | UpdateParams).appIdentityHash
+            )!.state
+        )
+      };
+    case Protocol.InstallVirtualApp:
+      // TODO: Have to take an InstallParams object and somehow compute the
+      //       appInstanceIdentityHash from it and then emit an event with
+      //       that value inside of it.
+      return;
+    case Protocol.UninstallVirtualApp:
+      return {
+        ...baseEvent,
+        type: NODE_EVENTS.UNINSTALL_VIRTUAL,
+        data: getUninstallVirtualAppEventData(
+          params as UninstallVirtualAppParams
+        )
+      };
+    default:
+      throw new Error(
+        `handleReceivedProtocolMessage received invalid protocol message: ${protocol}`
+      );
+  }
+}
+
+const getStateUpdateEventData = (
+  { appIdentityHash: appInstanceId }: TakeActionParams | UpdateParams,
+  newState: SolidityValueType
+) => ({ newState, appInstanceId });
+
+const getUninstallVirtualAppEventData = ({
+  intermediaryXpub: intermediaryIdentifier,
+  targetAppIdentityHash: appInstanceId
+}: UninstallVirtualAppParams) => ({ appInstanceId, intermediaryIdentifier });
+
+const getUninstallEventData = ({
+  appIdentityHash: appInstanceId
+}: UninstallParams) => ({ appInstanceId });
+
+const getWithdrawEventData = ({ amount }: WithdrawParams) => amount;
+
+const getSetupEventData = (
+  { initiatorXpub: counterpartyXpub, multisigAddress }: SetupParams,
+  owners: string[]
+) => ({ multisigAddress, owners, counterpartyXpub });
+
+/**
+ * Produces an array of queues that the client must halt execution on
+ * for some particular protocol and its set of parameters/
+ *
+ * @param {string} protocol - string name of the protocol
+ * @param {ProtocolParameters} params - parameters relevant for the protocol
+ * @param {Store} store - the store the client is connected to
+ * @param {RequestHandler} requestHandler - the request handler object of the client
+ *
+ * @returns {Promise<string[]>} - list of the names of the queues
+ */
+async function getQueueNamesListByProtocolName(
+  protocol: string,
+  params: ProtocolParameters,
+  store: Store,
+  requestHandler: RequestHandler
+): Promise<string[]> {
+  const { publicIdentifier } = requestHandler;
+
+  switch (protocol) {
+    case Protocol.Install:
+    case Protocol.Setup:
+    case Protocol.Uninstall:
+    case Protocol.Withdraw:
+      const { multisigAddress } = params as
+        | InstallParams
+        | SetupParams
+        | UninstallParams
+        | WithdrawParams;
+
+      return [multisigAddress];
+
+    case Protocol.TakeAction:
+    case Protocol.Update:
+      const { appIdentityHash } = params as TakeActionParams | UpdateParams;
+
+      return [appIdentityHash];
+
+    case Protocol.InstallVirtualApp:
+    case Protocol.UninstallVirtualApp:
+      const { initiatorXpub, intermediaryXpub, responderXpub } = params as
+        | UninstallVirtualAppParams
+        | InstallVirtualAppParams;
+
+      if (publicIdentifier === intermediaryXpub) {
+        return [
+          await store.getMultisigAddressFromOwnersHash(
+            hashOfOrderedPublicIdentifiers([initiatorXpub, intermediaryXpub])
+          ),
+          await store.getMultisigAddressFromOwnersHash(
+            hashOfOrderedPublicIdentifiers([responderXpub, intermediaryXpub])
+          )
+        ];
+      }
+
+      if (publicIdentifier === responderXpub) {
+        return [
+          await store.getMultisigAddressFromOwnersHash(
+            hashOfOrderedPublicIdentifiers([responderXpub, intermediaryXpub])
+          ),
+          await store.getMultisigAddressFromOwnersHash(
+            hashOfOrderedPublicIdentifiers([responderXpub, initiatorXpub])
+          )
+        ];
+      }
+
+    default:
+      throw new Error(
+        `handleReceivedProtocolMessage received invalid protocol message: ${protocol}`
+      );
   }
 }

--- a/packages/node/src/methods/app-instance/uninstall-virtual/controller.ts
+++ b/packages/node/src/methods/app-instance/uninstall-virtual/controller.ts
@@ -50,16 +50,14 @@ export default class UninstallVirtualController extends NodeController {
   }
 
   protected async beforeExecution(
+    // @ts-ignore
     requestHandler: RequestHandler,
     params: Node.UninstallVirtualParams
   ) {
-    const { store } = requestHandler;
     const { appInstanceId } = params;
 
-    const stateChannel = await store.getChannelFromAppInstanceID(appInstanceId);
-
-    if (!stateChannel.hasAppInstance(appInstanceId)) {
-      throw new Error(APP_ALREADY_UNINSTALLED(appInstanceId));
+    if (!appInstanceId) {
+      throw new Error(NO_APP_INSTANCE_ID_TO_UNINSTALL);
     }
   }
 

--- a/packages/node/src/methods/app-instance/uninstall/controller.ts
+++ b/packages/node/src/methods/app-instance/uninstall/controller.ts
@@ -39,16 +39,14 @@ export default class UninstallController extends NodeController {
   }
 
   protected async beforeExecution(
+    // @ts-ignore
     requestHandler: RequestHandler,
     params: Node.UninstallParams
   ) {
-    const { store } = requestHandler;
     const { appInstanceId } = params;
 
-    const stateChannel = await store.getChannelFromAppInstanceID(appInstanceId);
-
-    if (!stateChannel.hasAppInstance(appInstanceId)) {
-      throw new Error(APP_ALREADY_UNINSTALLED(appInstanceId));
+    if (!appInstanceId) {
+      throw new Error(NO_APP_INSTANCE_ID_TO_UNINSTALL);
     }
   }
 

--- a/packages/node/src/methods/queued-execution.ts
+++ b/packages/node/src/methods/queued-execution.ts
@@ -4,26 +4,26 @@ import Queue from "p-queue";
  * Executes a function call and adds it to one or more promise queues.
  *
  * @export
- * @param {Queue[]} queues - a list of p-queue queues
+ * @param {Queue[]} queueList - a list of p-queue queues
  * @param {() => Promise<any>} f - any asyncronous function
  * @returns
  */
 export async function executeFunctionWithinQueues(
-  queues: Queue[],
+  queueList: Queue[],
   f: () => Promise<any>
 ) {
   let promise;
 
-  const executeCached = async () => {
+  const executeCached = () => {
     if (!promise) promise = f();
-    return await promise;
+    return promise;
   };
 
-  if (queues.length > 0) {
-    for (const queue of queues) queue.add(executeCached);
-    for (const queue of queues) await queue;
-    return await promise;
+  if (queueList.length > 0) {
+    for (const queue of queueList) queue.add(executeCached);
+    for (const queue of queueList) await queue;
+    return promise;
   }
 
-  return await executeCached();
+  return executeCached();
 }

--- a/packages/node/src/methods/queued-execution.ts
+++ b/packages/node/src/methods/queued-execution.ts
@@ -1,0 +1,29 @@
+import Queue from "p-queue";
+
+/**
+ * Executes a function call and adds it to one or more promise queues.
+ *
+ * @export
+ * @param {Queue[]} queues - a list of p-queue queues
+ * @param {() => Promise<any>} f - any asyncronous function
+ * @returns
+ */
+export async function executeFunctionWithinQueues(
+  queues: Queue[],
+  f: () => Promise<any>
+) {
+  let promise;
+
+  const executeCached = async () => {
+    if (!promise) promise = f();
+    return await promise;
+  };
+
+  if (queues.length > 0) {
+    for (const queue of queues) queue.add(executeCached);
+    for (const queue of queues) await queue;
+    return await promise;
+  }
+
+  return await executeCached();
+}

--- a/packages/node/src/methods/queued-execution.ts
+++ b/packages/node/src/methods/queued-execution.ts
@@ -14,10 +14,10 @@ export async function executeFunctionWithinQueues(
 ) {
   let promise;
 
-  const executeCached = () => {
+  function executeCached() {
     if (!promise) promise = f();
     return promise;
-  };
+  }
 
   if (queueList.length > 0) {
     for (const queue of queueList) queue.add(executeCached);

--- a/packages/node/test/integration/uninstall-virtual.spec.ts
+++ b/packages/node/test/integration/uninstall-virtual.spec.ts
@@ -12,6 +12,8 @@ import {
   installVirtualApp
 } from "./utils";
 
+jest.setTimeout(10000);
+
 describe("Node method follows spec - uninstall virtual", () => {
   let nodeA: Node;
   let nodeB: Node;

--- a/packages/node/test/integration/uninstall-with-postgres.spec.ts
+++ b/packages/node/test/integration/uninstall-with-postgres.spec.ts
@@ -37,6 +37,9 @@ describe("Node method follows spec - uninstall", () => {
 
       await createChannel(nodeA, nodeB);
 
+      // FIXME: There is some timing issue with postgres @snario noticed
+      await timeout(2000);
+
       const [appInstanceId] = await installApp(
         nodeA,
         nodeB,

--- a/packages/node/test/integration/utils.ts
+++ b/packages/node/test/integration/utils.ts
@@ -416,18 +416,19 @@ export async function collateralizeChannel(
 
 export async function createChannel(nodeA: Node, nodeB: Node): Promise<string> {
   return new Promise(async resolve => {
-    nodeA.on(NODE_EVENTS.CREATE_CHANNEL, async (msg: CreateChannelMessage) => {
-      expect(await getInstalledAppInstances(nodeA)).toEqual([]);
+    nodeB.on(NODE_EVENTS.CREATE_CHANNEL, async (msg: CreateChannelMessage) => {
       expect(await getInstalledAppInstances(nodeB)).toEqual([]);
       resolve(msg.data.multisigAddress);
     });
 
     // trigger channel creation but only resolve with the multisig address
     // as acknowledged by the node
-    getMultisigCreationTransactionHash(nodeA, [
+    await getMultisigCreationTransactionHash(nodeA, [
       nodeA.publicIdentifier,
       nodeB.publicIdentifier
     ]);
+
+    expect(await getInstalledAppInstances(nodeA)).toEqual([]);
   });
 }
 
@@ -455,6 +456,7 @@ export async function installApp(
       responderDeposit,
       responderDepositTokenAddress
     );
+
     proposedParams = appInstanceInstallationProposalRequest.parameters as NodeTypes.ProposeInstallParams;
 
     nodeB.on(NODE_EVENTS.PROPOSE_INSTALL, async (msg: ProposeMessage) => {

--- a/packages/playground/package.json
+++ b/packages/playground/package.json
@@ -19,7 +19,7 @@
   "dependencies": {
     "@counterfactual/cf.js": "0.2.3",
     "@counterfactual/types": "0.0.29",
-    "@counterfactual/node": "0.2.37",
+    "@counterfactual/node": "0.2.38",
     "@stencil/core": "0.18.1-0",
     "@stencil/router": "0.3.3",
     "@stencil/sass": "0.1.1",

--- a/packages/simple-hub-server/package.json
+++ b/packages/simple-hub-server/package.json
@@ -39,7 +39,7 @@
   },
   "dependencies": {
     "@counterfactual/firebase-client": "0.0.3",
-    "@counterfactual/node": "0.2.37",
+    "@counterfactual/node": "0.2.38",
     "@counterfactual/types": "0.0.29",
     "@counterfactual/typescript-typings": "0.1.0",
     "@ebryn/jsonapi-ts": "0.1.17",

--- a/packages/tic-tac-toe-bot/package.json
+++ b/packages/tic-tac-toe-bot/package.json
@@ -35,7 +35,7 @@
   "dependencies": {
     "@counterfactual/firebase-client": "0.0.3",
     "@counterfactual/dapp-tic-tac-toe": "0.1.2",
-    "@counterfactual/node": "0.2.37",
+    "@counterfactual/node": "0.2.38",
     "@counterfactual/types": "0.0.29",
     "eventemitter3": "^4.0.0"
   },


### PR DESCRIPTION
Concurrency fixes:

1. Install virtual app now has queuing. It did not before.
2. Uninstall virtual app now queues on both channels with counterparties, not just one.
3. Update and take action now queues on app instance identity hash, not multisig address