### PR TITLE
[node] add customData field to ProtocolMessage

### DIFF
--- a/packages/node/src/machine/instruction-executor.ts
+++ b/packages/node/src/machine/instruction-executor.ts
@@ -109,7 +109,8 @@ export class InstructionExecutor {
       protocol: protocolName,
       protocolExecutionID: uuid.v1(),
       seq: 0,
-      toXpub: params[firstRecipientFromProtocolName(protocolName)]
+      toXpub: params[firstRecipientFromProtocolName(protocolName)],
+      customData: {}
     });
   }
 
@@ -123,7 +124,8 @@ export class InstructionExecutor {
         params,
         protocolExecutionID: uuid.v1(),
         seq: 0,
-        toXpub: params.responderXpub
+        toXpub: params.responderXpub,
+        customData: {}
       }
     );
   }

--- a/packages/node/src/machine/types.ts
+++ b/packages/node/src/machine/types.ts
@@ -35,6 +35,11 @@ export type ProtocolMessage = {
   params?: ProtocolParameters;
   toXpub: string;
   seq: number;
+  /*
+  Additional data which depends on the protocol (or even the specific message
+  number in a protocol) lives here. Includes signatures, final outcome of a
+  virtual app instance
+  */
   customData: { [key: string]: any };
 };
 

--- a/packages/node/src/machine/types.ts
+++ b/packages/node/src/machine/types.ts
@@ -5,7 +5,7 @@ import {
   SolidityValueType
 } from "@counterfactual/types";
 import { BaseProvider } from "ethers/providers";
-import { BigNumber, Signature } from "ethers/utils";
+import { BigNumber } from "ethers/utils";
 
 import { StateChannel } from "../models";
 
