### PR TITLE
[node-provider] Adds NodeProviderEthereum

### DIFF
--- a/packages/node-provider/package.json
+++ b/packages/node-provider/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@counterfactual/node-provider",
-  "version": "0.1.2",
+  "version": "0.2.0",
   "main": "dist/index.js",
   "types": "dist/src/index.d.ts",
   "module": "dist/index.es.js",

--- a/packages/node-provider/package.json
+++ b/packages/node-provider/package.json
@@ -24,6 +24,7 @@
     "@counterfactual/types": "0.0.31",
     "@types/jest": "24.0.15",
     "@types/node": "12.6.9",
+    "@types/web3": "^1.0.19",
     "jest": "24.8.0",
     "rollup": "1.18.0",
     "rollup-plugin-commonjs": "10.0.2",

--- a/packages/node-provider/src/index.ts
+++ b/packages/node-provider/src/index.ts
@@ -1,3 +1,5 @@
 import NodeProvider from "./node-provider";
+import NodeProviderEthereum from "./node-provider-ethereum";
 
+export { NodeProviderEthereum };
 export default NodeProvider;

--- a/packages/node-provider/src/node-provider-ethereum.ts
+++ b/packages/node-provider/src/node-provider-ethereum.ts
@@ -103,7 +103,7 @@ export default class NodeProviderEthereum implements INodeProvider {
     }
 
     ethereum
-      .send("counterfactual:nodeProvider", [message])
+      .send("counterfactual:nodeProvider:request", [message])
       .then(({ result }: { result: Node.Message }) => {
         this.eventEmitter.emit("message", result);
       });
