### PR TITLE
Add check to compare signatures and signer lengths

### DIFF
--- a/packages/cf-adjudicator-contracts/contracts/libs/LibStateChannelApp.sol
+++ b/packages/cf-adjudicator-contracts/contracts/libs/LibStateChannelApp.sol
@@ -51,6 +51,10 @@ contract LibStateChannelApp {
     pure
     returns (bool)
   {
+    require(
+      signers.length == signatures.length,
+      "Signers and signatures should be of equal length"
+    );
     address lastSigner = address(0);
     for (uint256 i = 0; i < signers.length; i++) {
       require(


### PR DESCRIPTION
### Description

Harden `verifySignatures` by requiring the number of signers matches the number of signatures.
