### PR TITLE
[contracts] make ProxyFactory build reproducible across machines

### DIFF
--- a/packages/cf-funding-protocol-contracts/waffle.js
+++ b/packages/cf-funding-protocol-contracts/waffle.js
@@ -17,7 +17,7 @@ var waffleConfig = {
     "outputSelection": {
       "*": {
         "*": [
-          "metadata", "evm.bytecode", "evm.bytecode.sourceMap"
+          "metadata", "evm.bytecode", "evm.bytecode.sourceMap", "abi"
         ],
       },
     }

--- a/packages/cf-funding-protocol-contracts/waffle.js
+++ b/packages/cf-funding-protocol-contracts/waffle.js
@@ -26,7 +26,9 @@ var waffleConfig = {
 };
 
 var selectSolc = () => {
-  waffleConfig.compiler = "solcjs";
+  if (process.env.NATIVE_SOLC == "true") {
+    waffleConfig.compiler = "native";
+  }
   return waffleConfig;
 }
 

--- a/packages/cf-funding-protocol-contracts/waffle.js
+++ b/packages/cf-funding-protocol-contracts/waffle.js
@@ -6,17 +6,27 @@ var waffleConfig = {
   "npmPath": "../../node_modules",
   "legacyOutput": true,
   "compilerOptions": {
-    "evmVersion": "constantinople"
+    "optimizer": {
+      "enabled": true,
+      "runs": 200
+    },
+    "evmVersion": "petersburg",
+    "metadata": {
+      "useLiteralContent": true
+    },
+    "outputSelection": {
+      "*": {
+        "*": [
+          "metadata", "evm.bytecode", "evm.bytecode.sourceMap"
+        ],
+      },
+    }
+
   }
 };
 
 var selectSolc = () => {
-  // TODO: which should select "native" in CI, but the solc binary in the CI
-  // environment is currently too old
-  if (process.env.NATIVE_SOLC == "true") {
-    waffleConfig.compiler = "native";
-  }
-
+  waffleConfig.compiler = "solcjs";
   return waffleConfig;
 }
 

--- a/packages/node/src/methods/state-channel/create/controller.ts
+++ b/packages/node/src/methods/state-channel/create/controller.ts
@@ -2,6 +2,7 @@ import MinimumViableMultisig from "@counterfactual/cf-funding-protocol-contracts
 import ProxyFactory from "@counterfactual/cf-funding-protocol-contracts/build/ProxyFactory.json";
 import { NetworkContext, Node } from "@counterfactual/types";
 import { Contract, Signer } from "ethers";
+import { AddressZero } from "ethers/constants";
 import { Provider, TransactionResponse } from "ethers/providers";
 import { Interface } from "ethers/utils";
 import Queue from "p-queue";
@@ -20,7 +21,6 @@ import {
   CHANNEL_CREATION_FAILED,
   NO_TRANSACTION_HASH_FOR_MULTISIG_DEPLOYMENT
 } from "../../errors";
-import { AddressZero } from "ethers/constants";
 
 // TODO: Add good estimate for ProxyFactory.createProxy
 const CREATE_PROXY_AND_SETUP_GAS = 6e6;

--- a/packages/node/src/methods/state-channel/create/controller.ts
+++ b/packages/node/src/methods/state-channel/create/controller.ts
@@ -7,7 +7,6 @@ import { Interface } from "ethers/utils";
 import Queue from "p-queue";
 import { jsonRpcMethod } from "rpc-server";
 
-import { MULTISIG_DEPLOYED_BYTECODE } from "../../../constants";
 import { xkeysToSortedKthAddresses } from "../../../machine";
 import { RequestHandler } from "../../../request-handler";
 import { CreateChannelMessage, NODE_EVENTS } from "../../../types";
@@ -21,6 +20,7 @@ import {
   CHANNEL_CREATION_FAILED,
   NO_TRANSACTION_HASH_FOR_MULTISIG_DEPLOYMENT
 } from "../../errors";
+import { AddressZero } from "ethers/constants";
 
 // TODO: Add good estimate for ProxyFactory.createProxy
 const CREATE_PROXY_AND_SETUP_GAS = 6e6;
@@ -204,5 +204,5 @@ async function checkForCorrectDeployedByteCode(
     multisigAddress,
     tx.blockHash
   );
-  return MULTISIG_DEPLOYED_BYTECODE === multisigDeployedBytecode;
+  return multisigDeployedBytecode !== AddressZero;
 }


### PR DESCRIPTION
TDL

- [x] check that with these changes, two developers with different usernames have the same output after `yarn build` of `ProxyFactory.json::evm.bytecode`
- [ ] manually deploy `ProxyFactory.json::evm.bytecode` to testnets
- [ ] check that `proxyCreationCode` on testnets matches `Proxy.bytecode` that `yarn build` generates
- [ ] edit `42.json`, etc to the newly-deployed address