@@ -128,12 +128,33 @@ export default class NodeProviderEthereum implements INodeProvider {
   }
 
   private startEthereumEventListeners() {
-    ethereum.on(
-      "counterfactual:proposeInstallVirtual",
-      (data: Node.Message) => {
-        this.eventEmitter.emit("message", data);
-      }
-    );
+    const NODE_EVENTS = [
+      "proposeInstallVirtual",
+      "installVirtualEvent",
+      "getAppInstanceDetails",
+      "getState",
+      "takeAction",
+      "updateStateEvent",
+      "uninstallEvent"
+    ];
+    NODE_EVENTS.forEach((event: string) => {
+      this.startIndividualEthereumEventListener(event);
+    });
+    // ethereum.on(
+    //   "counterfactual:proposeInstallVirtual",
+    //   (data: Node.Message) => {
+    //     this.eventEmitter.emit("message", data);
+    //   }
+    // );
+  }
+
+  startIndividualEthereumEventListener(event: string) {
+    ethereum
+      .send("counterfactual:nodeProvider:event", [event])
+      .then(({ result }: { result: Node.Message }) => {
+        this.eventEmitter.emit("message", result);
+        this.startIndividualEthereumEventListener(event);
+      });
   }
 
   private notifyNodeProviderIsConnected() {

--- a/packages/node-provider/src/node-provider-ethereum.ts
+++ b/packages/node-provider/src/node-provider-ethereum.ts
@@ -13,7 +13,6 @@ export default class NodeProviderEthereum implements INodeProvider {
    */
   private isConnected: boolean;
   private eventEmitter: EventEmitter;
-  private messagePort?: MessagePort;
   private debugMode: string = "none";
   private debugEmitter: (
     source: string,
@@ -104,9 +103,9 @@ export default class NodeProviderEthereum implements INodeProvider {
     }
 
     ethereum
-      .send(`counterfactual:${message.type}`)
-      .then((data: Node.Message) => {
-        this.eventEmitter.emit("message", data);
+      .send("counterfactual:nodeProvider", [message])
+      .then(({ result }: { result: Node.Message }) => {
+        this.eventEmitter.emit("message", result);
       });
 
     this.log(

--- a/packages/node-provider/src/node-provider-ethereum.ts
+++ b/packages/node-provider/src/node-provider-ethereum.ts
@@ -6,13 +6,6 @@ import EventEmitter from "eventemitter3";
 import { EthereumGlobal } from "./types";
 
 export default class NodeProviderEthereum implements INodeProvider {
-  /**
-   * This boolean determines if the NodeProvider has received a MessagePort
-   * via the `cf-node-provider:port` message.
-   *
-   * It is used to prevent attempts to send messages without an instance
-   * of MessagePort stored locally.
-   */
   private readonly eventEmitter: EventEmitter;
   private isConnected: boolean;
   private debugMode: string = "none";

--- a/packages/node-provider/src/node-provider-ethereum.ts
+++ b/packages/node-provider/src/node-provider-ethereum.ts
@@ -123,6 +123,7 @@ export default class NodeProviderEthereum implements INodeProvider {
   }
 
   private startEthereumEventListeners() {
+    // TODO: Get these names from a shared package for DRY purposes.
     const NODE_EVENTS = [
       "proposeInstallVirtual",
       "installVirtualEvent",

--- a/packages/node-provider/src/node-provider-ethereum.ts
+++ b/packages/node-provider/src/node-provider-ethereum.ts
@@ -1,7 +1,9 @@
-declare var ethereum: any;
+declare var ethereum: EthereumGlobal;
 
 import { INodeProvider, Node } from "@counterfactual/types";
 import EventEmitter from "eventemitter3";
+
+import { EthereumGlobal } from "./types";
 
 export default class NodeProviderEthereum implements INodeProvider {
   /**

--- a/packages/node-provider/src/node-provider-ethereum.ts
+++ b/packages/node-provider/src/node-provider-ethereum.ts
@@ -1,0 +1,144 @@
+declare var ethereum: any;
+
+import { INodeProvider, Node } from "@counterfactual/types";
+import EventEmitter from "eventemitter3";
+
+export default class NodeProviderEthereum implements INodeProvider {
+  /**
+   * This boolean determines if the NodeProvider has received a MessagePort
+   * via the `cf-node-provider:port` message.
+   *
+   * It is used to prevent attempts to send messages without an instance
+   * of MessagePort stored locally.
+   */
+  private isConnected: boolean;
+  private eventEmitter: EventEmitter;
+  private messagePort?: MessagePort;
+  private debugMode: string = "none";
+  private debugEmitter: (
+    source: string,
+    message: string,
+    data?: any
+  ) => void = _ => {};
+
+  constructor() {
+    this.isConnected = false;
+    this.eventEmitter = new EventEmitter();
+
+    this.detectDebugMode();
+  }
+
+  private detectDebugMode() {
+    try {
+      if (process && process.env.CF_NODE_PROVIDER_DEBUG) {
+        this.debugMode = "shell";
+        this.debugEmitter = (source: string, message: string, data?: any) => {
+          console.log(`[NodeProvider] ${source}(): ${message}`);
+          if (data) {
+            console.log("   ", data);
+          }
+        };
+      }
+    } catch {
+      try {
+        if (window.localStorage.getItem("cf:node-provider:debug") === "true") {
+          this.debugMode = "browser";
+          this.debugEmitter = (source: string, message: string, data?: any) => {
+            console.log(
+              ["%c[NodeProvider]", `%c#${source}()`, `%c${message}`].join(" "),
+              "color: gray;",
+              "color: green;",
+              "color: black;"
+            );
+
+            if (data) {
+              console.log("   ", data);
+            }
+          };
+        }
+      } catch {
+        // Fallback to allow debugging without Local Storage flag.
+        if (window.location.href.includes("#cf:node-provider:debug")) {
+          this.debugMode = "browser";
+          this.debugEmitter = (source: string, message: string, data?: any) => {
+            console.log(
+              ["%c[NodeProvider]", `%c#${source}()`, `%c${message}`].join(" "),
+              "color: gray;",
+              "color: green;",
+              "color: black;"
+            );
+
+            if (data) {
+              console.log("   ", data);
+            }
+          };
+        }
+      }
+    }
+  }
+
+  private log(source: string, message: string, data?: any) {
+    if (this.debugMode === "none") {
+      return;
+    }
+
+    this.debugEmitter(source, message, data);
+  }
+
+  public onMessage(callback: (message: Node.Message) => void) {
+    this.log(
+      "onMessage",
+      "Registered listener for eventEmitter#message",
+      callback.toString()
+    );
+
+    this.eventEmitter.on("message", callback);
+  }
+
+  public sendMessage(message: Node.Message) {
+    if (!this.isConnected) {
+      // We fail because we aren't connected.
+      throw new Error(
+        "It's not possible to use postMessage() before the NodeProvider is connected. Call the connect() method first."
+      );
+    }
+
+    ethereum
+      .send(`counterfactual:${message.type}`)
+      .then((data: Node.Message) => {
+        this.eventEmitter.emit("message", data);
+      });
+
+    this.log(
+      "sendMessage",
+      "Message has been posted via messagePort",
+      JSON.stringify(message)
+    );
+  }
+
+  public async connect(): Promise<NodeProviderEthereum> {
+    if (this.isConnected) {
+      console.warn("NodeProvider is already connected.");
+      return Promise.resolve(this);
+    }
+
+    this.startEthereumEventListeners();
+    this.notifyNodeProviderIsConnected();
+
+    return Promise.resolve(this);
+  }
+
+  private startEthereumEventListeners() {
+    ethereum.on(
+      "counterfactual:proposeInstallVirtual",
+      (data: Node.Message) => {
+        this.eventEmitter.emit("message", data);
+      }
+    );
+  }
+
+  private notifyNodeProviderIsConnected() {
+    this.isConnected = true;
+    this.log("notifyNodeProviderIsConnected", "Connection successful");
+  }
+}

--- a/packages/node-provider/src/node-provider-ethereum.ts
+++ b/packages/node-provider/src/node-provider-ethereum.ts
@@ -11,8 +11,8 @@ export default class NodeProviderEthereum implements INodeProvider {
    * It is used to prevent attempts to send messages without an instance
    * of MessagePort stored locally.
    */
+  private readonly eventEmitter: EventEmitter;
   private isConnected: boolean;
-  private eventEmitter: EventEmitter;
   private debugMode: string = "none";
   private debugEmitter: (
     source: string,
@@ -140,12 +140,6 @@ export default class NodeProviderEthereum implements INodeProvider {
     NODE_EVENTS.forEach((event: string) => {
       this.startIndividualEthereumEventListener(event);
     });
-    // ethereum.on(
-    //   "counterfactual:proposeInstallVirtual",
-    //   (data: Node.Message) => {
-    //     this.eventEmitter.emit("message", data);
-    //   }
-    // );
   }
 
   startIndividualEthereumEventListener(event: string) {

--- a/packages/node-provider/src/types.ts
+++ b/packages/node-provider/src/types.ts
@@ -1,0 +1,12 @@
+import { Node } from "@counterfactual/types";
+import { IpcProvider, JsonRPCResponse } from "web3/providers";
+
+export type EthereumGlobal = Omit<IpcProvider, "send"> & {
+  enable: () => Promise<void>;
+  selectedAddress: string;
+  networkVersion: string;
+  send: (
+    eventOrMethod: string,
+    data?: any[]
+  ) => Promise<JsonRPCResponse & { result: Node.Message }>;
+};

--- a/packages/node-provider/src/types.ts
+++ b/packages/node-provider/src/types.ts
@@ -1,12 +1,11 @@
 import { Node } from "@counterfactual/types";
 import { IpcProvider, JsonRPCResponse } from "web3/providers";
 
+export type NodeEthereumResponse = JsonRPCResponse & { result: Node.Message };
+
 export type EthereumGlobal = Omit<IpcProvider, "send"> & {
   enable: () => Promise<void>;
   selectedAddress: string;
   networkVersion: string;
-  send: (
-    eventOrMethod: string,
-    data?: any[]
-  ) => Promise<JsonRPCResponse & { result: Node.Message }>;
+  send: (eventOrMethod: string, data?: any[]) => Promise<NodeEthereumResponse>;
 };

--- a/packages/node-provider/test/unit/node-provider-ethereum.spec.ts
+++ b/packages/node-provider/test/unit/node-provider-ethereum.spec.ts
@@ -1,0 +1,60 @@
+declare global {
+  interface Window {
+    ethereum: EthereumMock;
+  }
+}
+
+import { Node } from "@counterfactual/types";
+
+import NodeProviderEthereum from "../../src/node-provider-ethereum";
+import EthereumMock from "../utils/ethereum-mock";
+
+describe("NodeProvider", () => {
+  beforeAll(() => {
+    window.ethereum = new EthereumMock();
+  });
+  it("should instantiate", () => {
+    new NodeProviderEthereum();
+  });
+  it("should connect", async () => {
+    const nodeProvider = new NodeProviderEthereum();
+    await nodeProvider.connect();
+  });
+  it("should emit a warning if you're connecting twice", async () => {
+    const originalConsoleWarn = console.warn;
+    console.warn = jest.fn();
+
+    const nodeProvider = new NodeProviderEthereum();
+    await nodeProvider.connect();
+    await nodeProvider.connect();
+
+    expect(console.warn).toBeCalledWith("NodeProvider is already connected.");
+    console.warn = originalConsoleWarn;
+  });
+  it("should fail to send a message if not connected", () => {
+    const nodeProvider = new NodeProviderEthereum();
+
+    expect(() => {
+      nodeProvider.sendMessage({
+        type: Node.MethodName.INSTALL
+      } as Node.Message);
+    }).toThrow(
+      "It's not possible to use postMessage() before the NodeProvider is connected. Call the connect() method first."
+    );
+  });
+  it("should send a message", async () => {
+    const nodeProvider = new NodeProviderEthereum();
+    await nodeProvider.connect();
+
+    const messageToSend = {
+      type: Node.MethodName.INSTALL
+    } as Node.Message;
+
+    const spySend = jest.spyOn(window.ethereum, "send");
+
+    nodeProvider.sendMessage(messageToSend);
+    expect(spySend).toBeCalledWith("counterfactual:nodeProvider:request", [
+      messageToSend
+    ]);
+  });
+});

--- a/packages/node-provider/test/utils/ethereum-mock.ts
+++ b/packages/node-provider/test/utils/ethereum-mock.ts
@@ -1,0 +1,61 @@
+import { EthereumGlobal, NodeEthereumResponse } from "../../src/types";
+
+export default class EthereumMock implements EthereumGlobal {
+  responseCallbacks: undefined;
+  notificationCallbacks: undefined;
+  connection: undefined;
+  addDefaultEvents: undefined;
+
+  networkVersion: string = "";
+  selectedAddress: string = "";
+
+  isMetaMask?: boolean = false;
+  host?: string;
+  path?: string;
+
+  token?: string;
+
+  constructor(private readonly events: { [key: string]: Function[] } = {}) {}
+
+  async enable() {
+    this.selectedAddress = "0x0";
+  }
+
+  on(type: string, callback: (...args: any[]) => any): undefined {
+    this.events[type] = [...(this.events[type] || []), callback];
+    return;
+  }
+
+  removeListener(type: string, callback: () => any): undefined {
+    this.events[type] = (this.events[type] || []).filter(cb => cb === callback);
+    return;
+  }
+
+  removeAllListeners(type: string): undefined {
+    this.events[type] = [];
+    return;
+  }
+
+  reset(): undefined {
+    return;
+  }
+
+  async send(
+    eventOrMethod: string
+    // data: any[] = []
+  ): Promise<NodeEthereumResponse> {
+    if (eventOrMethod === "counterfactual:nodeProvider:event") {
+      return new Promise(resolve => {
+        function relayMessageToDapp(event: any) {
+          return resolve(event);
+        }
+        this.on(eventOrMethod, event => relayMessageToDapp(event));
+      });
+    }
+
+    return {
+      jsonrpc: "2.0",
+      result: {}
+    } as NodeEthereumResponse;
+  }
+}

--- a/packages/node-provider/tsconfig.json
+++ b/packages/node-provider/tsconfig.json
@@ -3,11 +3,9 @@
   "compilerOptions": {
     "outDir": "dist/",
     "noImplicitAny": true,
-    "types": ["jest", "node"]
+    "types": ["jest", "node", "web3"]
   },
-  "references": [
-    { "path": "../types" }
-  ],
+  "references": [{ "path": "../types" }],
   "include": ["src", "test"],
   "exclude": ["dist"]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -937,6 +937,18 @@
     exec-sh "^0.3.2"
     minimist "^1.2.0"
 
+"@counterfactual/apps@0.1.4":
+  version "0.1.4"
+  resolved "https://registry.yarnpkg.com/@counterfactual/apps/-/apps-0.1.4.tgz#c12b6a22b73d90081a3448300fd04dc51695061a"
+  integrity sha512-jorW43aHWiKvINiezHkcgl1a0hz2DPV8RFirwG0adtihY+B4xakThqch44lNnWl2imdEmMh3gYEOinfMLy3A+w==
+
+"@counterfactual/node-provider@0.1.2":
+  version "0.1.2"
+  resolved "https://registry.yarnpkg.com/@counterfactual/node-provider/-/node-provider-0.1.2.tgz#423fa7c516a32e36e56143a9e6b4f9aa05194733"
+  integrity sha512-7DrRocC9etadQq1hXNuLZr0FqEWuWcYrT3EtfnJWUkgHbk8C4/liOo2DS5pR0rYxZhh5SH6kn5QyX08W6Oackw==
+  dependencies:
+    eventemitter3 "^3.1.0"
+
 "@csstools/convert-colors@^1.4.0":
   version "1.4.0"
   resolved "https://registry.npmjs.org/@csstools/convert-colors/-/convert-colors-1.4.0.tgz#ad495dc41b12e75d588c6db8b9834f08fa131eb7"
@@ -3113,6 +3125,14 @@
 "@types/web3@1.0.19", "@types/web3@^1.0.14":
   version "1.0.19"
   resolved "https://registry.npmjs.org/@types/web3/-/web3-1.0.19.tgz#46b85d91d398ded9ab7c85a5dd57cb33ac558924"
+  integrity sha512-fhZ9DyvDYDwHZUp5/STa9XW2re0E8GxoioYJ4pEUZ13YHpApSagixj7IAdoYH5uAK+UalGq6Ml8LYzmgRA/q+A==
+  dependencies:
+    "@types/bn.js" "*"
+    "@types/underscore" "*"
+
+"@types/web3@^1.0.19":
+  version "1.0.19"
+  resolved "https://registry.yarnpkg.com/@types/web3/-/web3-1.0.19.tgz#46b85d91d398ded9ab7c85a5dd57cb33ac558924"
   integrity sha512-fhZ9DyvDYDwHZUp5/STa9XW2re0E8GxoioYJ4pEUZ13YHpApSagixj7IAdoYH5uAK+UalGq6Ml8LYzmgRA/q+A==
   dependencies:
     "@types/bn.js" "*"
@@ -20153,10 +20173,10 @@ tslint-eslint-rules@^5.4.0:
     tslib "1.9.0"
     tsutils "^3.0.0"
 
-tslint-microsoft-contrib@^6.0.0, tslint-microsoft-contrib@~5.2.1:
-  version "6.2.0"
-  resolved "https://registry.yarnpkg.com/tslint-microsoft-contrib/-/tslint-microsoft-contrib-6.2.0.tgz#8aa0f40584d066d05e6a5e7988da5163b85f2ad4"
-  integrity sha512-6tfi/2tHqV/3CL77pULBcK+foty11Rr0idRDxKnteTaKm6gWF9qmaCNU17HVssOuwlYNyOmd9Jsmjd+1t3a3qw==
+tslint-microsoft-contrib@~5.2.1:
+  version "5.2.1"
+  resolved "https://registry.yarnpkg.com/tslint-microsoft-contrib/-/tslint-microsoft-contrib-5.2.1.tgz#a6286839f800e2591d041ea2800c77487844ad81"
+  integrity sha512-PDYjvpo0gN9IfMULwKk0KpVOPMhU6cNoT9VwCOLeDl/QS8v8W2yspRpFFuUS7/c5EIH/n8ApMi8TxJAz1tfFUA==
   dependencies:
     tsutils "^2.27.2 <2.29.0"
 


### PR DESCRIPTION
This is an extraction + enhancement PR based on #1001.

It'll add the `NodeProviderEthereum` class to the `NodeProvider` package, as per @Alonski's original commits, plus adding some better types + unit tests for the new class.