### PR TITLE
[wallet-ui] Node Tokens list getter and selector

### DIFF
--- a/packages/wallet-ui/src/App.tsx
+++ b/packages/wallet-ui/src/App.tsx
@@ -18,20 +18,26 @@ import {
 import { EthereumService } from "./providers/EthereumService";
 import { ActionType, ApplicationState } from "./store/types";
 import { getUser } from "./store/user/user";
-import { connectToWallet } from "./store/wallet/wallet";
+import { connectToWallet, getNodeTokens } from "./store/wallet/wallet";
 import { RoutePath } from "./types";
 
 type AppProps = {
   getUser: (provider: Web3Provider, history: History) => void;
   connectToWallet: (provider: Web3Provider) => void;
+  getNodeTokens: (provider: Web3Provider) => void;
 };
 
-const App: React.FC<AppProps> = ({ getUser, connectToWallet }) => {
+const App: React.FC<AppProps> = ({
+  getUser,
+  connectToWallet,
+  getNodeTokens
+}) => {
   const { provider } = useContext(EthereumService);
   const history = createBrowserHistory();
   useEffect(() => {
     connectToWallet(provider);
     getUser(provider, history);
+    getNodeTokens(provider);
   });
   return (
     <Router history={history}>
@@ -65,6 +71,7 @@ export default connect(
     getUser: (provider: Web3Provider, history: History) =>
       dispatch(getUser(provider, history)),
     connectToWallet: (provider: Web3Provider) =>
-      dispatch(connectToWallet(provider))
+      dispatch(connectToWallet(provider)),
+    getNodeTokens: (provider: Web3Provider) => dispatch(getNodeTokens(provider))
   })
 )(App);

--- a/packages/wallet-ui/src/components/form/form-input/FormInput.tsx
+++ b/packages/wallet-ui/src/components/form/form-input/FormInput.tsx
@@ -54,7 +54,7 @@ class FormInput extends React.Component<
     super(props);
     this.state = {
       tokenAddress:
-        props.units && Array.isArray(props.units) && props.units.length > 0
+        props.units && props.units.length > 0
           ? props.units[0].tokenAddress
           : undefined,
       lastChangeEvent: undefined,

--- a/packages/wallet-ui/src/components/form/form-input/FormInput.tsx
+++ b/packages/wallet-ui/src/components/form/form-input/FormInput.tsx
@@ -163,9 +163,13 @@ class FormInput extends React.Component<
               className="unit-selector"
               onChange={event => this.handleUnitChange(event)}
             >
-              {units.map(({ name, tokenAddress }) => (
-                <option className="unit-selector-item" value={tokenAddress}>
-                  {name}
+              {units.map(({ shortName, tokenAddress }) => (
+                <option
+                  key={shortName}
+                  className="unit-selector-item"
+                  value={tokenAddress}
+                >
+                  {shortName}
                 </option>
               ))}
             </select>

--- a/packages/wallet-ui/src/pages/account-deposit/AccountDeposit.tsx
+++ b/packages/wallet-ui/src/pages/account-deposit/AccountDeposit.tsx
@@ -113,7 +113,7 @@ export class AccountDeposit extends React.Component<
   render() {
     const { walletState, deposit, history, user } = this.props;
     const { provider } = this.context;
-    const { ethereumBalance, error, status } = walletState;
+    const { ethereumBalance, error, status, nodeAddresses } = walletState;
     const { amount, loading, depositCaseVariables } = this.state;
     const {
       halfWidget,
@@ -121,7 +121,6 @@ export class AccountDeposit extends React.Component<
       headerDetails,
       ctaButtonText
     } = depositCaseVariables;
-    const unitTypes = [{ name: "ETH", tokenAddress: "" }];
     return (
       <WidgetScreen header={header} half={halfWidget} exitable={false}>
         <form>
@@ -130,7 +129,7 @@ export class AccountDeposit extends React.Component<
             label={<BalanceLabel available={formatEther(ethereumBalance)} />}
             className="input--balance"
             type="number"
-            units={unitTypes}
+            units={nodeAddresses}
             name="amount"
             min={0.02}
             max={Number(ethereumBalance)}

--- a/packages/wallet-ui/src/pages/account-withdraw/AccountWithdraw.tsx
+++ b/packages/wallet-ui/src/pages/account-withdraw/AccountWithdraw.tsx
@@ -110,7 +110,7 @@ export class AccountWithdraw extends React.Component<
   render() {
     const { walletState, withdraw, history, user } = this.props;
     const { provider } = this.context;
-    const { ethereumBalance, error, status } = walletState;
+    const { ethereumBalance, error, status, nodeAddresses } = walletState;
     const { amount, loading, withdrawCaseVariables } = this.state;
     const {
       halfWidget,
@@ -118,7 +118,6 @@ export class AccountWithdraw extends React.Component<
       headerDetails,
       ctaButtonText
     } = withdrawCaseVariables;
-    const unitTypes = [{ name: "ETH", tokenAddress: "ETHETH" }];
     return (
       <WidgetScreen header={header} half={halfWidget} exitable={false}>
         <form>
@@ -127,7 +126,7 @@ export class AccountWithdraw extends React.Component<
             label={<BalanceLabel available={formatEther(ethereumBalance)} />}
             className="input--balance"
             type="number"
-            units={unitTypes}
+            units={nodeAddresses}
             name="amount"
             min={0.02}
             max={Number(ethereumBalance)}

--- a/packages/wallet-ui/src/store/types.ts
+++ b/packages/wallet-ui/src/store/types.ts
@@ -14,6 +14,7 @@ export type User = {
 
 export type AssetType = {
   name: string;
+  shortName: string;
   tokenAddress: string;
 };
 
@@ -37,9 +38,9 @@ export type BalanceRequest = {
 };
 
 export type ErrorData = {
-  message: string;
-  code: string;
-  field: string;
+  message?: string;
+  code?: string;
+  field?: string;
 };
 
 export enum ActionType {
@@ -48,6 +49,7 @@ export enum ActionType {
   UserError = "USER_ERROR",
   UserLogin = "USER_LOGIN",
   WalletSetAddress = "WALLET_SET_ADDRESS",
+  WalletSetNodeTokens = "WALLET_SET_NODE_TOKENS",
   WalletError = "WALLET_ERROR",
   WalletDeposit = "WALLET_DEPOSIT",
   WalletWithdraw = "WALLET_WITHDRAW",
@@ -70,6 +72,7 @@ export type WalletState = AppState & {
   counterfactualBalance: BigNumberish;
   ethereumBalance: BigNumberish;
   status: string;
+  nodeAddresses: AssetType[];
 };
 
 export type ChannelsMap = { [key: string]: Connection };

--- a/packages/wallet-ui/src/store/wallet/wallet.ts
+++ b/packages/wallet-ui/src/store/wallet/wallet.ts
@@ -17,10 +17,12 @@ import {
   StoreAction,
   WalletState
 } from "../types";
-
+import { getTokens, ShortTokenNetworksName } from "../../utils/nodeTokenClient";
 export const initialState = {
+  nodeAddresses: [],
   ethAddress: "",
   error: {},
+  status: "",
   counterfactualBalance: Zero,
   ethereumBalance: Zero
 } as WalletState;
@@ -178,12 +180,40 @@ export const withdraw = (
   }
 };
 
+export const getNodeTokens = (
+  provider: Web3Provider
+): ThunkAction<
+  void,
+  ApplicationState,
+  null,
+  Action<ActionType>
+> => async dispatch => {
+  try {
+    const network = await provider.getNetwork();
+    const nodeAddresses = await getTokens(ShortTokenNetworksName[network.name]);
+    dispatch({
+      data: { nodeAddresses },
+      type: ActionType.WalletSetNodeTokens
+    });
+  } catch (e) {
+    dispatch({
+      data: {
+        error: {
+          message: "Ups something went wrong retrieving the list of tokens"
+        }
+      } as WalletState,
+      type: ActionType.WalletError
+    });
+  }
+};
+
 export const reducers = function(
   state = initialState,
   action: StoreAction<WalletState, WalletDepositTransition>
 ) {
   switch (action.type) {
     case ActionType.WalletSetAddress:
+    case ActionType.WalletSetNodeTokens:
     case ActionType.WalletSetBalance:
     case ActionType.WalletDeposit:
     case ActionType.WalletWithdraw:

--- a/packages/wallet-ui/src/utils/nodeTokenClient.ts
+++ b/packages/wallet-ui/src/utils/nodeTokenClient.ts
@@ -21,5 +21,10 @@ export const getTokens = async (
       tokenAddress,
       name,
       shortName
-    }));
+    }))
+    .concat({
+      tokenAddress: null,
+      name: "Ethereum",
+      shortName: "ETH"
+    });
 };

--- a/packages/wallet-ui/src/utils/nodeTokenClient.ts
+++ b/packages/wallet-ui/src/utils/nodeTokenClient.ts
@@ -15,16 +15,19 @@ export const getTokens = async (
     `https://cdn.jsdelivr.net/gh/MyEtherWallet/ethereum-lists/dist/tokens/${network}/tokens-${network}.min.json`
   );
   const parsedResponse = await response.json();
-  return parsedResponse
-    .filter(({ type }) => type === "ERC20")
-    .map(({ address: tokenAddress, name, symbol: shortName }) => ({
-      tokenAddress,
-      name,
-      shortName
-    }))
-    .concat({
-      tokenAddress: null,
+  return [
+    {
+      tokenAddress: "",
       name: "Ethereum",
       shortName: "ETH"
-    });
+    }
+  ].concat(
+    parsedResponse
+      .filter(({ type }) => type === "ERC20")
+      .map(({ address: tokenAddress, name, symbol: shortName }) => ({
+        tokenAddress,
+        name,
+        shortName
+      }))
+  );
 };

--- a/packages/wallet-ui/src/utils/nodeTokenClient.ts
+++ b/packages/wallet-ui/src/utils/nodeTokenClient.ts
@@ -1,0 +1,25 @@
+import { AssetType } from "../store/types";
+
+export enum ShortTokenNetworksName {
+  kovan = "kov",
+  rinkeby = "rin",
+  goerli = "goerli",
+  ropsten = "rop",
+  homestead = "eth"
+}
+
+export const getTokens = async (
+  network: ShortTokenNetworksName
+): Promise<AssetType[]> => {
+  const response = await fetch(
+    `https://cdn.jsdelivr.net/gh/MyEtherWallet/ethereum-lists/dist/tokens/${network}/tokens-${network}.min.json`
+  );
+  const parsedResponse = await response.json();
+  return parsedResponse
+    .filter(({ type }) => type === "ERC20")
+    .map(({ address: tokenAdress, name, symbol: shortName }) => ({
+      tokenAdress,
+      name,
+      shortName
+    }));
+};

--- a/packages/wallet-ui/src/utils/nodeTokenClient.ts
+++ b/packages/wallet-ui/src/utils/nodeTokenClient.ts
@@ -17,8 +17,8 @@ export const getTokens = async (
   const parsedResponse = await response.json();
   return parsedResponse
     .filter(({ type }) => type === "ERC20")
-    .map(({ address: tokenAdress, name, symbol: shortName }) => ({
-      tokenAdress,
+    .map(({ address: tokenAddress, name, symbol: shortName }) => ({
+      tokenAddress,
       name,
       shortName
     }));


### PR DESCRIPTION
## Description

This PR adds a getter of a list of tokens to use in the wallet-ui.

Currently we use the [MyEtherWallet/ethereum-lists](https://github.com/MyEtherWallet/ethereum-lists), but through a cdn (jsdelivr) e.g [the kovan list of tokens](https://cdn.jsdelivr.net/gh/MyEtherWallet/ethereum-lists/dist/tokens/kov/tokens-kov.min.json).

It also detects the currently selected MM network (I only added support for the non-custom ones).

### Related issues

references #1955

