### PR TITLE
[node] cache xkeyKthHDNode

### DIFF
--- a/packages/node/src/machine/xkeys.ts
+++ b/packages/node/src/machine/xkeys.ts
@@ -53,7 +53,7 @@ export function xkeysToSortedKthSigningKeys(
   k: number
 ): SigningKey[] {
   const sortedKeys = sortSigningkeys(
-    xkeys.map(xkey => new SigningKey(xkeyKthHDNode(xkey, k).privateKey)),
+    xkeys.map(xkey => new SigningKey(xkeyKthHDNode(xkey, k).privateKey))
   );
   console.log(`Got sorted keys: ${JSON.stringify(sortedKeys)}`);
   return sortedKeys;

--- a/packages/node/src/machine/xkeys.ts
+++ b/packages/node/src/machine/xkeys.ts
@@ -32,7 +32,7 @@ export function xkeyKthAddress(xkey: string, k: number): string {
     cache[xkey] = {};
   }
   if (!cache[xkey][k]) {
-    cache[xkey][k] = computeAddress(xkeyKthHDNode(xkey, k).publicKey);;
+    cache[xkey][k] = computeAddress(xkeyKthHDNode(xkey, k).publicKey);
   }
   return cache[xkey][k];
 }
@@ -53,7 +53,7 @@ export function xkeysToSortedKthSigningKeys(
   k: number
 ): SigningKey[] {
   const sortedKeys = sortSigningkeys(
-    xkeys.map(xkey => new SigningKey(xkeyKthHDNode(xkey, k).privateKey));
+    xkeys.map(xkey => new SigningKey(xkeyKthHDNode(xkey, k).privateKey)),
   );
   console.log(`Got sorted keys: ${JSON.stringify(sortedKeys)}`);
   return sortedKeys;

--- a/packages/node/src/machine/xkeys.ts
+++ b/packages/node/src/machine/xkeys.ts
@@ -29,8 +29,15 @@ export function xkeyKthAddress(xkey: string, k: number): string {
   return computeAddress(xkeyKthHDNode(xkey, k).publicKey);
 }
 
+const cache = {} as any;
 export function xkeyKthHDNode(xkey: string, k: number): HDNode {
-  return fromExtendedKey(xkey).derivePath(`${k}`);
+  if (!cache.xkey) {
+    cache.xkey = {};
+  }
+  if (!cache.xkey.k) {
+    cache.xkey.k = fromExtendedKey(xkey).derivePath(`${k}`);
+  }
+  return cache.xkey.k;
 }
 
 export function xkeysToSortedKthAddresses(

--- a/packages/node/src/machine/xkeys.ts
+++ b/packages/node/src/machine/xkeys.ts
@@ -26,19 +26,19 @@ function sortSigningkeys(addrs: SigningKey[]): SigningKey[] {
   );
 }
 
-export function xkeyKthAddress(xkey: string, k: number): string {
-  return computeAddress(xkeyKthHDNode(xkey, k).publicKey);
-}
-
 const cache = {} as any;
-export function xkeyKthHDNode(xkey: string, k: number): HDNode {
+export function xkeyKthAddress(xkey: string, k: number): string {
   if (!cache[xkey]) {
     cache[xkey] = {};
   }
   if (!cache[xkey][k]) {
-    cache[xkey][k] = fromExtendedKey(xkey).derivePath(`${k}`);
+    cache[xkey][k] = computeAddress(xkeyKthHDNode(xkey, k).publicKey);;
   }
   return cache[xkey][k];
+}
+
+export function xkeyKthHDNode(xkey: string, k: number): HDNode {
+  return fromExtendedKey(xkey).derivePath(`${k}`);
 }
 
 export function xkeysToSortedKthAddresses(

--- a/packages/node/src/machine/xkeys.ts
+++ b/packages/node/src/machine/xkeys.ts
@@ -32,14 +32,13 @@ export function xkeyKthAddress(xkey: string, k: number): string {
 
 const cache = {} as any;
 export function xkeyKthHDNode(xkey: string, k: number): HDNode {
-  if (!cache.xkey) {
-    cache.xkey = {};
+  if (!cache[xkey]) {
+    cache[xkey] = {};
   }
-  if (!cache.xkey.k) {
-    cache.xkey.k = fromExtendedKey(xkey).derivePath(`${k}`);
-    console.log(`Added ${cache.xkey.k} to cache`);
+  if (!cache[xkey][k]) {
+    cache[xkey][k] = fromExtendedKey(xkey).derivePath(`${k}`);
   }
-  return cache.xkey.k;
+  return cache[xkey][k];
 }
 
 export function xkeysToSortedKthAddresses(

--- a/packages/node/src/machine/xkeys.ts
+++ b/packages/node/src/machine/xkeys.ts
@@ -20,6 +20,7 @@ export function sortAddresses(addrs: string[]): string[] {
 }
 
 function sortSigningkeys(addrs: SigningKey[]): SigningKey[] {
+  console.log(`Sorting keys: ${JSON.stringify(addrs)}`);
   return addrs.sort((a, b) =>
     parseInt(a.address, 16) < parseInt(b.address, 16) ? -1 : 1
   );
@@ -36,6 +37,7 @@ export function xkeyKthHDNode(xkey: string, k: number): HDNode {
   }
   if (!cache.xkey.k) {
     cache.xkey.k = fromExtendedKey(xkey).derivePath(`${k}`);
+    console.log(`Added ${cache.xkey.k} to cache`);
   }
   return cache.xkey.k;
 }
@@ -51,7 +53,9 @@ export function xkeysToSortedKthSigningKeys(
   xkeys: string[],
   k: number
 ): SigningKey[] {
-  return sortSigningkeys(
-    xkeys.map(xkey => new SigningKey(xkeyKthHDNode(xkey, k).privateKey))
+  const sortedKeys = sortSigningkeys(
+    xkeys.map(xkey => new SigningKey(xkeyKthHDNode(xkey, k).privateKey));
   );
+  console.log(`Got sorted keys: ${JSON.stringify(sortedKeys)}`);
+  return sortedKeys;
 }

--- a/packages/node/src/machine/xkeys.ts
+++ b/packages/node/src/machine/xkeys.ts
@@ -20,7 +20,6 @@ export function sortAddresses(addrs: string[]): string[] {
 }
 
 function sortSigningkeys(addrs: SigningKey[]): SigningKey[] {
-  console.log(`Sorting keys: ${JSON.stringify(addrs)}`);
   return addrs.sort((a, b) =>
     parseInt(a.address, 16) < parseInt(b.address, 16) ? -1 : 1
   );
@@ -52,9 +51,7 @@ export function xkeysToSortedKthSigningKeys(
   xkeys: string[],
   k: number
 ): SigningKey[] {
-  const sortedKeys = sortSigningkeys(
+  return sortSigningkeys(
     xkeys.map(xkey => new SigningKey(xkeyKthHDNode(xkey, k).privateKey))
   );
-  console.log(`Got sorted keys: ${JSON.stringify(sortedKeys)}`);
-  return sortedKeys;
 }


### PR DESCRIPTION
### Description

Don't recompute keys from xpubs any more than needed, cache result the first time then use that again later

### Related issues

[Link here any issues relevant to this PR, using the GitHub `fixes/resolves/closes` keywords to close related issues automatically.]

- [ ] Deploy preview is functional
