### PR TITLE
[node] remove AppInstance::multisigAddress

### DIFF
--- a/packages/node/src/models/app-instance.ts
+++ b/packages/node/src/models/app-instance.ts
@@ -24,9 +24,6 @@ import { bigNumberifyJson } from "../utils";
 /**
  * Representation of an AppInstance.
  *
- * @property multisigAddress The address of the multisignature wallet on-chain for
- *           the state channel that holds the state this AppInstance controls.
-
  * @property participants The sorted array of public keys used by the users of
  *           this AppInstance for which n-of-n consensus is needed on updates.
 
@@ -54,7 +51,6 @@ import { bigNumberifyJson } from "../utils";
  */
 export class AppInstance {
   constructor(
-    public readonly multisigAddress: string,
     public readonly participants: string[],
     public readonly defaultTimeout: number,
     public readonly appInterface: AppInterface,
@@ -104,7 +100,6 @@ export class AppInstance {
     const deserialized = bigNumberifyJson(json);
 
     return new AppInstance(
-      deserialized.multisigAddress,
       deserialized.participants,
       deserialized.defaultTimeout,
       deserialized.appInterface,
@@ -125,7 +120,6 @@ export class AppInstance {
     // an example would be having an `undefined` value for the `actionEncoding`
     // of an AppInstance that's not turn based
     return bigNumberifyJson({
-      multisigAddress: this.multisigAddress,
       participants: this.participants,
       defaultTimeout: this.defaultTimeout,
       appInterface: this.appInterface,

--- a/packages/node/src/models/free-balance.ts
+++ b/packages/node/src/models/free-balance.ts
@@ -53,7 +53,6 @@ export type FreeBalanceStateJSON = {
  * and only converted to more complex types (i.e. BigNumber) upon usage.
  */
 export function createFreeBalance(
-  multisigAddress: string,
   userNeuteredExtendedKeys: string[],
   coinBucketAddress: string,
   freeBalanceTimeout: number
@@ -77,7 +76,6 @@ export function createFreeBalance(
   };
 
   return new AppInstance(
-    multisigAddress,
     sortedTopLevelKeys,
     freeBalanceTimeout,
     getFreeBalanceAppInterface(coinBucketAddress),

--- a/packages/node/src/models/proposed-app-instance-info.ts
+++ b/packages/node/src/models/proposed-app-instance-info.ts
@@ -92,7 +92,6 @@ export class AppInstanceProposal {
 
   toAppInstanceFor(stateChannel: StateChannel) {
     return new AppInstance(
-      stateChannel.multisigAddress,
       stateChannel.getNextSigningKeys(),
       bigNumberify(this.timeout).toNumber(),
       {

--- a/packages/node/src/models/state-channel.ts
+++ b/packages/node/src/models/state-channel.ts
@@ -329,7 +329,6 @@ export class StateChannel {
       new Map<string, AppInstance>([]),
       new Map<string, SingleAssetTwoPartyIntermediaryAgreement>(),
       createFreeBalance(
-        multisigAddress,
         userNeuteredExtendedKeys,
         freeBalanceAppAddress,
         freeBalanceTimeout || HARD_CODED_ASSUMPTIONS.freeBalanceDefaultTimeout

--- a/packages/node/src/protocol/install-virtual-app.ts
+++ b/packages/node/src/protocol/install-virtual-app.ts
@@ -13,7 +13,7 @@ import {
   TwoPartyFixedOutcomeInterpreterParams,
   virtualAppAgreementEncoding
 } from "@counterfactual/types";
-import { AddressZero, MaxUint256 } from "ethers/constants";
+import { MaxUint256 } from "ethers/constants";
 import { BaseProvider } from "ethers/providers";
 import { BigNumber, bigNumberify, defaultAbiCoder } from "ethers/utils";
 
@@ -867,7 +867,6 @@ function constructVirtualAppInstance(
   );
 
   return new AppInstance(
-    /* multisigAddress */ stateChannelBetweenEndpoints.multisigAddress,
     /* participants */ sortAddresses([initiatorAddress, responderAddress]),
     defaultTimeout,
     appInterface,
@@ -938,7 +937,6 @@ function constructTimeLockedPassThroughAppInstance(
   );
 
   return new AppInstance(
-    /* multisigAddress */ AddressZero,
     /* participants */
     sortAddresses([initiatorAddress, responderAddress, intermediaryAddress]),
     /* defaultTimeout */ HARD_CODED_CHALLENGE_TIMEOUT,

--- a/packages/node/src/protocol/install.ts
+++ b/packages/node/src/protocol/install.ts
@@ -285,7 +285,6 @@ function computeStateChannelTransition(
     initialState,
     appInterface,
     defaultTimeout,
-    multisigAddress,
     outcomeType
   } = params;
 
@@ -307,7 +306,6 @@ function computeStateChannelTransition(
   );
 
   const appInstanceToBeInstalled = new AppInstance(
-    /* multisigAddress */ multisigAddress,
     /* participants */ participants,
     /* defaultTimeout */ defaultTimeout,
     /* appInterface */ appInterface,

--- a/packages/node/src/protocol/withdraw.ts
+++ b/packages/node/src/protocol/withdraw.ts
@@ -504,7 +504,6 @@ function addRefundAppToStateChannel(
 
   // TODO: Use a wrapper function for making new AppInstance objects.
   const refundAppInstance = new AppInstance(
-    multisigAddress,
     stateChannel.getNextSigningKeys(),
     defaultTimeout,
     {

--- a/packages/node/test/machine/integration/install-then-set-state.spec.ts
+++ b/packages/node/test/machine/integration/install-then-set-state.spec.ts
@@ -116,7 +116,6 @@ describe("Scenario: install AppInstance, set state, put on-chain", () => {
       // todo(xuanji): don't reuse state
       // todo(xuanji): use createAppInstance
       const identityAppInstance = new AppInstance(
-        stateChannel.multisigAddress,
         uniqueAppSigningKeys.map(x => x.address),
         stateChannel.freeBalance.defaultTimeout, // Re-use ETH FreeBalance timeout
         {

--- a/packages/node/test/machine/integration/install-virtual.spec.ts
+++ b/packages/node/test/machine/integration/install-virtual.spec.ts
@@ -178,7 +178,7 @@ describe("Scenario: Install virtual app with and put on-chain", () => {
       );
     };
 
-    createTargetAppInstance = function () {
+    createTargetAppInstance = function() {
       return new AppInstance(
         multisigOwnerKeys.map(x => x.address),
         /* default timeout */ 0,

--- a/packages/node/test/machine/integration/install-virtual.spec.ts
+++ b/packages/node/test/machine/integration/install-virtual.spec.ts
@@ -108,7 +108,7 @@ describe("Scenario: Install virtual app with and put on-chain", () => {
     tokenAddress: string
   ) => Promise<StateChannel>;
 
-  let createTargetAppInstance: (stateChannel: StateChannel) => AppInstance;
+  let createTargetAppInstance: () => AppInstance;
 
   let setStatesAndOutcomes: (
     targetAppInstance: AppInstance,
@@ -178,9 +178,8 @@ describe("Scenario: Install virtual app with and put on-chain", () => {
       );
     };
 
-    createTargetAppInstance = function(stateChannel: StateChannel) {
+    createTargetAppInstance = function () {
       return new AppInstance(
-        stateChannel.multisigAddress,
         multisigOwnerKeys.map(x => x.address),
         /* default timeout */ 0,
         /* appInterface */ {
@@ -269,7 +268,7 @@ describe("Scenario: Install virtual app with and put on-chain", () => {
         erc20ContractAddress
       );
 
-      const targetAppInstance = createTargetAppInstance(stateChannel);
+      const targetAppInstance = createTargetAppInstance();
 
       const agreement = {
         capitalProvider,
@@ -340,7 +339,7 @@ describe("Scenario: Install virtual app with and put on-chain", () => {
         CONVENTION_FOR_ETH_TOKEN_ADDRESS
       );
 
-      const targetAppInstance = createTargetAppInstance(stateChannel);
+      const targetAppInstance = createTargetAppInstance();
 
       const agreement = {
         capitalProvider,

--- a/packages/node/test/machine/unit/models/app-instance/app-instance.spec.ts
+++ b/packages/node/test/machine/unit/models/app-instance/app-instance.spec.ts
@@ -6,14 +6,12 @@ import { AppInstance } from "../../../../../src/models";
 
 describe("AppInstance", () => {
   it("should be able to instantiate", () => {
-    const multisigAddress = getAddress(hexlify(randomBytes(20)));
     const participants = [
       getAddress(hexlify(randomBytes(20))),
       getAddress(hexlify(randomBytes(20)))
     ];
 
     const appInstance = new AppInstance(
-      multisigAddress,
       participants,
       Math.ceil(Math.random() * 2e10),
       {
@@ -38,7 +36,6 @@ describe("AppInstance", () => {
 
     expect(appInstance).not.toBe(null);
     expect(appInstance).not.toBe(undefined);
-    expect(appInstance.multisigAddress).toBe(multisigAddress);
     expect(appInstance.participants).toBe(participants);
 
     // TODO: moar tests pl0x

--- a/packages/node/test/machine/unit/models/state-channel/setup-channel.spec.ts
+++ b/packages/node/test/machine/unit/models/state-channel/setup-channel.spec.ts
@@ -46,10 +46,6 @@ describe("StateChannel::setupChannel", () => {
       expect(fb).not.toBe(undefined);
     });
 
-    it("should be owned by the multisig", () => {
-      expect(fb.multisigAddress).toBe(multisigAddress);
-    });
-
     it("should not be a virtual app", () => {
       expect(fb.isVirtualApp).toBe(false);
     });

--- a/packages/node/test/unit/utils.ts
+++ b/packages/node/test/unit/utils.ts
@@ -47,9 +47,6 @@ export function createAppInstanceProposalForTest(appInstanceId: string) {
 
 export function createAppInstanceForTest(stateChannel?: StateChannel) {
   return new AppInstance(
-    /* multisigAddress */ stateChannel
-      ? stateChannel.multisigAddress
-      : getAddress(hexlify(randomBytes(20))),
     /* participants */ stateChannel
       ? stateChannel.getSigningKeysFor(stateChannel.numInstalledApps)
       : [


### PR DESCRIPTION
This field is never read; we always use the containing state channel's multisig address instead