### PR TITLE
[node] bump version

### DIFF
--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@counterfactual/node",
-  "version": "0.2.44",
+  "version": "0.2.45",
   "main": "dist/index.js",
   "iife": "dist/index.iife.js",
   "types": "dist/src/index.d.ts",

--- a/packages/simple-hub-server/package.json
+++ b/packages/simple-hub-server/package.json
@@ -39,7 +39,7 @@
   },
   "dependencies": {
     "@counterfactual/firebase-client": "0.0.3",
-    "@counterfactual/node": "0.2.44",
+    "@counterfactual/node": "0.2.45",
     "@counterfactual/types": "0.0.34",
     "@counterfactual/typescript-typings": "0.1.0",
     "@ebryn/jsonapi-ts": "0.1.17",


### PR DESCRIPTION
heroku is reject pushes, because building `simple-hub-server` from scratch fails, because that uses `@counterfactual/node` from npm and the changes in #2183 are not on npm, because #2183 did not bump node version