### PR TITLE
[high-roller-bot] Fixes typo in .env-cmdrc

### DIFF
--- a/packages/high-roller-bot/.env-cmdrc
+++ b/packages/high-roller-bot/.env-cmdrc
@@ -5,7 +5,7 @@
     "TIER": "development",
     "FIREBASE_SERVER_HOST": "localhost",
     "FIREBASE_SERVER_PORT": "5555",
-    "NODE_EXTENDED_PRIVATE_KE": "xprv9s21ZrQH143K3g2nxWRPPsffixXkk5nQF9AMu1psGYzuJhD3TzkZMimoLwGBQJHmRAALcS8JJrfVjirnDCsN8tD6qMfmbQ37TAuthrP7bct",
+    "NODE_EXTENDED_PRIVATE_KEY": "xprv9s21ZrQH143K3g2nxWRPPsffixXkk5nQF9AMu1psGYzuJhD3TzkZMimoLwGBQJHmRAALcS8JJrfVjirnDCsN8tD6qMfmbQ37TAuthrP7bct",
     "ETHEREUM_NETWORK": "kovan",
     "NODE_ENV": "development",
     "LOG_LEVEL": "DEBUG"


### PR DESCRIPTION
Fixes typo introduced in #2097.