### PR TITLE
[node] feat: Add babel to Node to transpile object rest spread

### DIFF
--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -22,7 +22,6 @@
   "devDependencies": {
     "@babel/core": "^7.5.5",
     "@babel/plugin-proposal-object-rest-spread": "^7.5.5",
-    "@babel/preset-env": "^7.5.5",
     "@counterfactual/apps": "0.1.4",
     "@counterfactual/firebase-server": "0.0.1",
     "@counterfactual/local-ganache-server": "0.0.2",

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -20,6 +20,9 @@
     "lint": "tslint -c tslint.json -p ."
   },
   "devDependencies": {
+    "@babel/core": "^7.5.5",
+    "@babel/plugin-proposal-object-rest-spread": "^7.5.5",
+    "@babel/preset-env": "^7.5.5",
     "@counterfactual/apps": "0.1.4",
     "@counterfactual/firebase-server": "0.0.1",
     "@counterfactual/local-ganache-server": "0.0.2",
@@ -40,6 +43,7 @@
     "jest-cli": "24.8.0",
     "jest-dot-reporter": "1.0.8",
     "rollup": "1.19.4",
+    "rollup-plugin-babel": "^4.3.3",
     "rollup-plugin-commonjs": "10.0.2",
     "rollup-plugin-json": "4.0.0",
     "rollup-plugin-node-resolve": "5.2.0",

--- a/packages/node/rollup.config.js
+++ b/packages/node/rollup.config.js
@@ -1,3 +1,4 @@
+import babel from "rollup-plugin-babel";
 import commonjs from "rollup-plugin-commonjs";
 import json from "rollup-plugin-json";
 import nodeResolve from "rollup-plugin-node-resolve";
@@ -8,7 +9,7 @@ import pkg from "./package.json";
 const globals = {
   "@counterfactual/cf.js": "cfjs",
   eventemitter3: "EventEmitter",
-  "ethers": "ethers",
+  ethers: "ethers",
   "ethers/constants": "ethers.constants",
   "ethers/errors": "ethers.errors",
   "ethers/providers": "ethers.providers",
@@ -49,26 +50,24 @@ const onwarn = warning => {
   // refers to the `RequestHandler` to access certain resources. The
   // `RequestHandler` refers to the `src/api.ts` file to lookup the method & event
   // mapping so it knows how to route the call.
-  // The more elegnat solution, instead of overlooking this circular dependency,
+  // The more elegant solution, instead of overlooking this circular dependency,
   // is to refactor how calls are routed to controllers, specifically the
   // behavior around `mapPublicApiMethods` and `mapEventHandlers`
   const circularDependencyWarnings = new Set([
     "Circular dependency: src/api.ts -> src/methods/index.ts -> src/methods/app-instance/get-app-instance/controller.ts -> src/request-handler.ts -> src/api.ts"
   ]);
 
-  if (circularDependencyWarnings.has(warning.message) ||
-    (
-      // It's expected that the ethers package is an external dependency
-      // meaning its import technically is unresolved at rollup time
-      warning.code === "UNRESOLVED_IMPORT" &&
-      warning.message.includes("ethers")
-    )
+  if (
+    circularDependencyWarnings.has(warning.message) ||
+    // It's expected that the ethers package is an external dependency
+    // meaning its import technically is unresolved at rollup time
+    (warning.code === "UNRESOLVED_IMPORT" && warning.message.includes("ethers"))
   ) {
     return;
   }
 
-  console.warn(`(!) ${warning.message}`)
-}
+  console.warn(`(!) ${warning.message}`);
+};
 
 export default [
   {
@@ -103,6 +102,12 @@ export default [
         only: [...bundledDependencies]
       }),
       typescript(),
+      // use Babel to transpile to ES5
+      babel({
+        exclude: "node_modules/**",
+        presets: ["@babel/preset-env"],
+        plugins: ["@babel/plugin-proposal-object-rest-spread"]
+      })
     ],
     onwarn
   }

--- a/packages/node/rollup.config.js
+++ b/packages/node/rollup.config.js
@@ -105,7 +105,6 @@ export default [
       // use Babel to transpile to ES5
       babel({
         exclude: "node_modules/**",
-        presets: ["@babel/preset-env"],
         plugins: ["@babel/plugin-proposal-object-rest-spread"]
       })
     ],

--- a/yarn.lock
+++ b/yarn.lock
@@ -807,7 +807,7 @@
     js-levenshtein "^1.1.3"
     semver "^5.5.0"
 
-"@babel/preset-env@^7.1.6", "@babel/preset-env@^7.5.5":
+"@babel/preset-env@^7.1.6":
   version "7.5.5"
   resolved "https://registry.yarnpkg.com/@babel/preset-env/-/preset-env-7.5.5.tgz#bc470b53acaa48df4b8db24a570d6da1fef53c9a"
   integrity sha512-GMZQka/+INwsMz1A5UEql8tG015h5j/qjptpKY2gJ7giy8ohzU710YciJB5rcKsWGWHiW3RUnHib0E5/m3Tp3A==

--- a/yarn.lock
+++ b/yarn.lock
@@ -36,9 +36,9 @@
     semver "^5.4.1"
     source-map "^0.5.0"
 
-"@babel/core@^7.1.0", "@babel/core@^7.1.6", "@babel/core@^7.4.5":
+"@babel/core@^7.1.0", "@babel/core@^7.1.6", "@babel/core@^7.4.5", "@babel/core@^7.5.5":
   version "7.5.5"
-  resolved "https://registry.npmjs.org/@babel/core/-/core-7.5.5.tgz#17b2686ef0d6bc58f963dddd68ab669755582c30"
+  resolved "https://registry.yarnpkg.com/@babel/core/-/core-7.5.5.tgz#17b2686ef0d6bc58f963dddd68ab669755582c30"
   integrity sha512-i4qoSr2KTtce0DmkuuQBV4AuQgGPUcPXMr9L5MyYAtk06z068lQ10a4O009fe5OB/DfNV+h+qqT7ddNV8UnRjg==
   dependencies:
     "@babel/code-frame" "^7.5.5"
@@ -317,7 +317,7 @@
 
 "@babel/plugin-proposal-object-rest-spread@^7.4.3", "@babel/plugin-proposal-object-rest-spread@^7.5.5":
   version "7.5.5"
-  resolved "https://registry.npmjs.org/@babel/plugin-proposal-object-rest-spread/-/plugin-proposal-object-rest-spread-7.5.5.tgz#61939744f71ba76a3ae46b5eea18a54c16d22e58"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-object-rest-spread/-/plugin-proposal-object-rest-spread-7.5.5.tgz#61939744f71ba76a3ae46b5eea18a54c16d22e58"
   integrity sha512-F2DxJJSQ7f64FyTVl5cw/9MWn6naXGdk3Q3UhDbFEEHv+EilCPoeRD3Zh/Utx1CJz4uyKlQ4uH+bJPbEhMV7Zw==
   dependencies:
     "@babel/helper-plugin-utils" "^7.0.0"
@@ -807,9 +807,9 @@
     js-levenshtein "^1.1.3"
     semver "^5.5.0"
 
-"@babel/preset-env@^7.1.6":
+"@babel/preset-env@^7.1.6", "@babel/preset-env@^7.5.5":
   version "7.5.5"
-  resolved "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.5.5.tgz#bc470b53acaa48df4b8db24a570d6da1fef53c9a"
+  resolved "https://registry.yarnpkg.com/@babel/preset-env/-/preset-env-7.5.5.tgz#bc470b53acaa48df4b8db24a570d6da1fef53c9a"
   integrity sha512-GMZQka/+INwsMz1A5UEql8tG015h5j/qjptpKY2gJ7giy8ohzU710YciJB5rcKsWGWHiW3RUnHib0E5/m3Tp3A==
   dependencies:
     "@babel/helper-module-imports" "^7.0.0"
@@ -4530,7 +4530,7 @@ babel-plugin-transform-exponentiation-operator@^6.22.0:
 
 babel-plugin-transform-object-rest-spread@^6.26.0:
   version "6.26.0"
-  resolved "https://registry.npmjs.org/babel-plugin-transform-object-rest-spread/-/babel-plugin-transform-object-rest-spread-6.26.0.tgz#0f36692d50fef6b7e2d4b3ac1478137a963b7b06"
+  resolved "https://registry.yarnpkg.com/babel-plugin-transform-object-rest-spread/-/babel-plugin-transform-object-rest-spread-6.26.0.tgz#0f36692d50fef6b7e2d4b3ac1478137a963b7b06"
   integrity sha1-DzZpLVD+9rfi1LOsFHgTepY7ewY=
   dependencies:
     babel-plugin-syntax-object-rest-spread "^6.8.0"
@@ -17402,6 +17402,14 @@ rlp@^2.0.0, rlp@^2.2.1:
   dependencies:
     bn.js "^4.11.1"
     safe-buffer "^5.1.1"
+
+rollup-plugin-babel@^4.3.3:
+  version "4.3.3"
+  resolved "https://registry.yarnpkg.com/rollup-plugin-babel/-/rollup-plugin-babel-4.3.3.tgz#7eb5ac16d9b5831c3fd5d97e8df77ba25c72a2aa"
+  integrity sha512-tKzWOCmIJD/6aKNz0H1GMM+lW1q9KyFubbWzGiOG540zxPPifnEAHTZwjo0g991Y+DyOZcLqBgqOdqazYE5fkw==
+  dependencies:
+    "@babel/helper-module-imports" "^7.0.0"
+    rollup-pluginutils "^2.8.1"
 
 rollup-plugin-commonjs@10.0.2:
   version "10.0.2"


### PR DESCRIPTION
### Description

This adds Babel along with @babel/plugin-proposal-object-rest-spread to Node so that Rollup transpiles the code.

Object rest spread was causing issues in MM build script.