@@ -32,13 +32,10 @@ export interface Context {
 export type ProtocolMessage = {
   protocolExecutionID: string;
   protocol: Protocol;
-  params: ProtocolParameters;
+  params?: ProtocolParameters;
   toXpub: string;
   seq: number;
-  signature?: Signature;
-  signature2?: Signature;
-  signature3?: Signature;
-  signature4?: Signature;
+  customData: { [key: string]: any };
 };
 
 export type SetupParams = {

--- a/packages/node/src/message-handling/handle-protocol-message.ts
+++ b/packages/node/src/message-handling/handle-protocol-message.ts
@@ -46,7 +46,7 @@ export async function handleReceivedProtocolMessage(
 
   const queueNames = await getQueueNamesListByProtocolName(
     protocol,
-    params,
+    params!,
     requestHandler
   );
 
@@ -68,7 +68,7 @@ export async function handleReceivedProtocolMessage(
 
   const outgoingEventData = getOutgoingEventDataFromProtocol(
     protocol,
-    params,
+    params!,
     publicIdentifier,
     postProtocolStateChannelsMap
   );

--- a/packages/node/src/protocol/install-virtual-app.ts
+++ b/packages/node/src/protocol/install-virtual-app.ts
@@ -104,22 +104,24 @@ export const INSTALL_VIRTUAL_APP_PROTOCOL: ProtocolExecutionFlow = {
       protocolExecutionID,
       toXpub: intermediaryXpub,
       seq: 1,
-      signature: initiatorSignatureOnAliceIngridVirtualAppAgreement,
-      // FIXME: We are abusing these typed parameters in the ProtocolMessage
-      //        to pass through some variables from the initiating party
-      //        to the intermediary party. To fix, we ought to have some
-      //        kind of `metadata` fields on the ProtocolMessage
-      signature2: virtualAppInstance.identityHash as unknown,
-      signature3: timeLockedPassThroughAppInstance.state[
-        "defaultOutcome"
-      ] as unknown
+      customData: {
+        signature: initiatorSignatureOnAliceIngridVirtualAppAgreement,
+        // FIXME: We are abusing these typed parameters in the ProtocolMessage
+        //        to pass through some variables from the initiating party
+        //        to the intermediary party. To fix, we ought to have some
+        //        kind of `metadata` fields on the ProtocolMessage
+        signature2: virtualAppInstance.identityHash,
+        signature3: timeLockedPassThroughAppInstance.state["defaultOutcome"]
+      }
     } as ProtocolMessage;
 
-    const m4 = yield [IO_SEND_AND_WAIT, m1];
+    const m4 = (yield [IO_SEND_AND_WAIT, m1]) as ProtocolMessage;
 
     const {
-      signature: intermediarySignatureOnAliceIngridVirtualAppAgreement,
-      signature2: intermediarySignatureOnAliceIngridFreeBalanceAppActivation
+      customData: {
+        signature: intermediarySignatureOnAliceIngridVirtualAppAgreement,
+        signature2: intermediarySignatureOnAliceIngridFreeBalanceAppActivation
+      }
     } = m4;
 
     assertIsValidSignature(
@@ -202,17 +204,21 @@ export const INSTALL_VIRTUAL_APP_PROTOCOL: ProtocolExecutionFlow = {
       protocolExecutionID,
       toXpub: intermediaryXpub,
       seq: UNASSIGNED_SEQ_NO,
-      signature: initiatorSignatureOnAliceIngridFreeBalanceAppActivation,
-      signature2: initiatorSignatureOnTimeLockedPassThroughSetStateCommitment,
-      signature3: initiatorSignatureOnVirtualAppSetStateCommitment
+      customData: {
+        signature: initiatorSignatureOnAliceIngridFreeBalanceAppActivation,
+        signature2: initiatorSignatureOnTimeLockedPassThroughSetStateCommitment,
+        signature3: initiatorSignatureOnVirtualAppSetStateCommitment
+      }
     } as ProtocolMessage;
 
-    const m8 = yield [IO_SEND_AND_WAIT, m5];
+    const m8 = (yield [IO_SEND_AND_WAIT, m5]) as ProtocolMessage;
 
     const {
-      signature: intermediarySignatureOnTimeLockedPassThroughSetStateCommitment,
-      signature2: responderSignatureOnTimeLockedPassThroughSetStateCommitment,
-      signature3: responderSignatureOnVirtualAppSetStateCommitment
+      customData: {
+        signature: intermediarySignatureOnTimeLockedPassThroughSetStateCommitment,
+        signature2: responderSignatureOnTimeLockedPassThroughSetStateCommitment,
+        signature3: responderSignatureOnVirtualAppSetStateCommitment
+      }
     } = m8;
 
     assertIsValidSignature(
@@ -276,13 +282,15 @@ export const INSTALL_VIRTUAL_APP_PROTOCOL: ProtocolExecutionFlow = {
     const {
       params,
       protocolExecutionID,
-      signature: initiatorSignatureOnAliceIngridVirtualAppAgreement,
-      // FIXME: We are abusing these typed parameters in the ProtocolMessage
-      //        to pass through some variables from the initiating party
-      //        to the intermediary party. To fix, we ought to have some
-      //        kind of `metadata` fields on the ProtocolMessage
-      signature2: virtualAppInstanceIdentityHash,
-      signature3: virtualAppInstanceDefaultOutcome
+      customData: {
+        signature: initiatorSignatureOnAliceIngridVirtualAppAgreement,
+        // FIXME: We are abusing these typed parameters in the ProtocolMessage
+        //        to pass through some variables from the initiating party
+        //        to the intermediary party. To fix, we ought to have some
+        //        kind of `metadata` fields on the ProtocolMessage
+        signature2: virtualAppInstanceIdentityHash,
+        signature3: virtualAppInstanceDefaultOutcome
+      }
     } = m1;
 
     const { initiatorXpub, responderXpub } = params as InstallVirtualAppParams;
@@ -353,14 +361,18 @@ export const INSTALL_VIRTUAL_APP_PROTOCOL: ProtocolExecutionFlow = {
       protocolExecutionID,
       seq: 2,
       toXpub: responderXpub,
-      signature: intermediarySignatureOnIngridBobVirtualAppAgreement
+      customData: {
+        signature: intermediarySignatureOnIngridBobVirtualAppAgreement
+      }
     } as ProtocolMessage;
 
-    const m3 = yield [IO_SEND_AND_WAIT, m2];
+    const m3 = (yield [IO_SEND_AND_WAIT, m2]) as ProtocolMessage;
 
     const {
-      signature: responderSignatureOnIngridBobVirtualAppAgreement,
-      signature2: responderSignatureOnIngridBobFreeBalanceAppActivation
+      customData: {
+        signature: responderSignatureOnIngridBobVirtualAppAgreement,
+        signature2: responderSignatureOnIngridBobFreeBalanceAppActivation
+      }
     } = m3;
 
     assertIsValidSignature(
@@ -418,16 +430,20 @@ export const INSTALL_VIRTUAL_APP_PROTOCOL: ProtocolExecutionFlow = {
       protocolExecutionID,
       seq: UNASSIGNED_SEQ_NO,
       toXpub: initiatorXpub,
-      signature: intermediarySignatureOnAliceIngridVirtualAppAgreement,
-      signature2: intermediarySignatureOnAliceIngridFreeBalanceAppActivation
+      customData: {
+        signature: intermediarySignatureOnAliceIngridVirtualAppAgreement,
+        signature2: intermediarySignatureOnAliceIngridFreeBalanceAppActivation
+      }
     } as ProtocolMessage;
 
-    const m5 = yield [IO_SEND_AND_WAIT, m4];
+    const m5 = (yield [IO_SEND_AND_WAIT, m4]) as ProtocolMessage;
 
     const {
-      signature: initiatorSignatureOnAliceIngridFreeBalanceAppActivation,
-      signature2: initiatorSignatureOnTimeLockedPassThroughSetStateCommitment,
-      signature3: initiatorSignatureOnVirtualAppSetStateCommitment
+      customData: {
+        signature: initiatorSignatureOnAliceIngridFreeBalanceAppActivation,
+        signature2: initiatorSignatureOnTimeLockedPassThroughSetStateCommitment,
+        signature3: initiatorSignatureOnVirtualAppSetStateCommitment
+      }
     } = m5;
 
     assertIsValidSignature(
@@ -489,17 +505,21 @@ export const INSTALL_VIRTUAL_APP_PROTOCOL: ProtocolExecutionFlow = {
       protocolExecutionID,
       toXpub: responderXpub,
       seq: UNASSIGNED_SEQ_NO,
-      signature: intermediarySignatureOnIngridBobFreeBalanceAppActivation,
-      signature2: intermediarySignatureOnTimeLockedPassThroughSetStateCommitment,
-      signature3: initiatorSignatureOnTimeLockedPassThroughSetStateCommitment,
-      signature4: initiatorSignatureOnVirtualAppSetStateCommitment
+      customData: {
+        signature: intermediarySignatureOnIngridBobFreeBalanceAppActivation,
+        signature2: intermediarySignatureOnTimeLockedPassThroughSetStateCommitment,
+        signature3: initiatorSignatureOnTimeLockedPassThroughSetStateCommitment,
+        signature4: initiatorSignatureOnVirtualAppSetStateCommitment
+      }
     } as ProtocolMessage;
 
-    const m7 = yield [IO_SEND_AND_WAIT, m6];
+    const m7 = (yield [IO_SEND_AND_WAIT, m6]) as ProtocolMessage;
 
     const {
-      signature: responderSignatureOnTimeLockedPassThroughSetStateCommitment,
-      signature2: responderSignatureOnVirtualAppSetStateCommitment
+      customData: {
+        signature: responderSignatureOnTimeLockedPassThroughSetStateCommitment,
+        signature2: responderSignatureOnVirtualAppSetStateCommitment
+      }
     } = m7;
 
     assertIsValidSignature(
@@ -524,9 +544,11 @@ export const INSTALL_VIRTUAL_APP_PROTOCOL: ProtocolExecutionFlow = {
       protocolExecutionID,
       toXpub: initiatorXpub,
       seq: UNASSIGNED_SEQ_NO,
-      signature: intermediarySignatureOnTimeLockedPassThroughSetStateCommitment,
-      signature2: responderSignatureOnTimeLockedPassThroughSetStateCommitment,
-      signature3: responderSignatureOnVirtualAppSetStateCommitment
+      customData: {
+        signature: intermediarySignatureOnTimeLockedPassThroughSetStateCommitment,
+        signature2: responderSignatureOnTimeLockedPassThroughSetStateCommitment,
+        signature3: responderSignatureOnVirtualAppSetStateCommitment
+      }
     } as ProtocolMessage;
 
     yield [IO_SEND, m8];
@@ -553,7 +575,9 @@ export const INSTALL_VIRTUAL_APP_PROTOCOL: ProtocolExecutionFlow = {
     const {
       params,
       protocolExecutionID,
-      signature: intermediarySignatureOnIngridBobVirtualAppAgreement
+      customData: {
+        signature: intermediarySignatureOnIngridBobVirtualAppAgreement
+      }
     } = m2;
 
     const {
@@ -635,17 +659,21 @@ export const INSTALL_VIRTUAL_APP_PROTOCOL: ProtocolExecutionFlow = {
       protocolExecutionID,
       toXpub: intermediaryXpub,
       seq: UNASSIGNED_SEQ_NO,
-      signature: responderSignatureOnIngridBobVirtualAppAgreement,
-      signature2: responderSignatureOnIngridBobFreeBalanceAppActivation
+      customData: {
+        signature: responderSignatureOnIngridBobVirtualAppAgreement,
+        signature2: responderSignatureOnIngridBobFreeBalanceAppActivation
+      }
     } as ProtocolMessage;
 
-    const m6 = yield [IO_SEND_AND_WAIT, m3];
+    const m6 = (yield [IO_SEND_AND_WAIT, m3]) as ProtocolMessage;
 
     const {
-      signature: intermediarySignatureOnIngridBobFreeBalanceAppActivation,
-      signature2: intermediarySignatureOnTimeLockedPassThroughSetStateCommitment,
-      signature3: initiatorSignatureOnTimeLockedPassThroughSetStateCommitment,
-      signature4: initiatorSignatureOnVirtualAppSetStateCommitment
+      customData: {
+        signature: intermediarySignatureOnIngridBobFreeBalanceAppActivation,
+        signature2: intermediarySignatureOnTimeLockedPassThroughSetStateCommitment,
+        signature3: initiatorSignatureOnTimeLockedPassThroughSetStateCommitment,
+        signature4: initiatorSignatureOnVirtualAppSetStateCommitment
+      }
     } = m6;
 
     assertIsValidSignature(
@@ -736,8 +764,10 @@ export const INSTALL_VIRTUAL_APP_PROTOCOL: ProtocolExecutionFlow = {
       protocolExecutionID,
       toXpub: intermediaryXpub,
       seq: UNASSIGNED_SEQ_NO,
-      signature: responderSignatureOnTimeLockedPassThroughSetStateCommitment,
-      signature2: responderSignatureOnVirtualAppSetStateCommitment
+      customData: {
+        signature: responderSignatureOnTimeLockedPassThroughSetStateCommitment,
+        signature2: responderSignatureOnVirtualAppSetStateCommitment
+      }
     } as ProtocolMessage;
 
     yield [IO_SEND, m7];

--- a/packages/node/src/protocol/install.ts
+++ b/packages/node/src/protocol/install.ts
@@ -66,8 +66,10 @@ export const INSTALL_PROTOCOL: ProtocolExecutionFlow = {
     ];
 
     const {
-      signature: counterpartySignatureOnConditionalTransaction,
-      signature2: counterpartySignatureOnFreeBalanceStateUpdate
+      customData: {
+        signature: counterpartySignatureOnConditionalTransaction,
+        signature2: counterpartySignatureOnFreeBalanceStateUpdate
+      }
     } = yield [
       Opcode.IO_SEND_AND_WAIT,
       {
@@ -75,7 +77,9 @@ export const INSTALL_PROTOCOL: ProtocolExecutionFlow = {
         params,
         protocol: Protocol.Install,
         toXpub: responderXpub,
-        signature: mySignatureOnConditionalTransaction,
+        customData: {
+          signature: mySignatureOnConditionalTransaction
+        },
         seq: 1
       } as ProtocolMessage
     ];
@@ -144,7 +148,9 @@ export const INSTALL_PROTOCOL: ProtocolExecutionFlow = {
         protocolExecutionID,
         protocol: Protocol.Install,
         toXpub: responderXpub,
-        signature: mySignatureOnFreeBalanceStateUpdate,
+        customData: {
+          signature: mySignatureOnFreeBalanceStateUpdate
+        },
         seq: UNASSIGNED_SEQ_NO
       } as ProtocolMessage
     ];
@@ -162,7 +168,11 @@ export const INSTALL_PROTOCOL: ProtocolExecutionFlow = {
   1 /* Responding */: async function*(context: Context) {
     const {
       stateChannelsMap,
-      message: { params, protocolExecutionID, signature },
+      message: {
+        params,
+        protocolExecutionID,
+        customData: { signature }
+      },
       network
     } = context;
 
@@ -228,14 +238,18 @@ export const INSTALL_PROTOCOL: ProtocolExecutionFlow = {
       freeBalanceUpdateData
     ];
 
-    const { signature: counterpartySignatureOnFreeBalanceStateUpdate } = yield [
+    const {
+      customData: { signature: counterpartySignatureOnFreeBalanceStateUpdate }
+    } = yield [
       Opcode.IO_SEND_AND_WAIT,
       {
         protocolExecutionID,
         protocol: Protocol.Install,
         toXpub: initiatorXpub,
-        signature: mySignatureOnConditionalTransaction,
-        signature2: mySignatureOnFreeBalanceStateUpdate,
+        customData: {
+          signature: mySignatureOnConditionalTransaction,
+          signature2: mySignatureOnFreeBalanceStateUpdate
+        },
         seq: UNASSIGNED_SEQ_NO
       } as ProtocolMessage
     ];

--- a/packages/node/src/protocol/setup.ts
+++ b/packages/node/src/protocol/setup.ts
@@ -26,19 +26,23 @@ export const SETUP_PROTOCOL: ProtocolExecutionFlow = {
       .params as SetupParams;
     const responderAddress = xkeyKthAddress(responderXpub, 0);
     const setupCommitment = proposeStateTransition(
-      context.message.params,
+      context.message.params!,
       context
     );
     const mySig = yield [Opcode.OP_SIGN, setupCommitment];
 
-    const { signature: theirSig } = yield [
+    const {
+      customData: { signature: theirSig }
+    } = yield [
       Opcode.IO_SEND_AND_WAIT,
       {
         protocol: Protocol.Setup,
         protocolExecutionID: context.message.protocolExecutionID,
         params: context.message.params,
         toXpub: responderXpub,
-        signature: mySig,
+        customData: {
+          signature: mySig
+        },
         seq: 1
       } as ProtocolMessage
     ];
@@ -63,11 +67,11 @@ export const SETUP_PROTOCOL: ProtocolExecutionFlow = {
     const initiatorAddress = xkeyKthAddress(initiatorXpub, 0);
 
     const setupCommitment = proposeStateTransition(
-      context.message.params,
+      context.message.params!,
       context
     );
 
-    const theirSig = context.message.signature!;
+    const theirSig = context.message.customData.signature!;
     assertIsValidSignature(initiatorAddress, setupCommitment, theirSig);
 
     const mySig = yield [Opcode.OP_SIGN, setupCommitment];
@@ -89,7 +93,9 @@ export const SETUP_PROTOCOL: ProtocolExecutionFlow = {
         protocol: Protocol.Setup,
         protocolExecutionID: context.message.protocolExecutionID,
         toXpub: initiatorXpub,
-        signature: mySig,
+        customData: {
+          signature: mySig
+        },
         seq: UNASSIGNED_SEQ_NO
       } as ProtocolMessage
     ];

--- a/packages/node/src/protocol/take-action.ts
+++ b/packages/node/src/protocol/take-action.ts
@@ -42,7 +42,9 @@ export const TAKE_ACTION_PROTOCOL: ProtocolExecutionFlow = {
         params: context.message.params,
         seq: 1,
         toXpub: responderXpub,
-        signature: mySig
+        customData: {
+          signature: mySig
+        }
       } as ProtocolMessage
     ];
 
@@ -59,7 +61,7 @@ export const TAKE_ACTION_PROTOCOL: ProtocolExecutionFlow = {
       context.provider
     );
 
-    const { signature, params } = context.message;
+    const { customData, params } = context.message;
     const {
       appIdentityHash,
       multisigAddress,
@@ -72,7 +74,7 @@ export const TAKE_ACTION_PROTOCOL: ProtocolExecutionFlow = {
     assertIsValidSignature(
       xkeyKthAddress(initiatorXpub, appSeqNo),
       setStateCommitment,
-      signature
+      customData.signature
     );
 
     const mySig = yield [Opcode.OP_SIGN, setStateCommitment, appSeqNo];

--- a/packages/node/src/protocol/uninstall-virtual-app.ts
+++ b/packages/node/src/protocol/uninstall-virtual-app.ts
@@ -71,7 +71,7 @@ export const UNINSTALL_VIRTUAL_APP_PROTOCOL: ProtocolExecutionFlow = {
       timeLockedPassThroughAppInstance
     ] = await getUpdatedStateChannelAndAppInstanceObjectsForInitiating(
       stateChannelsMap,
-      params,
+      params!,
       provider,
       network
     );
@@ -95,14 +95,18 @@ export const UNINSTALL_VIRTUAL_APP_PROTOCOL: ProtocolExecutionFlow = {
       protocol: Protocol.UninstallVirtualApp,
       seq: 1,
       toXpub: intermediaryXpub,
-      signature: initiatingSignatureOnTimeLockedPassThroughSetStateCommitment
+      customData: {
+        signature: initiatingSignatureOnTimeLockedPassThroughSetStateCommitment
+      }
     } as ProtocolMessage;
 
-    const m4 = yield [IO_SEND_AND_WAIT, m1];
+    const m4 = (yield [IO_SEND_AND_WAIT, m1]) as ProtocolMessage;
 
     const {
-      signature: responderSignatureOnTimeLockedPassThroughSetStateCommitment,
-      signature2: intermediarySignatureOnTimeLockedPassThroughSetStateCommitment
+      customData: {
+        signature: responderSignatureOnTimeLockedPassThroughSetStateCommitment,
+        signature2: intermediarySignatureOnTimeLockedPassThroughSetStateCommitment
+      }
     } = m4;
 
     assertIsValidSignature(
@@ -135,13 +139,17 @@ export const UNINSTALL_VIRTUAL_APP_PROTOCOL: ProtocolExecutionFlow = {
       protocol: Protocol.UninstallVirtualApp,
       seq: UNASSIGNED_SEQ_NO,
       toXpub: intermediaryXpub,
-      signature: initiatingSignatureOnAliceIngridAppDisactivationCommitment
-    };
+      customData: {
+        signature: initiatingSignatureOnAliceIngridAppDisactivationCommitment
+      }
+    } as ProtocolMessage;
 
-    const m6 = yield [IO_SEND_AND_WAIT, m5];
+    const m6 = (yield [IO_SEND_AND_WAIT, m5]) as ProtocolMessage;
 
     const {
-      signature: intermediarySignatureOnAliceIngridAppDisactivationCommitment
+      customData: {
+        signature: intermediarySignatureOnAliceIngridAppDisactivationCommitment
+      }
     } = m6;
 
     assertIsValidSignature(
@@ -171,7 +179,9 @@ export const UNINSTALL_VIRTUAL_APP_PROTOCOL: ProtocolExecutionFlow = {
       message: {
         protocolExecutionID,
         params,
-        signature: initiatingSignatureOnTimeLockedPassThroughSetStateCommitment
+        customData: {
+          signature: initiatingSignatureOnTimeLockedPassThroughSetStateCommitment
+        }
       },
       provider,
       stateChannelsMap,
@@ -193,7 +203,7 @@ export const UNINSTALL_VIRTUAL_APP_PROTOCOL: ProtocolExecutionFlow = {
       timeLockedPassThroughAppInstance
     ] = await getUpdatedStateChannelAndAppInstanceObjectsForIntermediary(
       stateChannelsMap,
-      params,
+      params!,
       provider,
       network
     );
@@ -223,14 +233,18 @@ export const UNINSTALL_VIRTUAL_APP_PROTOCOL: ProtocolExecutionFlow = {
       protocol: Protocol.UninstallVirtualApp,
       seq: 2,
       toXpub: responderXpub,
-      signature: initiatingSignatureOnTimeLockedPassThroughSetStateCommitment,
-      signature2: intermediarySignatureOnTimeLockedPassThroughSetStateCommitment
+      customData: {
+        signature: initiatingSignatureOnTimeLockedPassThroughSetStateCommitment,
+        signature2: intermediarySignatureOnTimeLockedPassThroughSetStateCommitment
+      }
     } as ProtocolMessage;
 
-    const m3 = yield [IO_SEND_AND_WAIT, m2];
+    const m3 = (yield [IO_SEND_AND_WAIT, m2]) as ProtocolMessage;
 
     const {
-      signature: respondingSignatureOnTimeLockedPassThroughSetStateCommitment
+      customData: {
+        signature: respondingSignatureOnTimeLockedPassThroughSetStateCommitment
+      }
     } = m3;
 
     assertIsValidSignature(
@@ -244,14 +258,18 @@ export const UNINSTALL_VIRTUAL_APP_PROTOCOL: ProtocolExecutionFlow = {
       protocol: Protocol.UninstallVirtualApp,
       seq: UNASSIGNED_SEQ_NO,
       toXpub: initiatorXpub,
-      signature: respondingSignatureOnTimeLockedPassThroughSetStateCommitment,
-      signature2: intermediarySignatureOnTimeLockedPassThroughSetStateCommitment
+      customData: {
+        signature: respondingSignatureOnTimeLockedPassThroughSetStateCommitment,
+        signature2: intermediarySignatureOnTimeLockedPassThroughSetStateCommitment
+      }
     } as ProtocolMessage;
 
-    const m5 = yield [IO_SEND_AND_WAIT, m4];
+    const m5 = (yield [IO_SEND_AND_WAIT, m4]) as ProtocolMessage;
 
     const {
-      signature: initiatingSignatureOnAliceIngridAppDisactivationCommitment
+      customData: {
+        signature: initiatingSignatureOnAliceIngridAppDisactivationCommitment
+      }
     } = m5;
 
     const aliceIngridAppDisactivationCommitment = new SetStateCommitment(
@@ -280,7 +298,9 @@ export const UNINSTALL_VIRTUAL_APP_PROTOCOL: ProtocolExecutionFlow = {
         protocol: Protocol.UninstallVirtualApp,
         seq: UNASSIGNED_SEQ_NO,
         toXpub: initiatorXpub,
-        signature: intermediarySignatureOnAliceIngridAppDisactivationCommitment
+        customData: {
+          signature: intermediarySignatureOnAliceIngridAppDisactivationCommitment
+        }
       } as ProtocolMessage
     ];
 
@@ -302,13 +322,17 @@ export const UNINSTALL_VIRTUAL_APP_PROTOCOL: ProtocolExecutionFlow = {
       protocol: Protocol.UninstallVirtualApp,
       seq: UNASSIGNED_SEQ_NO,
       toXpub: responderXpub,
-      signature: intermediarySignatureOnIngridBobAppDisactivationCommitment
+      customData: {
+        signature: intermediarySignatureOnIngridBobAppDisactivationCommitment
+      }
     } as ProtocolMessage;
 
-    const m8 = yield [IO_SEND_AND_WAIT, m7];
+    const m8 = (yield [IO_SEND_AND_WAIT, m7]) as ProtocolMessage;
 
     const {
-      signature: respondingSignatureOnIngridBobAppDisactivationCommitment
+      customData: {
+        signature: respondingSignatureOnIngridBobAppDisactivationCommitment
+      }
     } = m8;
 
     assertIsValidSignature(
@@ -338,8 +362,10 @@ export const UNINSTALL_VIRTUAL_APP_PROTOCOL: ProtocolExecutionFlow = {
       message: {
         protocolExecutionID,
         params,
-        signature: initiatingSignatureOnTimeLockedPassThroughSetStateCommitment,
-        signature2: intermediarySignatureOnTimeLockedPassThroughSetStateCommitment
+        customData: {
+          signature: initiatingSignatureOnTimeLockedPassThroughSetStateCommitment,
+          signature2: intermediarySignatureOnTimeLockedPassThroughSetStateCommitment
+        }
       },
       provider,
       stateChannelsMap,
@@ -361,7 +387,7 @@ export const UNINSTALL_VIRTUAL_APP_PROTOCOL: ProtocolExecutionFlow = {
       timeLockedPassThroughAppInstance
     ] = await getUpdatedStateChannelAndAppInstanceObjectsForResponding(
       stateChannelsMap,
-      params,
+      params!,
       provider,
       network
     );
@@ -396,13 +422,17 @@ export const UNINSTALL_VIRTUAL_APP_PROTOCOL: ProtocolExecutionFlow = {
       protocol: Protocol.UninstallVirtualApp,
       seq: UNASSIGNED_SEQ_NO,
       toXpub: intermediaryXpub,
-      signature: respondingSignatureOnTimeLockedPassThroughSetStateCommitment
+      customData: {
+        signature: respondingSignatureOnTimeLockedPassThroughSetStateCommitment
+      }
     } as ProtocolMessage;
 
-    const m7 = yield [IO_SEND_AND_WAIT, m3];
+    const m7 = (yield [IO_SEND_AND_WAIT, m3]) as ProtocolMessage;
 
     const {
-      signature: intermediarySignatureOnIngridBobAppDisactivationCommitment
+      customData: {
+        signature: intermediarySignatureOnIngridBobAppDisactivationCommitment
+      }
     } = m7;
 
     const ingridBobAppDisactivationCommitment = new SetStateCommitment(
@@ -429,7 +459,9 @@ export const UNINSTALL_VIRTUAL_APP_PROTOCOL: ProtocolExecutionFlow = {
       protocol: Protocol.UninstallVirtualApp,
       seq: UNASSIGNED_SEQ_NO,
       toXpub: intermediaryXpub,
-      signature: respondingSignatureOnIngridBobAppDisactivationCommitment
+      customData: {
+        signature: respondingSignatureOnIngridBobAppDisactivationCommitment
+      }
     } as ProtocolMessage;
 
     yield [IO_SEND, m8];

--- a/packages/node/src/protocol/withdraw.ts
+++ b/packages/node/src/protocol/withdraw.ts
@@ -88,8 +88,10 @@ export const WITHDRAW_PROTOCOL: ProtocolExecutionFlow = {
     ];
 
     const {
-      signature: counterpartySignatureOnConditionalTransaction,
-      signature2: counterpartySignatureOnFreeBalanceStateUpdate
+      customData: {
+        signature: counterpartySignatureOnConditionalTransaction,
+        signature2: counterpartySignatureOnFreeBalanceStateUpdate
+      }
     } = yield [
       Opcode.IO_SEND_AND_WAIT,
       {
@@ -97,7 +99,9 @@ export const WITHDRAW_PROTOCOL: ProtocolExecutionFlow = {
         params,
         protocol: Protocol.Withdraw,
         toXpub: responderXpub,
-        signature: mySignatureOnConditionalTransaction,
+        customData: {
+          signature: mySignatureOnConditionalTransaction
+        },
         seq: 1
       } as ProtocolMessage
     ];
@@ -173,16 +177,20 @@ export const WITHDRAW_PROTOCOL: ProtocolExecutionFlow = {
     ];
 
     const {
-      signature: counterpartySignatureOnWithdrawalCommitment,
-      signature2: counterpartySignatureOnUninstallCommitment
+      customData: {
+        signature: counterpartySignatureOnWithdrawalCommitment,
+        signature2: counterpartySignatureOnUninstallCommitment
+      }
     } = yield [
       Opcode.IO_SEND_AND_WAIT,
       {
         protocolExecutionID,
         protocol: Protocol.Withdraw,
         toXpub: responderXpub,
-        signature: mySignatureOnFreeBalanceStateUpdate,
-        signature2: mySignatureOnWithdrawalCommitment,
+        customData: {
+          signature: mySignatureOnFreeBalanceStateUpdate,
+          signature2: mySignatureOnWithdrawalCommitment
+        },
         seq: UNASSIGNED_SEQ_NO
       } as ProtocolMessage
     ];
@@ -222,13 +230,15 @@ export const WITHDRAW_PROTOCOL: ProtocolExecutionFlow = {
       uninstallRefundAppCommitment
     ];
 
-    yield [
+    yield <[Opcode, ProtocolMessage]>[
       Opcode.IO_SEND,
       {
         protocol: Protocol.Withdraw,
         protocolExecutionID: context.message.protocolExecutionID,
         toXpub: responderXpub,
-        signature: mySignatureOnUninstallCommitment,
+        customData: {
+          signature: mySignatureOnUninstallCommitment
+        },
         seq: UNASSIGNED_SEQ_NO
       }
     ];
@@ -276,12 +286,12 @@ export const WITHDRAW_PROTOCOL: ProtocolExecutionFlow = {
   1 /* Responding */: async function*(context: Context) {
     const {
       stateChannelsMap,
-      message: { params, protocolExecutionID, signature },
+      message: { params, protocolExecutionID, customData },
       network
     } = context;
 
     // Aliasing `signature` to this variable name for code clarity
-    const counterpartySignatureOnConditionalTransaction = signature;
+    const counterpartySignatureOnConditionalTransaction = customData.signature;
 
     const {
       initiatorXpub,
@@ -356,16 +366,20 @@ export const WITHDRAW_PROTOCOL: ProtocolExecutionFlow = {
     ];
 
     const {
-      signature: counterpartySignatureOnFreeBalanceStateUpdate,
-      signature2: counterpartySignatureOnWithdrawalCommitment
+      customData: {
+        signature: counterpartySignatureOnFreeBalanceStateUpdate,
+        signature2: counterpartySignatureOnWithdrawalCommitment
+      }
     } = yield [
       Opcode.IO_SEND_AND_WAIT,
       {
         protocolExecutionID,
         protocol: Protocol.Withdraw,
         toXpub: initiatorXpub,
-        signature: mySignatureOnConditionalTransaction,
-        signature2: mySignatureOnFreeBalanceStateUpdate,
+        customData: {
+          signature: mySignatureOnConditionalTransaction,
+          signature2: mySignatureOnFreeBalanceStateUpdate
+        },
         seq: UNASSIGNED_SEQ_NO
       } as ProtocolMessage
     ];
@@ -443,14 +457,18 @@ export const WITHDRAW_PROTOCOL: ProtocolExecutionFlow = {
       uninstallRefundAppCommitment
     ];
 
-    const { signature: counterpartySignatureOnUninstallCommitment } = yield [
+    const {
+      customData: { signature: counterpartySignatureOnUninstallCommitment }
+    } = yield [
       Opcode.IO_SEND_AND_WAIT,
       {
         protocolExecutionID,
         protocol: Protocol.Withdraw,
         toXpub: initiatorXpub,
-        signature: mySignatureOnWithdrawalCommitment,
-        signature2: mySignatureOnUninstallCommitment,
+        customData: {
+          signature: mySignatureOnWithdrawalCommitment,
+          signature2: mySignatureOnUninstallCommitment
+        },
         seq: UNASSIGNED_SEQ_NO
       } as ProtocolMessage
     ];


### PR DESCRIPTION
`ProtocolMessage` had two issues:

- `signature{1,2,3,4}` are not meaningful labels used by the spec
- the install-virtual-app protocol was misusing one of the signatures to pass data

This PR fixes both issues by creating a `customData` field with arbitrary keys allowed and mechanically moving `signature{1,2,3,4}` into it. A follow-up PR will give the signatures better names.