### PR TITLE
[apps] Output networks folder in apps package

### DIFF
--- a/packages/apps/package.json
+++ b/packages/apps/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@counterfactual/apps",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "description": "Collection of various apps built on Counterfactual",
   "repository": "github.com/counterfactual/monorepo",
   "license": "MIT",
@@ -9,7 +9,8 @@
     "node": "10.15.3"
   },
   "files": [
-    "build"
+    "build",
+    "networks"
   ],
   "scripts": {
     "build": "waffle waffle.js",


### PR DESCRIPTION
### Description

Output networks folder in apps package.
Dapp Tic Tac Toe depends on this.
In the process of extracting the dapps into their own repo I found that building the dapp fails.

### Related issues

#1956 

- [ ] Deploy preview is functional
