### PR TITLE
[testing] Removes usage of nvm in test:e2e:setup

### DIFF
--- a/e2e-prepare.sh
+++ b/e2e-prepare.sh
@@ -12,16 +12,6 @@ else
   echo "  > Found Python at: $PYTHON"
 fi
 
-if [ -z "$NVM_DIR" ];
-then
-  echo "  > Error: Please install nvm."
-  exit
-else
-  echo "  > Found NVM"
-  . $NVM_DIR/nvm.sh
-  nvm use
-fi
-
 if [ -d "packages/greenboard/extension" ];
 then
   unlink packages/greenboard/extension
@@ -54,12 +44,13 @@ cp packages/node/dist/index.iife.js /tmp/metamask-extension/app/vendor/counterfa
 
 echo "(6/7) Installing Metamask dependencies and building extension..."
 
-cd /tmp/metamask-extension
-nvm use
-yarn --frozen-lockfile
-yarn dist
-
-cd "$MONOREPO_PATH"
+pushd /tmp/metamask-extension
+  # Metamask and Counterfactual use very close Node/Yarn versions.
+  # Since integrating NVM into this bash script adds more trouble than anything else,
+  # we use --ignore-engines to build the extension. Works enough for this context.
+  yarn --ignore-engines --frozen-lockfile
+  yarn --ignore-engines dist
+popd
 
 echo "(7/7) Symlinking Metamask build into Greenboard workspace..."
 


### PR DESCRIPTION
Using `nvm` to build with the exact version of Node/Yarn that Metamask requires is not working due to `nvm` not being able to persist the version change in a subshell:

```bash
Found '/home/joel/Projects/counterfactual/.nvmrc' with version <v10.15.3>
Now using node v10.15.3 (npm v6.10.2)
(6/7) Installing Metamask dependencies and building extension...
/tmp/metamask-extension ~/Projects/counterfactual
Running node v10.16.0 (npm v6.10.2)
[1/5] Validating package.json...
error metamask-crx@0.0.0: The engine "node" is incompatible with this module. Expected version "^10.16.0". Got "10.15.3"
error metamask-crx@0.0.0: The engine "yarn" is incompatible with this module. Expected version "^1.16.0". Got "1.12.3"
error Found incompatible module
```

Since there's no significant difference between 10.15.3 and 10.16.0, this PR removes usage of `nvm` and allows to build the extension while using `--ignore-engines` while setting up the environment for running the Greenboard.