### PR TITLE
[node] Replace `free-balance` API with `FreeBalanceClass`

### DIFF
--- a/packages/node/docs/source/api.md
+++ b/packages/node/docs/source/api.md
@@ -346,11 +346,13 @@ Error(s):
 
 ### Method: `getFreeBalance`
 
-Gets the free balance AppInstance of the specified channel.
+Gets the free balance AppInstance of the specified channel for the specified
+token. Defaults to ETH if no token is specified.
 
 Params:
 
 - `multisigAddress: string`
+- `tokenAddress?: string`
 
 Result:
 
@@ -361,6 +363,9 @@ Result:
 ```
 
 Returns a mapping from address to balance in wei. The address of a node with public identifier `publicIdentifier` is defined as `fromExtendedKey(publicIdentifier).derivePath("0").address`.
+
+Note: calling this a specific token address will return Zero even if the channel
+has never had any deposits/withdrawals of that token.
 
 ### Method: `getTokenIndexedFreeBalanceStates`
 

--- a/packages/node/src/ethereum/utils/free-balance-app.ts
+++ b/packages/node/src/ethereum/utils/free-balance-app.ts
@@ -1,10 +1,9 @@
 import { AppInterface } from "@counterfactual/types";
 import { Zero } from "ethers/constants";
-import { BigNumber, defaultAbiCoder } from "ethers/utils";
+import { BigNumber } from "ethers/utils";
 
 import {
   CoinTransferMap,
-  FreeBalanceStateJSON,
   TokenIndexedCoinTransferMap
 } from "../../models/free-balance";
 
@@ -25,10 +24,6 @@ export function getFreeBalanceAppInterface(addr: string): AppInterface {
     stateEncoding: freeBalanceAppStateEncoding,
     actionEncoding: undefined // because no actions exist for FreeBalanceApp
   };
-}
-
-export function encodeFreeBalanceAppState(state: FreeBalanceStateJSON) {
-  return defaultAbiCoder.encode([freeBalanceAppStateEncoding], [state]);
 }
 
 export function flipTokenIndexedBalances(
@@ -59,8 +54,8 @@ export function flip(coinTransferMap: CoinTransferMap): CoinTransferMap {
 /**
  * Returns the first base mapping, but incremented by values specified in the
  * second increment. Passing increments whose keys are not present in the base
- * is an error. Keys in the base mapping which are not explicitly incremented
- * are returned unchanged.
+ * sets them to the increment. Keys in the base mapping which are not explicitly
+ * incremented are returned unchanged.
  */
 export function merge(
   base: { [s: string]: BigNumber },
@@ -68,22 +63,13 @@ export function merge(
 ) {
   const ret = {} as { [s: string]: BigNumber };
 
-  for (const key of Object.keys(base)) {
-    if (increments[key]) {
-      ret[key] = base[key].add(increments[key]);
-      if (ret[key].lt(Zero)) {
-        throw new Error("Underflow in merge");
-      }
-    } else {
-      ret[key] = base[key];
-    }
-  }
+  const s1 = new Set(Object.keys(base));
+  const s2 = new Set(Object.keys(increments));
 
-  for (const key of Object.keys(increments)) {
-    if (!base[key]) {
-      throw new Error(
-        `mismatch: ${Object.keys(increments)} ⊄ ${Object.keys(base)}`
-      );
+  for (const key of new Set([...s1, ...s2])) {
+    ret[key] = (base[key] || Zero).add(increments[key] || Zero);
+    if (ret[key].lt(Zero)) {
+      throw new Error("Underflow in merge");
     }
   }
 

--- a/packages/node/src/ethereum/utils/free-balance-app.ts
+++ b/packages/node/src/ethereum/utils/free-balance-app.ts
@@ -68,9 +68,6 @@ export function merge(
 
   for (const key of new Set([...s1, ...s2])) {
     ret[key] = (base[key] || Zero).add(increments[key] || Zero);
-    if (ret[key].lt(Zero)) {
-      throw new Error("Underflow in merge");
-    }
   }
 
   return ret;

--- a/packages/node/src/methods/app-instance/get-free-balance/controller.ts
+++ b/packages/node/src/methods/app-instance/get-free-balance/controller.ts
@@ -2,11 +2,6 @@ import { Node } from "@counterfactual/types";
 import { jsonRpcMethod } from "rpc-server";
 
 import { CONVENTION_FOR_ETH_TOKEN_ADDRESS } from "../../../constants";
-import {
-  convertCoinTransfersToCoinTransfersMap,
-  deserializeFreeBalanceState,
-  FreeBalanceStateJSON
-} from "../../../models/free-balance";
 import { RequestHandler } from "../../../request-handler";
 import { NodeController } from "../../controller";
 import { NO_FREE_BALANCE_EXISTS } from "../../errors";
@@ -35,15 +30,14 @@ export default class GetFreeBalanceController extends NodeController {
 
     const stateChannel = await store.getStateChannel(multisigAddress);
 
-    const freeBalanceState = deserializeFreeBalanceState(stateChannel
-      .freeBalance.state as FreeBalanceStateJSON);
+    const ret = stateChannel
+      .getFreeBalanceClass()
+      .withTokenAddress(tokenAddress);
 
-    if (!freeBalanceState.balancesIndexedByToken[tokenAddress]) {
+    if (!ret) {
       throw new Error(NO_FREE_BALANCE_EXISTS(tokenAddress));
     }
 
-    return convertCoinTransfersToCoinTransfersMap(
-      freeBalanceState.balancesIndexedByToken[tokenAddress]
-    );
+    return ret;
   }
 }

--- a/packages/node/src/methods/app-instance/get-token-indexed-free-balances/controller.ts
+++ b/packages/node/src/methods/app-instance/get-token-indexed-free-balances/controller.ts
@@ -1,11 +1,6 @@
 import { Node } from "@counterfactual/types";
 import { jsonRpcMethod } from "rpc-server";
 
-import {
-  convertCoinTransfersToCoinTransfersMap,
-  deserializeFreeBalanceState,
-  FreeBalanceStateJSON
-} from "../../../models/free-balance";
 import { RequestHandler } from "../../../request-handler";
 import { NodeController } from "../../controller";
 
@@ -31,17 +26,6 @@ export default class GetTokenIndexedFreeBalancesController extends NodeControlle
 
     const stateChannel = await store.getStateChannel(multisigAddress);
 
-    const tokenIndexedFreeBalances = deserializeFreeBalanceState(stateChannel
-      .freeBalance.state as FreeBalanceStateJSON).balancesIndexedByToken;
-
-    return Object.entries(tokenIndexedFreeBalances).reduce(
-      (accumulator, tokenIndexedFreeBalance) => ({
-        ...accumulator,
-        [tokenIndexedFreeBalance[0]]: convertCoinTransfersToCoinTransfersMap(
-          tokenIndexedFreeBalance[1]
-        )
-      }),
-      {}
-    );
+    return stateChannel.getFreeBalanceClass().toTokenIndexedCoinTransferMap();
   }
 }

--- a/packages/node/src/methods/app-instance/propose-install/controller.ts
+++ b/packages/node/src/methods/app-instance/propose-install/controller.ts
@@ -6,7 +6,6 @@ import { jsonRpcMethod } from "rpc-server";
 import { CONVENTION_FOR_ETH_TOKEN_ADDRESS } from "../../../constants";
 import { xkeyKthAddress } from "../../../machine";
 import { StateChannel } from "../../../models";
-import { getBalancesFromFreeBalanceAppInstance } from "../../../models/free-balance";
 import { RequestHandler } from "../../../request-handler";
 import { NODE_EVENTS, ProposeMessage } from "../../../types";
 import { getCreate2MultisigAddress } from "../../../utils";
@@ -139,10 +138,9 @@ function assertSufficientFundsWithinFreeBalance(
   tokenAddress: string,
   depositAmount: BigNumber
 ) {
-  const freeBalanceForToken = getBalancesFromFreeBalanceAppInstance(
-    channel.freeBalance,
-    tokenAddress
-  )[xkeyKthAddress(publicIdentifier, 0)];
+  const freeBalanceForToken = channel
+    .getFreeBalanceClass()
+    .getBalance(tokenAddress, xkeyKthAddress(publicIdentifier, 0));
 
   if (freeBalanceForToken.lt(depositAmount)) {
     throw new Error(

--- a/packages/node/src/methods/errors.ts
+++ b/packages/node/src/methods/errors.ts
@@ -65,9 +65,6 @@ export const INSUFFICIENT_FUNDS =
 
 export const INVALID_ACTION = "Invalid action taken";
 
-export const INVALID_WITHDRAW = (tokenAddress: string) =>
-  `Cannot withdraw the specified token (${tokenAddress}) as its balance in the channel is 0`;
-
 export const INVALID_NETWORK_NAME =
   "Invalid network name provided for initializing Node";
 

--- a/packages/node/src/methods/state-channel/withdraw/controller.ts
+++ b/packages/node/src/methods/state-channel/withdraw/controller.ts
@@ -5,18 +5,12 @@ import { jsonRpcMethod } from "rpc-server";
 
 import { CONVENTION_FOR_ETH_TOKEN_ADDRESS } from "../../../constants";
 import { xkeyKthAddress } from "../../../machine";
-import {
-  convertCoinTransfersToCoinTransfersMap,
-  deserializeFreeBalanceState,
-  FreeBalanceStateJSON
-} from "../../../models/free-balance";
 import { RequestHandler } from "../../../request-handler";
 import { NODE_EVENTS } from "../../../types";
 import { NodeController } from "../../controller";
 import {
   CANNOT_WITHDRAW,
   INSUFFICIENT_FUNDS_TO_WITHDRAW,
-  INVALID_WITHDRAW,
   WITHDRAWAL_FAILED
 } from "../../errors";
 
@@ -42,23 +36,15 @@ export default class WithdrawController extends NodeController {
       throw new Error(CANNOT_WITHDRAW);
     }
 
-    const freeBalance = deserializeFreeBalanceState(stateChannel.freeBalance
-      .state as FreeBalanceStateJSON);
-
     const tokenAddress =
       params.tokenAddress || CONVENTION_FOR_ETH_TOKEN_ADDRESS;
 
-    if (!(tokenAddress in freeBalance.balancesIndexedByToken)) {
-      throw new Error(INVALID_WITHDRAW(tokenAddress));
-    }
-
-    const tokenFreeBalance = convertCoinTransfersToCoinTransfersMap(
-      freeBalance.balancesIndexedByToken[tokenAddress]
-    );
-
-    const senderBalance =
-      tokenFreeBalance[stateChannel.getFreeBalanceAddrOf(publicIdentifier)];
-
+    const senderBalance = stateChannel
+      .getFreeBalanceClass()
+      .getBalance(
+        tokenAddress,
+        stateChannel.getFreeBalanceAddrOf(publicIdentifier)
+      );
     if (senderBalance.lt(params.amount)) {
       throw new Error(
         INSUFFICIENT_FUNDS_TO_WITHDRAW(

--- a/packages/node/src/models/free-balance.ts
+++ b/packages/node/src/models/free-balance.ts
@@ -1,6 +1,6 @@
 import { OutcomeType } from "@counterfactual/types";
 import { Zero } from "ethers/constants";
-import { BigNumber, bigNumberify } from "ethers/utils";
+import { BigNumber, bigNumberify, getAddress } from "ethers/utils";
 import { fromExtendedKey } from "ethers/utils/hdnode";
 
 import { CONVENTION_FOR_ETH_TOKEN_ADDRESS } from "../constants";
@@ -156,6 +156,15 @@ export class FreeBalanceClass {
         this.balancesIndexedByToken[tokenAddress]
       );
       const t2 = merge(t1, increments[tokenAddress]);
+
+      for (const val of Object.values(t2)) {
+        if (val.lt(Zero)) {
+          throw new Error(
+            `FreeBalanceClass::increment ended up with a negative balance when
+            merging ${t1} and ${increments[tokenAddress]}`
+          );
+        }
+      }
 
       this.balancesIndexedByToken[
         tokenAddress

--- a/packages/node/src/models/free-balance.ts
+++ b/packages/node/src/models/free-balance.ts
@@ -1,10 +1,13 @@
 import { OutcomeType } from "@counterfactual/types";
 import { Zero } from "ethers/constants";
-import { BigNumber, bigNumberify, getAddress } from "ethers/utils";
+import { BigNumber, bigNumberify } from "ethers/utils";
 import { fromExtendedKey } from "ethers/utils/hdnode";
 
 import { CONVENTION_FOR_ETH_TOKEN_ADDRESS } from "../constants";
-import { getFreeBalanceAppInterface } from "../ethereum/utils/free-balance-app";
+import {
+  getFreeBalanceAppInterface,
+  merge
+} from "../ethereum/utils/free-balance-app";
 import { xkeysToSortedKthAddresses } from "../machine/xkeys";
 
 import { AppInstance } from "./app-instance";
@@ -26,7 +29,7 @@ export type CoinTransfer = {
 /*
 Equivalent to the above type but with serialized BigNumbers
 */
-export type CoinTransferJSON = {
+type CoinTransferJSON = {
   to: string;
   amount: {
     _hex: string;
@@ -52,14 +55,122 @@ export type TokenIndexedCoinTransferMap = {
   [tokenAddress: string]: CoinTransferMap;
 };
 
+// todo(xuanji): replace with Set
 export type ActiveAppsMap = { [appInstanceIdentityHash: string]: true };
 
-export type FreeBalanceState = {
+export class FreeBalanceClass {
+  private constructor(
+    private readonly activeAppsMap: ActiveAppsMap,
+    private readonly balancesIndexedByToken: {
+      // todo: change this type to TokenIndexedCoinTransferMap
+      [tokenAddress: string]: CoinTransfer[];
+    }
+  ) {}
+  public toFreeBalanceState(): FreeBalanceState {
+    return {
+      activeAppsMap: this.activeAppsMap,
+      balancesIndexedByToken: this.balancesIndexedByToken
+    };
+  }
+  public toTokenIndexedCoinTransferMap() {
+    const ret = {};
+    for (const tokenAddress of Object.keys(this.balancesIndexedByToken)) {
+      ret[tokenAddress] = convertCoinTransfersToCoinTransfersMap(
+        this.balancesIndexedByToken[tokenAddress]
+      );
+    }
+    return ret;
+  }
+  public toAppInstance(oldAppInstance: AppInstance) {
+    return oldAppInstance.setState(
+      serializeFreeBalanceState(this.toFreeBalanceState())
+    );
+  }
+
+  public static createWithFundedTokenAmounts(
+    addresses: string[],
+    amount: BigNumber,
+    tokenAddresses: string[]
+  ): FreeBalanceClass {
+    return new FreeBalanceClass(
+      {},
+      tokenAddresses.reduce(
+        (balancesIndexedByToken, tokenAddress) => ({
+          ...balancesIndexedByToken,
+          [tokenAddress]: addresses.map(to => ({ to, amount }))
+        }),
+        {} as { [tokenAddress: string]: CoinTransfer[] }
+      )
+    );
+  }
+
+  public static fromAppInstance(appInstance: AppInstance): FreeBalanceClass {
+    const freeBalanceState = deserializeFreeBalanceState(
+      appInstance.state as FreeBalanceStateJSON
+    );
+    return new FreeBalanceClass(
+      freeBalanceState.activeAppsMap,
+      freeBalanceState.balancesIndexedByToken
+    );
+  }
+  public getBalance(tokenAddress: string, beneficiary: string) {
+    try {
+      return convertCoinTransfersToCoinTransfersMap(
+        this.balancesIndexedByToken[tokenAddress]
+      )[beneficiary];
+    } catch {
+      return Zero;
+    }
+  }
+  public withTokenAddress(tokenAddress: string): CoinTransferMap | null {
+    if (!this.balancesIndexedByToken[tokenAddress]) {
+      return null;
+    }
+    return convertCoinTransfersToCoinTransfersMap(
+      this.balancesIndexedByToken[tokenAddress]
+    );
+  }
+  public removeActiveApp(activeApp: string) {
+    delete this.activeAppsMap[activeApp];
+    return this;
+  }
+  public addActiveApp(activeApp: string) {
+    this.activeAppsMap[activeApp] = true;
+    return this;
+  }
+  public prettyPrint() {
+    const balances = this.balancesIndexedByToken;
+    const ret = {} as any;
+    for (const tokenAddress of Object.keys(balances)) {
+      const ret2 = {} as any;
+      for (const coinTransfer of balances[tokenAddress]) {
+        ret2[coinTransfer.to] = coinTransfer.amount;
+      }
+      ret[tokenAddress] = ret2;
+    }
+    console.table(ret);
+  }
+  public increment(increments: TokenIndexedCoinTransferMap) {
+    for (const tokenAddress of Object.keys(increments)) {
+      const t1 = convertCoinTransfersToCoinTransfersMap(
+        this.balancesIndexedByToken[tokenAddress]
+      );
+      const t2 = merge(t1, increments[tokenAddress]);
+
+      this.balancesIndexedByToken[
+        tokenAddress
+      ] = convertCoinTransfersMapToCoinTransfers(t2);
+    }
+    return this;
+  }
+}
+
+type FreeBalanceState = {
   activeAppsMap: ActiveAppsMap;
   balancesIndexedByToken: { [tokenAddress: string]: CoinTransfer[] };
 };
 
-export type FreeBalanceStateJSON = {
+type FreeBalanceStateJSON = {
   tokenAddresses: string[];
   balances: CoinTransferJSON[][];
   activeApps: string[];
@@ -93,50 +204,19 @@ export function createFreeBalance(
   };
 
   return new AppInstance(
-    sortedTopLevelKeys,
-    freeBalanceTimeout,
-    getFreeBalanceAppInterface(coinBucketAddress),
-    false,
-    HARD_CODED_ASSUMPTIONS.appSequenceNumberForFreeBalance,
-    serializeFreeBalanceState(initialState),
-    0,
-    HARD_CODED_ASSUMPTIONS.freeBalanceInitialStateTimeout,
-    OutcomeType.MULTI_ASSET_MULTI_PARTY_COIN_TRANSFER
+    /* participants */ sortedTopLevelKeys,
+    /* defaultTimeout */ freeBalanceTimeout,
+    /* appInterface */ getFreeBalanceAppInterface(coinBucketAddress),
+    /* isVirtualApp */ false,
+    /* appSeqNo */ HARD_CODED_ASSUMPTIONS.appSequenceNumberForFreeBalance,
+    /* latestState */ serializeFreeBalanceState(initialState),
+    /* latestVersionNumber */ 0,
+    /* latestTimeout */ HARD_CODED_ASSUMPTIONS.freeBalanceInitialStateTimeout,
+    /* outcomeType */ OutcomeType.MULTI_ASSET_MULTI_PARTY_COIN_TRANSFER
   );
 }
 
-/**
- * Given an AppInstance whose state is FreeBalanceState, convert the state
- * into the locally more convenient data type CoinTransferMap and return that.
- *
- * Note that this function will also default the `to` addresses of a new token
- * to the 0th derived public addresses of the StateChannel, the same as all
- * FreeBalanceApp AppInstances.
- *
- * @export
- * @param {AppInstance} freeBalance - an AppInstance that is a FreeBalanceApp
- *
- * @returns {CoinTransferMap} - HexFreeBalanceState indexed on tokenAddresses
- */
-export function getBalancesFromFreeBalanceAppInstance(
-  freeBalanceAppInstance: AppInstance,
-  tokenAddress: string
-): CoinTransferMap {
-  const freeBalanceState = deserializeFreeBalanceState(
-    freeBalanceAppInstance.state as FreeBalanceStateJSON
-  );
-
-  const coinTransfers = freeBalanceState.balancesIndexedByToken[
-    getAddress(tokenAddress)
-  ] || [
-    { to: freeBalanceAppInstance.participants[0], amount: Zero },
-    { to: freeBalanceAppInstance.participants[1], amount: Zero }
-  ];
-
-  return convertCoinTransfersToCoinTransfersMap(coinTransfers);
-}
-
-export function deserializeFreeBalanceState(
+function deserializeFreeBalanceState(
   freeBalanceStateJSON: FreeBalanceStateJSON
 ): FreeBalanceState {
   const { activeApps, tokenAddresses, balances } = freeBalanceStateJSON;
@@ -158,7 +238,7 @@ export function deserializeFreeBalanceState(
   };
 }
 
-export function serializeFreeBalanceState(
+function serializeFreeBalanceState(
   freeBalanceState: FreeBalanceState
 ): FreeBalanceStateJSON {
   return {
@@ -187,7 +267,7 @@ export function convertCoinTransfersToCoinTransfersMap(
   );
 }
 
-export function convertCoinTransfersMapToCoinTransfers(
+function convertCoinTransfersMapToCoinTransfers(
   coinTransfersMap: CoinTransferMap
 ): CoinTransfer[] {
   return Object.entries(coinTransfersMap).map(([to, amount]) => ({

--- a/packages/node/src/models/state-channel.ts
+++ b/packages/node/src/models/state-channel.ts
@@ -3,8 +3,7 @@ import { BigNumber, bigNumberify } from "ethers/utils";
 
 import {
   flip,
-  flipTokenIndexedBalances,
-  merge
+  flipTokenIndexedBalances
 } from "../ethereum/utils/free-balance-app";
 import { xkeyKthAddress } from "../machine/xkeys";
 import { Store } from "../store";
@@ -13,11 +12,7 @@ import { AppInstance } from "./app-instance";
 import {
   CoinTransferMap,
   createFreeBalance,
-  deserializeFreeBalanceState,
-  FreeBalanceState,
-  FreeBalanceStateJSON,
-  getBalancesFromFreeBalanceAppInstance,
-  serializeFreeBalanceState,
+  FreeBalanceClass,
   TokenIndexedCoinTransferMap
 } from "./free-balance";
 
@@ -210,21 +205,8 @@ export class StateChannel {
     return topLevelKey;
   }
 
-  // useful for debugging
-  public prettyPrintFB() {
-    const balances = deserializeFreeBalanceState(this.freeBalanceAppInstance!
-      .state as FreeBalanceStateJSON).balancesIndexedByToken;
-
-    const ret = {} as any;
-
-    for (const tokenAddress of Object.keys(balances)) {
-      const ret2 = {} as any;
-      for (const coinTransfer of balances[tokenAddress]) {
-        ret2[coinTransfer.to] = coinTransfer.amount;
-      }
-      ret[tokenAddress] = ret2;
-    }
-    console.table(ret);
+  public getFreeBalanceClass() {
+    return FreeBalanceClass.fromAppInstance(this.freeBalance);
   }
 
   private build(args: {
@@ -252,57 +234,26 @@ export class StateChannel {
   }
 
   public incrementFreeBalance(increments: TokenIndexedCoinTransferMap) {
-    const json = this.freeBalance.state as FreeBalanceStateJSON;
-
-    const freeBalanceState = deserializeFreeBalanceState(json);
-
-    for (const tokenAddress of Object.keys(increments)) {
-      freeBalanceState.balancesIndexedByToken[tokenAddress] = Object.entries(
-        merge(
-          getBalancesFromFreeBalanceAppInstance(this.freeBalance, tokenAddress),
-          increments[tokenAddress]
-        )
-      ).map(([to, amount]) => ({ to, amount }));
-    }
-
     return this.build({
-      freeBalanceAppInstance: this.freeBalance.setState(
-        serializeFreeBalanceState(freeBalanceState)
-      )
+      freeBalanceAppInstance: this.getFreeBalanceClass()
+        .increment(increments)
+        .toAppInstance(this.freeBalance)
     });
   }
 
   public addActiveApp(activeApp: string) {
-    const json = this.freeBalance.state as FreeBalanceStateJSON;
-
-    const freeBalanceState = deserializeFreeBalanceState(json);
-
-    freeBalanceState.activeAppsMap[activeApp] = true;
-
     return this.build({
-      freeBalanceAppInstance: this.freeBalance.setState(
-        serializeFreeBalanceState(freeBalanceState)
-      )
+      freeBalanceAppInstance: this.getFreeBalanceClass()
+        .addActiveApp(activeApp)
+        .toAppInstance(this.freeBalance)
     });
   }
 
   public removeActiveApp(activeApp: string) {
-    const json = this.freeBalance.state as FreeBalanceStateJSON;
-
-    const freeBalanceState = deserializeFreeBalanceState(json);
-
-    if (!freeBalanceState.activeAppsMap[activeApp]) {
-      throw new Error(
-        "Cannot uninstall app that is not installed in the first place"
-      );
-    }
-
-    delete freeBalanceState.activeAppsMap[activeApp];
-
     return this.build({
-      freeBalanceAppInstance: this.freeBalance.setState(
-        serializeFreeBalanceState(freeBalanceState)
-      )
+      freeBalanceAppInstance: this.getFreeBalanceClass()
+        .removeActiveApp(activeApp)
+        .toAppInstance(this.freeBalance)
     });
   }
 
@@ -324,10 +275,10 @@ export class StateChannel {
     );
   }
 
-  public setFreeBalance(newState: FreeBalanceState) {
+  public setFreeBalance(newFreeBalanceClass: FreeBalanceClass) {
     return this.build({
-      freeBalanceAppInstance: this.freeBalance.setState(
-        serializeFreeBalanceState(newState)
+      freeBalanceAppInstance: newFreeBalanceClass.toAppInstance(
+        this.freeBalance
       )
     });
   }

--- a/packages/node/test/integration/utils.ts
+++ b/packages/node/test/integration/utils.ts
@@ -27,7 +27,6 @@ import {
   Rpc
 } from "../../src";
 import { CONVENTION_FOR_ETH_TOKEN_ADDRESS } from "../../src/constants";
-import { CoinTransfer, FreeBalanceState } from "../../src/models/free-balance";
 
 import { initialEmptyTTTState, tttAbiEncodings } from "./tic-tac-toe";
 
@@ -721,23 +720,6 @@ export async function makeProposeCall(
   return {
     appInstanceId,
     params: appInstanceProposalReq.parameters as NodeTypes.ProposeInstallParams
-  };
-}
-
-export function createFreeBalanceStateWithFundedTokenAmounts(
-  addresses: string[],
-  amount: BigNumber,
-  tokenAddresses: string[]
-): FreeBalanceState {
-  return {
-    activeAppsMap: {},
-    balancesIndexedByToken: tokenAddresses.reduce(
-      (balancesIndexedByToken, tokenAddress) => ({
-        ...balancesIndexedByToken,
-        [tokenAddress]: addresses.map(to => ({ to, amount }))
-      }),
-      {} as { [tokenAddress: string]: CoinTransfer[] }
-    )
   };
 }
 

--- a/packages/node/test/machine/integration/install-then-set-state.spec.ts
+++ b/packages/node/test/machine/integration/install-then-set-state.spec.ts
@@ -27,10 +27,8 @@ import {
 } from "../../../src/ethereum";
 import { xkeysToSortedKthSigningKeys } from "../../../src/machine/xkeys";
 import { AppInstance, StateChannel } from "../../../src/models";
-import {
-  createFreeBalanceStateWithFundedTokenAmounts,
-  transferERC20Tokens
-} from "../../integration/utils";
+import { FreeBalanceClass } from "../../../src/models/free-balance";
+import { transferERC20Tokens } from "../../integration/utils";
 
 import { toBeEq } from "./bignumber-jest-matcher";
 import { connectToGanache } from "./connect-ganache";
@@ -104,7 +102,7 @@ describe("Scenario: install AppInstance, set state, put on-chain", () => {
         xpubs,
         1
       ).setFreeBalance(
-        createFreeBalanceStateWithFundedTokenAmounts(
+        FreeBalanceClass.createWithFundedTokenAmounts(
           multisigOwnerKeys.map(key => key.address),
           WeiPerEther,
           [CONVENTION_FOR_ETH_TOKEN_ADDRESS, erc20TokenAddress]

--- a/packages/node/test/machine/integration/install-virtual.spec.ts
+++ b/packages/node/test/machine/integration/install-virtual.spec.ts
@@ -17,11 +17,9 @@ import {
 } from "../../../src/ethereum";
 import { xkeysToSortedKthSigningKeys } from "../../../src/machine/xkeys";
 import { AppInstance, StateChannel } from "../../../src/models";
+import { FreeBalanceClass } from "../../../src/models/free-balance";
 import { encodeSingleAssetTwoPartyIntermediaryAgreementParams } from "../../../src/protocol/install-virtual-app";
-import {
-  createFreeBalanceStateWithFundedTokenAmounts,
-  transferERC20Tokens
-} from "../../integration/utils";
+import { transferERC20Tokens } from "../../integration/utils";
 
 import { toBeEq } from "./bignumber-jest-matcher";
 import { connectToGanache } from "./connect-ganache";
@@ -170,7 +168,7 @@ describe("Scenario: Install virtual app with and put on-chain", () => {
         proxyAddress,
         xpubs
       ).setFreeBalance(
-        createFreeBalanceStateWithFundedTokenAmounts(
+        FreeBalanceClass.createWithFundedTokenAmounts(
           multisigOwnerKeys.map<string>(key => key.address),
           tokenAmounts,
           [tokenAddress]

--- a/packages/node/test/machine/integration/protocols/test-runner.ts
+++ b/packages/node/test/machine/integration/protocols/test-runner.ts
@@ -8,7 +8,6 @@ import { BigNumber } from "ethers/utils";
 import { CONVENTION_FOR_ETH_TOKEN_ADDRESS } from "../../../../src/constants";
 import { Protocol, xkeyKthAddress } from "../../../../src/machine";
 import { sortAddresses } from "../../../../src/machine/xkeys";
-import { getBalancesFromFreeBalanceAppInstance } from "../../../../src/models/free-balance";
 import { getCreate2MultisigAddress } from "../../../../src/utils";
 import { toBeEq } from "../bignumber-jest-matcher";
 import { connectToGanache } from "../connect-ganache";
@@ -404,10 +403,10 @@ export class TestRunner {
     ]) {
       if (mininode.scm.has(multisig)) {
         expect(
-          getBalancesFromFreeBalanceAppInstance(
-            mininode.scm.get(multisig)!.freeBalance,
-            tokenAddress
-          )[xkeyKthAddress(mininode.xpub, 0)]
+          mininode.scm
+            .get(multisig)!
+            .getFreeBalanceClass()
+            .getBalance(tokenAddress, xkeyKthAddress(mininode.xpub, 0))
         ).toBeEq(expected);
       }
     }

--- a/packages/node/test/machine/integration/set-state.spec.ts
+++ b/packages/node/test/machine/integration/set-state.spec.ts
@@ -7,7 +7,7 @@ import { CONVENTION_FOR_ETH_TOKEN_ADDRESS } from "../../../src/constants";
 import { SetStateCommitment } from "../../../src/ethereum";
 import { xkeysToSortedKthSigningKeys } from "../../../src/machine";
 import { StateChannel } from "../../../src/models";
-import { createFreeBalanceStateWithFundedTokenAmounts } from "../../integration/utils";
+import { FreeBalanceClass } from "../../../src/models/free-balance";
 
 import { toBeEq } from "./bignumber-jest-matcher";
 import { connectToGanache } from "./connect-ganache";
@@ -52,7 +52,7 @@ describe("set state on free balance", () => {
       AddressZero,
       xprvs.map(extendedPrvKeyToExtendedPubKey)
     ).setFreeBalance(
-      createFreeBalanceStateWithFundedTokenAmounts(
+      FreeBalanceClass.createWithFundedTokenAmounts(
         multisigOwnerKeys.map<string>(key => key.address),
         WeiPerEther,
         [CONVENTION_FOR_ETH_TOKEN_ADDRESS]

--- a/packages/node/test/machine/integration/setup-then-set-state.spec.ts
+++ b/packages/node/test/machine/integration/setup-then-set-state.spec.ts
@@ -11,7 +11,7 @@ import { CONVENTION_FOR_ETH_TOKEN_ADDRESS } from "../../../src/constants";
 import { SetStateCommitment, SetupCommitment } from "../../../src/ethereum";
 import { xkeysToSortedKthSigningKeys } from "../../../src/machine";
 import { StateChannel } from "../../../src/models";
-import { createFreeBalanceStateWithFundedTokenAmounts } from "../../integration/utils";
+import { FreeBalanceClass } from "../../../src/models/free-balance";
 
 import { toBeEq } from "./bignumber-jest-matcher";
 import { connectToGanache } from "./connect-ganache";
@@ -72,7 +72,7 @@ describe("Scenario: Setup, set state on free balance, go on chain", () => {
         xprvs.map(extendedPrvKeyToExtendedPubKey),
         1
       ).setFreeBalance(
-        createFreeBalanceStateWithFundedTokenAmounts(
+        FreeBalanceClass.createWithFundedTokenAmounts(
           multisigOwnerKeys.map<string>(key => key.address),
           WeiPerEther,
           [CONVENTION_FOR_ETH_TOKEN_ADDRESS]

--- a/packages/node/test/machine/unit/ethereum/conditional-transaction-commitment.spec.ts
+++ b/packages/node/test/machine/unit/ethereum/conditional-transaction-commitment.spec.ts
@@ -13,7 +13,7 @@ import { ConditionalTransaction } from "../../../../src/ethereum";
 import { MultisigTransaction } from "../../../../src/ethereum/types";
 import { appIdentityToHash } from "../../../../src/ethereum/utils/app-identity";
 import { StateChannel } from "../../../../src/models";
-import { createFreeBalanceStateWithFundedTokenAmounts } from "../../../integration/utils";
+import { FreeBalanceClass } from "../../../../src/models/free-balance";
 import { createAppInstanceForTest } from "../../../unit/utils";
 import { getRandomExtendedPubKey } from "../../integration/random-signing-keys";
 import { generateRandomNetworkContext } from "../../mocks";
@@ -39,7 +39,7 @@ describe("ConditionalTransaction", () => {
 
   // Set the state to some test values
   stateChannel = stateChannel.setFreeBalance(
-    createFreeBalanceStateWithFundedTokenAmounts(
+    FreeBalanceClass.createWithFundedTokenAmounts(
       stateChannel.multisigOwners,
       WeiPerEther,
       [CONVENTION_FOR_ETH_TOKEN_ADDRESS]

--- a/packages/node/test/machine/unit/models/state-channel/install.spec.ts
+++ b/packages/node/test/machine/unit/models/state-channel/install.spec.ts
@@ -4,8 +4,7 @@ import { getAddress, hexlify, randomBytes } from "ethers/utils";
 import { CONVENTION_FOR_ETH_TOKEN_ADDRESS } from "../../../../../src/constants";
 import { xkeyKthAddress } from "../../../../../src/machine";
 import { AppInstance, StateChannel } from "../../../../../src/models";
-import { getBalancesFromFreeBalanceAppInstance } from "../../../../../src/models/free-balance";
-import { createFreeBalanceStateWithFundedTokenAmounts } from "../../../../integration/utils";
+import { FreeBalanceClass } from "../../../../../src/models/free-balance";
 import { createAppInstanceForTest } from "../../../../unit/utils";
 import { getRandomExtendedPubKeys } from "../../../integration/random-signing-keys";
 import { generateRandomNetworkContext } from "../../../mocks";
@@ -35,7 +34,7 @@ describe("StateChannel::uninstallApp", () => {
     // Give 1 ETH to Alice and to Bob so they can spend it on the new app
 
     sc1 = sc1.setFreeBalance(
-      createFreeBalanceStateWithFundedTokenAmounts(
+      FreeBalanceClass.createWithFundedTokenAmounts(
         [xkeyKthAddress(xpubs[0], 0), xkeyKthAddress(xpubs[1], 0)],
         WeiPerEther,
         [CONVENTION_FOR_ETH_TOKEN_ADDRESS]
@@ -64,18 +63,15 @@ describe("StateChannel::uninstallApp", () => {
   });
 
   describe("the updated ETH Free Balance", () => {
-    let fb: AppInstance;
+    let fb: FreeBalanceClass;
 
     beforeAll(() => {
-      fb = sc2.freeBalance;
+      fb = sc2.getFreeBalanceClass();
     });
 
     it("should have updated balances for Alice and Bob", () => {
       for (const amount of Object.values(
-        getBalancesFromFreeBalanceAppInstance(
-          fb,
-          CONVENTION_FOR_ETH_TOKEN_ADDRESS
-        )
+        fb.withTokenAddress(CONVENTION_FOR_ETH_TOKEN_ADDRESS) || {}
       )) {
         expect(amount).toEqual(Zero);
       }

--- a/packages/node/test/machine/unit/models/state-channel/setup-channel.spec.ts
+++ b/packages/node/test/machine/unit/models/state-channel/setup-channel.spec.ts
@@ -3,7 +3,6 @@ import { getAddress, hexlify, randomBytes } from "ethers/utils";
 
 import { CONVENTION_FOR_ETH_TOKEN_ADDRESS } from "../../../../../src/constants";
 import { AppInstance, StateChannel } from "../../../../../src/models";
-import { getBalancesFromFreeBalanceAppInstance } from "../../../../../src/models/free-balance";
 import { getRandomExtendedPubKeys } from "../../../integration/random-signing-keys";
 import { generateRandomNetworkContext } from "../../../mocks";
 
@@ -77,10 +76,9 @@ describe("StateChannel::setupChannel", () => {
 
     it("should have 0 balances for Alice and Bob", () => {
       for (const amount of Object.values(
-        getBalancesFromFreeBalanceAppInstance(
-          fb,
-          CONVENTION_FOR_ETH_TOKEN_ADDRESS
-        )
+        sc
+          .getFreeBalanceClass()
+          .withTokenAddress(CONVENTION_FOR_ETH_TOKEN_ADDRESS) || {}
       )) {
         expect(amount).toEqual(Zero);
       }

--- a/packages/node/test/machine/unit/models/state-channel/uninstall-app.spec.ts
+++ b/packages/node/test/machine/unit/models/state-channel/uninstall-app.spec.ts
@@ -4,7 +4,7 @@ import { getAddress, hexlify, randomBytes } from "ethers/utils";
 import { CONVENTION_FOR_ETH_TOKEN_ADDRESS } from "../../../../../src/constants";
 import { xkeyKthAddress } from "../../../../../src/machine";
 import { AppInstance, StateChannel } from "../../../../../src/models";
-import { getBalancesFromFreeBalanceAppInstance } from "../../../../../src/models/free-balance";
+import { FreeBalanceClass } from "../../../../../src/models/free-balance";
 import { createAppInstanceForTest } from "../../../../unit/utils";
 import { getRandomExtendedPubKeys } from "../../../integration/random-signing-keys";
 import { generateRandomNetworkContext } from "../../../mocks";
@@ -61,18 +61,15 @@ describe("StateChannel::uninstallApp", () => {
   });
 
   describe("the updated ETH Free Balance", () => {
-    let fb: AppInstance;
+    let fb: FreeBalanceClass;
 
     beforeAll(() => {
-      fb = sc2.freeBalance;
+      fb = sc2.getFreeBalanceClass();
     });
 
     it("should have updated balances for Alice and Bob", () => {
       for (const amount of Object.values(
-        getBalancesFromFreeBalanceAppInstance(
-          fb,
-          CONVENTION_FOR_ETH_TOKEN_ADDRESS
-        )
+        fb.withTokenAddress(CONVENTION_FOR_ETH_TOKEN_ADDRESS) || {}
       )) {
         expect(amount).toEqual(Zero);
       }

--- a/packages/node/test/unit/install.spec.ts
+++ b/packages/node/test/unit/install.spec.ts
@@ -21,11 +21,6 @@ import {
 } from "../../src/machine";
 import { install } from "../../src/methods/app-instance/install/operation";
 import { StateChannel } from "../../src/models";
-import {
-  convertCoinTransfersToCoinTransfersMap,
-  deserializeFreeBalanceState,
-  FreeBalanceStateJSON
-} from "../../src/models/free-balance";
 import { Store } from "../../src/store";
 import { getRandomExtendedPubKeys } from "../machine/integration/random-signing-keys";
 import { MemoryStoreService } from "../services/memory-store-service";
@@ -115,15 +110,16 @@ describe("Can handle correct & incorrect installs", () => {
       extendedKeys
     );
 
-    const balancesForETHToken = convertCoinTransfersToCoinTransfersMap(
-      deserializeFreeBalanceState(stateChannel.freeBalance
-        .state as FreeBalanceStateJSON).balancesIndexedByToken[
-        CONVENTION_FOR_ETH_TOKEN_ADDRESS
-      ]
-    );
-
-    expect(balancesForETHToken[participants[0]]).toEqual(Zero);
-    expect(balancesForETHToken[participants[1]]).toEqual(Zero);
+    expect(
+      stateChannel
+        .getFreeBalanceClass()
+        .getBalance(CONVENTION_FOR_ETH_TOKEN_ADDRESS, participants[0])
+    ).toEqual(Zero);
+    expect(
+      stateChannel
+        .getFreeBalanceClass()
+        .getBalance(CONVENTION_FOR_ETH_TOKEN_ADDRESS, participants[1])
+    ).toEqual(Zero);
 
     await store.saveStateChannel(stateChannel);
 


### PR DESCRIPTION
Previously, the helper file `free-balance.ts` exported 6 data structures and 5 functions:

### Data Structures

- `FreeBalanceState`
- `FreeBalanceStateJSON`
- `CoinTransfer`
- `CoinTransferJSON`
- `CoinTransferMap`
- `TokenIndexedCoinTransferMap`

### Functions

- `getBalancesFromFreeBalanceAppInstance`
- `deserializeFreeBalanceState`
-  `serializeFreeBalanceState`
- `convertCoinTransfersMapToCoinTransfers` 
- `convertCoinTransfersToCoinTransfersMap`

This PR creates a new class, `FreeBalanceClass`, with a smaller conversion API - it has 1 method each to convert to and from from an `AppInstance`, and no other methods should be used for conversion. This allows us to de-export most of the data structures and conversion functions listed above.