### PR TITLE
[node-docs] fix heading

### DIFF
--- a/packages/node/docs/source/introduction.md
+++ b/packages/node/docs/source/introduction.md
@@ -1,3 +1,5 @@
+# Introduction
+
 The Node contains a TypeScript implementation of the [Counterfactual protocol](https://specs.counterfactual.com). It is responsible for executing the protocols and producing correctly constructed signed commitments that correspond to state transitions of the users' state channels.
 
 The main areas of interest with this implementation are:


### PR DESCRIPTION
Add a heading to introduction.md so that toctree parses it correctly