### PR TITLE
[node] do getAddress on token addresses

### DIFF
--- a/packages/node/src/methods/app-instance/get-free-balance/controller.ts
+++ b/packages/node/src/methods/app-instance/get-free-balance/controller.ts
@@ -1,7 +1,6 @@
 import { Node } from "@counterfactual/types";
 import { jsonRpcMethod } from "rpc-server";
 
-import { CONVENTION_FOR_ETH_TOKEN_ADDRESS } from "../../../constants";
 import {
   convertCoinTransfersToCoinTransfersMap,
   deserializeFreeBalanceState,
@@ -10,6 +9,7 @@ import {
 import { RequestHandler } from "../../../request-handler";
 import { NodeController } from "../../controller";
 import { NO_FREE_BALANCE_EXISTS } from "../../errors";
+import { normalizeTokenAddress } from "../../../utils";
 
 export default class GetFreeBalanceController extends NodeController {
   public static readonly methodName = Node.MethodName.GET_FREE_BALANCE_STATE;
@@ -25,7 +25,7 @@ export default class GetFreeBalanceController extends NodeController {
     const { multisigAddress, tokenAddress: tokenAddressParam } = params;
 
     // NOTE: We default to ETH in case of undefined tokenAddress param
-    const tokenAddress = tokenAddressParam || CONVENTION_FOR_ETH_TOKEN_ADDRESS;
+    const tokenAddress = normalizeTokenAddress(tokenAddressParam)
 
     if (!multisigAddress) {
       throw new Error(

--- a/packages/node/src/methods/app-instance/get-free-balance/controller.ts
+++ b/packages/node/src/methods/app-instance/get-free-balance/controller.ts
@@ -7,9 +7,9 @@ import {
   FreeBalanceStateJSON
 } from "../../../models/free-balance";
 import { RequestHandler } from "../../../request-handler";
+import { normalizeTokenAddress } from "../../../utils";
 import { NodeController } from "../../controller";
 import { NO_FREE_BALANCE_EXISTS } from "../../errors";
-import { normalizeTokenAddress } from "../../../utils";
 
 export default class GetFreeBalanceController extends NodeController {
   public static readonly methodName = Node.MethodName.GET_FREE_BALANCE_STATE;
@@ -25,7 +25,7 @@ export default class GetFreeBalanceController extends NodeController {
     const { multisigAddress, tokenAddress: tokenAddressParam } = params;
 
     // NOTE: We default to ETH in case of undefined tokenAddress param
-    const tokenAddress = normalizeTokenAddress(tokenAddressParam)
+    const tokenAddress = normalizeTokenAddress(tokenAddressParam);
 
     if (!multisigAddress) {
       throw new Error(

--- a/packages/node/src/methods/app-instance/propose-install-virtual/operation.ts
+++ b/packages/node/src/methods/app-instance/propose-install-virtual/operation.ts
@@ -2,7 +2,10 @@ import { NetworkContext, Node } from "@counterfactual/types";
 
 import { AppInstanceProposal, StateChannel } from "../../../models";
 import { Store } from "../../../store";
-import { getCreate2MultisigAddress, normalizeTokenAddress } from "../../../utils";
+import {
+  getCreate2MultisigAddress,
+  normalizeTokenAddress
+} from "../../../utils";
 import { NO_STATE_CHANNEL_FOR_MULTISIG_ADDR } from "../../errors";
 
 /**
@@ -32,10 +35,12 @@ export async function createProposedVirtualAppInstance(
     {
       ...params,
       proposedByIdentifier: myIdentifier,
-      initiatorDepositTokenAddress:
-        normalizeTokenAddress(params.initiatorDepositTokenAddress),
-      responderDepositTokenAddress:
-        normalizeTokenAddress(params.responderDepositTokenAddress)
+      initiatorDepositTokenAddress: normalizeTokenAddress(
+        params.initiatorDepositTokenAddress
+      ),
+      responderDepositTokenAddress: normalizeTokenAddress(
+        params.responderDepositTokenAddress
+      )
     },
     channel
   );

--- a/packages/node/src/methods/app-instance/propose-install-virtual/operation.ts
+++ b/packages/node/src/methods/app-instance/propose-install-virtual/operation.ts
@@ -1,9 +1,8 @@
 import { NetworkContext, Node } from "@counterfactual/types";
 
-import { CONVENTION_FOR_ETH_TOKEN_ADDRESS } from "../../../constants";
 import { AppInstanceProposal, StateChannel } from "../../../models";
 import { Store } from "../../../store";
-import { getCreate2MultisigAddress } from "../../../utils";
+import { getCreate2MultisigAddress, normalizeTokenAddress } from "../../../utils";
 import { NO_STATE_CHANNEL_FOR_MULTISIG_ADDR } from "../../errors";
 
 /**
@@ -34,9 +33,9 @@ export async function createProposedVirtualAppInstance(
       ...params,
       proposedByIdentifier: myIdentifier,
       initiatorDepositTokenAddress:
-        params.initiatorDepositTokenAddress || CONVENTION_FOR_ETH_TOKEN_ADDRESS,
+        normalizeTokenAddress(params.initiatorDepositTokenAddress),
       responderDepositTokenAddress:
-        params.responderDepositTokenAddress || CONVENTION_FOR_ETH_TOKEN_ADDRESS
+        normalizeTokenAddress(params.responderDepositTokenAddress)
     },
     channel
   );

--- a/packages/node/src/methods/app-instance/propose-install/controller.ts
+++ b/packages/node/src/methods/app-instance/propose-install/controller.ts
@@ -8,7 +8,10 @@ import { StateChannel } from "../../../models";
 import { getBalancesFromFreeBalanceAppInstance } from "../../../models/free-balance";
 import { RequestHandler } from "../../../request-handler";
 import { NODE_EVENTS, ProposeMessage } from "../../../types";
-import { getCreate2MultisigAddress, normalizeTokenAddress } from "../../../utils";
+import {
+  getCreate2MultisigAddress,
+  normalizeTokenAddress
+} from "../../../utils";
 import { NodeController } from "../../controller";
 import {
   INSUFFICIENT_FUNDS_IN_FREE_BALANCE_FOR_ASSET,
@@ -72,11 +75,13 @@ export default class ProposeInstallController extends NodeController {
       networkContext.MinimumViableMultisig
     );
 
-    const initiatorDepositTokenAddress =
-      normalizeTokenAddress(initiatorDepositTokenAddressParam);
+    const initiatorDepositTokenAddress = normalizeTokenAddress(
+      initiatorDepositTokenAddressParam
+    );
 
-    const responderDepositTokenAddress =
-      normalizeTokenAddress(responderDepositTokenAddressParam);
+    const responderDepositTokenAddress = normalizeTokenAddress(
+      responderDepositTokenAddressParam
+    );
 
     const stateChannel = await store.getStateChannel(multisigAddress);
 

--- a/packages/node/src/methods/app-instance/propose-install/controller.ts
+++ b/packages/node/src/methods/app-instance/propose-install/controller.ts
@@ -3,13 +3,12 @@ import { BigNumber } from "ethers/utils";
 import Queue from "p-queue";
 import { jsonRpcMethod } from "rpc-server";
 
-import { CONVENTION_FOR_ETH_TOKEN_ADDRESS } from "../../../constants";
 import { xkeyKthAddress } from "../../../machine";
 import { StateChannel } from "../../../models";
 import { getBalancesFromFreeBalanceAppInstance } from "../../../models/free-balance";
 import { RequestHandler } from "../../../request-handler";
 import { NODE_EVENTS, ProposeMessage } from "../../../types";
-import { getCreate2MultisigAddress } from "../../../utils";
+import { getCreate2MultisigAddress, normalizeTokenAddress } from "../../../utils";
 import { NodeController } from "../../controller";
 import {
   INSUFFICIENT_FUNDS_IN_FREE_BALANCE_FOR_ASSET,
@@ -74,10 +73,10 @@ export default class ProposeInstallController extends NodeController {
     );
 
     const initiatorDepositTokenAddress =
-      initiatorDepositTokenAddressParam || CONVENTION_FOR_ETH_TOKEN_ADDRESS;
+      normalizeTokenAddress(initiatorDepositTokenAddressParam);
 
     const responderDepositTokenAddress =
-      responderDepositTokenAddressParam || CONVENTION_FOR_ETH_TOKEN_ADDRESS;
+      normalizeTokenAddress(responderDepositTokenAddressParam);
 
     const stateChannel = await store.getStateChannel(multisigAddress);
 

--- a/packages/node/src/methods/app-instance/propose-install/operation.ts
+++ b/packages/node/src/methods/app-instance/propose-install/operation.ts
@@ -1,9 +1,8 @@
 import { Node } from "@counterfactual/types";
 
-import { CONVENTION_FOR_ETH_TOKEN_ADDRESS } from "../../../constants";
 import { AppInstanceProposal } from "../../../models";
 import { Store } from "../../../store";
-import { getCreate2MultisigAddress } from "../../../utils";
+import { getCreate2MultisigAddress, normalizeTokenAddress } from "../../../utils";
 
 /**
  * Creates a AppInstanceProposal to reflect the proposal received from
@@ -33,9 +32,9 @@ export async function createProposedAppInstance(
       ...params,
       proposedByIdentifier: myIdentifier,
       initiatorDepositTokenAddress:
-        params.initiatorDepositTokenAddress || CONVENTION_FOR_ETH_TOKEN_ADDRESS,
+        normalizeTokenAddress(params.initiatorDepositTokenAddress),
       responderDepositTokenAddress:
-        params.responderDepositTokenAddress || CONVENTION_FOR_ETH_TOKEN_ADDRESS
+        normalizeTokenAddress(params.responderDepositTokenAddress)
     },
     stateChannel
   );

--- a/packages/node/src/methods/app-instance/propose-install/operation.ts
+++ b/packages/node/src/methods/app-instance/propose-install/operation.ts
@@ -2,7 +2,10 @@ import { Node } from "@counterfactual/types";
 
 import { AppInstanceProposal } from "../../../models";
 import { Store } from "../../../store";
-import { getCreate2MultisigAddress, normalizeTokenAddress } from "../../../utils";
+import {
+  getCreate2MultisigAddress,
+  normalizeTokenAddress
+} from "../../../utils";
 
 /**
  * Creates a AppInstanceProposal to reflect the proposal received from
@@ -31,10 +34,12 @@ export async function createProposedAppInstance(
     {
       ...params,
       proposedByIdentifier: myIdentifier,
-      initiatorDepositTokenAddress:
-        normalizeTokenAddress(params.initiatorDepositTokenAddress),
-      responderDepositTokenAddress:
-        normalizeTokenAddress(params.responderDepositTokenAddress)
+      initiatorDepositTokenAddress: normalizeTokenAddress(
+        params.initiatorDepositTokenAddress
+      ),
+      responderDepositTokenAddress: normalizeTokenAddress(
+        params.responderDepositTokenAddress
+      )
     },
     stateChannel
   );

--- a/packages/node/src/methods/state-channel/deposit/controller.ts
+++ b/packages/node/src/methods/state-channel/deposit/controller.ts
@@ -22,6 +22,7 @@ import {
   makeDeposit,
   uninstallBalanceRefundApp
 } from "./operation";
+import { normalizeTokenAddress } from "../../../utils";
 
 export default class DepositController extends NodeController {
   public static readonly methodName = Node.MethodName.DEPOSIT;
@@ -43,7 +44,7 @@ export default class DepositController extends NodeController {
     const { store, provider, networkContext } = requestHandler;
     const { multisigAddress, amount, tokenAddress: tokenAddressParam } = params;
 
-    const tokenAddress = tokenAddressParam || CONVENTION_FOR_ETH_TOKEN_ADDRESS;
+    const tokenAddress = normalizeTokenAddress(tokenAddressParam);
 
     const channel = await store.getStateChannel(multisigAddress);
 
@@ -84,7 +85,7 @@ export default class DepositController extends NodeController {
     const { provider } = requestHandler;
     const { multisigAddress, tokenAddress } = params;
 
-    params.tokenAddress = tokenAddress || CONVENTION_FOR_ETH_TOKEN_ADDRESS;
+    params.tokenAddress = normalizeTokenAddress(tokenAddress);
 
     await installBalanceRefundApp(requestHandler, params);
     await makeDeposit(requestHandler, params);

--- a/packages/node/src/methods/state-channel/deposit/controller.ts
+++ b/packages/node/src/methods/state-channel/deposit/controller.ts
@@ -9,6 +9,7 @@ import { CONVENTION_FOR_ETH_TOKEN_ADDRESS } from "../../../constants";
 import { StateChannel } from "../../../models";
 import { RequestHandler } from "../../../request-handler";
 import { DepositConfirmationMessage, NODE_EVENTS } from "../../../types";
+import { normalizeTokenAddress } from "../../../utils";
 import { NodeController } from "../../controller";
 import {
   CANNOT_DEPOSIT,
@@ -22,7 +23,6 @@ import {
   makeDeposit,
   uninstallBalanceRefundApp
 } from "./operation";
-import { normalizeTokenAddress } from "../../../utils";
 
 export default class DepositController extends NodeController {
   public static readonly methodName = Node.MethodName.DEPOSIT;

--- a/packages/node/src/methods/state-channel/withdraw/controller.ts
+++ b/packages/node/src/methods/state-channel/withdraw/controller.ts
@@ -2,8 +2,6 @@ import { Node } from "@counterfactual/types";
 import { JsonRpcProvider, TransactionResponse } from "ethers/providers";
 import Queue from "p-queue";
 import { jsonRpcMethod } from "rpc-server";
-
-import { CONVENTION_FOR_ETH_TOKEN_ADDRESS } from "../../../constants";
 import { xkeyKthAddress } from "../../../machine";
 import {
   convertCoinTransfersToCoinTransfersMap,
@@ -21,6 +19,7 @@ import {
 } from "../../errors";
 
 import { runWithdrawProtocol } from "./operation";
+import { normalizeTokenAddress } from "../../../utils";
 
 export default class WithdrawController extends NodeController {
   public static readonly methodName = Node.MethodName.WITHDRAW;
@@ -46,7 +45,7 @@ export default class WithdrawController extends NodeController {
       .state as FreeBalanceStateJSON);
 
     const tokenAddress =
-      params.tokenAddress || CONVENTION_FOR_ETH_TOKEN_ADDRESS;
+      normalizeTokenAddress(params.tokenAddress);
 
     if (!(tokenAddress in freeBalance.balancesIndexedByToken)) {
       throw new Error(INVALID_WITHDRAW(tokenAddress));

--- a/packages/node/src/methods/state-channel/withdraw/controller.ts
+++ b/packages/node/src/methods/state-channel/withdraw/controller.ts
@@ -2,6 +2,7 @@ import { Node } from "@counterfactual/types";
 import { JsonRpcProvider, TransactionResponse } from "ethers/providers";
 import Queue from "p-queue";
 import { jsonRpcMethod } from "rpc-server";
+
 import { xkeyKthAddress } from "../../../machine";
 import {
   convertCoinTransfersToCoinTransfersMap,
@@ -10,6 +11,7 @@ import {
 } from "../../../models/free-balance";
 import { RequestHandler } from "../../../request-handler";
 import { NODE_EVENTS } from "../../../types";
+import { normalizeTokenAddress } from "../../../utils";
 import { NodeController } from "../../controller";
 import {
   CANNOT_WITHDRAW,
@@ -19,7 +21,6 @@ import {
 } from "../../errors";
 
 import { runWithdrawProtocol } from "./operation";
-import { normalizeTokenAddress } from "../../../utils";
 
 export default class WithdrawController extends NodeController {
   public static readonly methodName = Node.MethodName.WITHDRAW;
@@ -44,8 +45,7 @@ export default class WithdrawController extends NodeController {
     const freeBalance = deserializeFreeBalanceState(stateChannel.freeBalance
       .state as FreeBalanceStateJSON);
 
-    const tokenAddress =
-      normalizeTokenAddress(params.tokenAddress);
+    const tokenAddress = normalizeTokenAddress(params.tokenAddress);
 
     if (!(tokenAddress in freeBalance.balancesIndexedByToken)) {
       throw new Error(INVALID_WITHDRAW(tokenAddress));

--- a/packages/node/src/methods/state-channel/withdraw/operation.ts
+++ b/packages/node/src/methods/state-channel/withdraw/operation.ts
@@ -1,9 +1,9 @@
 import { Node } from "@counterfactual/types";
 
-import { CONVENTION_FOR_ETH_TOKEN_ADDRESS } from "../../../constants";
 import { Protocol } from "../../../machine";
 import { StateChannel } from "../../../models";
 import { RequestHandler } from "../../../request-handler";
+import { normalizeTokenAddress } from "../../../utils";
 
 export async function runWithdrawProtocol(
   requestHandler: RequestHandler,
@@ -12,7 +12,7 @@ export async function runWithdrawProtocol(
   const { publicIdentifier, instructionExecutor, store } = requestHandler;
   const { multisigAddress, amount } = params;
 
-  const tokenAddress = params.tokenAddress || CONVENTION_FOR_ETH_TOKEN_ADDRESS;
+  const tokenAddress = normalizeTokenAddress(params.tokenAddress);
 
   const [peerAddress] = await StateChannel.getPeersAddressFromChannel(
     publicIdentifier,

--- a/packages/node/src/utils.ts
+++ b/packages/node/src/utils.ts
@@ -14,8 +14,8 @@ import {
 } from "ethers/utils";
 import log from "loglevel";
 
-import { xkeysToSortedKthAddresses } from "./machine/xkeys";
 import { CONVENTION_FOR_ETH_TOKEN_ADDRESS } from "./constants";
+import { xkeysToSortedKthAddresses } from "./machine/xkeys";
 
 export function getCounterpartyAddress(
   myIdentifier: string,

--- a/packages/node/src/utils.ts
+++ b/packages/node/src/utils.ts
@@ -15,6 +15,7 @@ import {
 import log from "loglevel";
 
 import { xkeysToSortedKthAddresses } from "./machine/xkeys";
+import { CONVENTION_FOR_ETH_TOKEN_ADDRESS } from "./constants";
 
 export function getCounterpartyAddress(
   myIdentifier: string,
@@ -157,4 +158,11 @@ export function signaturesToBytesSortedBySignerAddress(
   return signaturesToBytes(
     ...sortSignaturesBySignerAddress(digest, signatures)
   );
+}
+
+export function normalizeTokenAddress(tokenAddress?: string) {
+  if (!tokenAddress) {
+    return CONVENTION_FOR_ETH_TOKEN_ADDRESS;
+  }
+  return getAddress(tokenAddress);
 }


### PR DESCRIPTION
There are multiple controllers that check a certain token address and default it to ETH if it is falsy.
- Create a helper function to do that
- Do a `ethers.getAddress` normalization in addition