### PR TITLE
[node] remove unused legacy RPC endpoints

### DIFF
--- a/packages/node/src/api.ts
+++ b/packages/node/src/api.ts
@@ -78,7 +78,7 @@ const controllers = [
 export const methodNameToImplementation = controllers.reduce(
   (acc, controller) => {
     if (!controller.methodName) {
-      throw Error(`Fatal: Every controller must have a "methodName" property`);
+      return acc;
     }
 
     if (acc[controller.methodName]) {

--- a/packages/node/src/methods/app-instance/get-all/controller.ts
+++ b/packages/node/src/methods/app-instance/get-all/controller.ts
@@ -10,8 +10,6 @@ import { NodeController } from "../../controller";
  * this Node.
  */
 export default class GetAppInstancesController extends NodeController {
-  public static readonly methodName = Node.MethodName.GET_APP_INSTANCES;
-
   @jsonRpcMethod(Node.RpcMethodName.GET_APP_INSTANCES)
   public executeMethod = super.executeMethod;
 

--- a/packages/node/src/methods/app-instance/get-app-instance/controller.ts
+++ b/packages/node/src/methods/app-instance/get-app-instance/controller.ts
@@ -11,8 +11,6 @@ import { NO_APP_INSTANCE_ID_TO_GET_DETAILS } from "../../errors";
  * @param params
  */
 export default class GetAppInstanceDetailsController extends NodeController {
-  public static readonly methodName = Node.MethodName.GET_APP_INSTANCE_DETAILS;
-
   @jsonRpcMethod(Node.RpcMethodName.GET_APP_INSTANCE_DETAILS)
   protected async executeMethodImplementation(
     requestHandler: RequestHandler,

--- a/packages/node/src/methods/app-instance/get-free-balance/controller.ts
+++ b/packages/node/src/methods/app-instance/get-free-balance/controller.ts
@@ -6,8 +6,6 @@ import { RequestHandler } from "../../../request-handler";
 import { NodeController } from "../../controller";
 
 export default class GetFreeBalanceController extends NodeController {
-  public static readonly methodName = Node.MethodName.GET_FREE_BALANCE_STATE;
-
   @jsonRpcMethod(Node.RpcMethodName.GET_FREE_BALANCE_STATE)
   public executeMethod = super.executeMethod;
 

--- a/packages/node/src/methods/app-instance/get-state/controller.ts
+++ b/packages/node/src/methods/app-instance/get-state/controller.ts
@@ -11,8 +11,6 @@ import { NO_APP_INSTANCE_ID_FOR_GET_STATE } from "../../errors";
  * @param params
  */
 export default class GetStateController extends NodeController {
-  public static readonly methodName = Node.MethodName.GET_STATE;
-
   @jsonRpcMethod(Node.RpcMethodName.GET_STATE)
   protected async executeMethodImplementation(
     requestHandler: RequestHandler,

--- a/packages/node/src/methods/app-instance/get-token-indexed-free-balances/controller.ts
+++ b/packages/node/src/methods/app-instance/get-token-indexed-free-balances/controller.ts
@@ -5,9 +5,6 @@ import { RequestHandler } from "../../../request-handler";
 import { NodeController } from "../../controller";
 
 export default class GetTokenIndexedFreeBalancesController extends NodeController {
-  public static readonly methodName =
-    Node.MethodName.GET_TOKEN_INDEXED_FREE_BALANCE_STATES;
-
   @jsonRpcMethod(Node.RpcMethodName.GET_TOKEN_INDEXED_FREE_BALANCE_STATES)
   public executeMethod = super.executeMethod;
 

--- a/packages/node/src/methods/app-instance/install-virtual/controller.ts
+++ b/packages/node/src/methods/app-instance/install-virtual/controller.ts
@@ -11,8 +11,6 @@ import { NO_MULTISIG_FOR_APP_INSTANCE_ID } from "../../errors";
 import { installVirtual } from "./operation";
 
 export default class InstallVirtualController extends NodeController {
-  public static readonly methodName = Node.MethodName.INSTALL_VIRTUAL;
-
   @jsonRpcMethod(Node.RpcMethodName.INSTALL_VIRTUAL)
   public executeMethod = super.executeMethod;
 

--- a/packages/node/src/methods/app-instance/install/controller.ts
+++ b/packages/node/src/methods/app-instance/install/controller.ts
@@ -15,8 +15,6 @@ import { install } from "./operation";
  * @param params
  */
 export default class InstallController extends NodeController {
-  public static readonly methodName = Node.MethodName.INSTALL;
-
   @jsonRpcMethod(Node.RpcMethodName.INSTALL)
   public executeMethod = super.executeMethod;
 

--- a/packages/node/src/methods/app-instance/propose-install-virtual/controller.ts
+++ b/packages/node/src/methods/app-instance/propose-install-virtual/controller.ts
@@ -20,8 +20,6 @@ import {
  * @returns The AppInstanceId for the proposed AppInstance
  */
 export default class ProposeInstallVirtualController extends NodeController {
-  public static readonly methodName = Node.MethodName.PROPOSE_INSTALL_VIRTUAL;
-
   @jsonRpcMethod(Node.RpcMethodName.PROPOSE_INSTALL_VIRTUAL)
   public executeMethod = super.executeMethod;
 

--- a/packages/node/src/methods/app-instance/propose-install/controller.ts
+++ b/packages/node/src/methods/app-instance/propose-install/controller.ts
@@ -24,8 +24,6 @@ import { createProposedAppInstance } from "./operation";
  * @returns The AppInstanceId for the proposed AppInstance
  */
 export default class ProposeInstallController extends NodeController {
-  public static readonly methodName = Node.MethodName.PROPOSE_INSTALL;
-
   @jsonRpcMethod(Node.RpcMethodName.PROPOSE_INSTALL)
   public executeMethod = super.executeMethod;
 

--- a/packages/node/src/methods/app-instance/reject-install/controller.ts
+++ b/packages/node/src/methods/app-instance/reject-install/controller.ts
@@ -8,8 +8,6 @@ import { NodeController } from "../../controller";
 import rejectInstallVirtualController from "../reject-install-virtual/controller";
 
 export default class RejectInstallController extends NodeController {
-  public static readonly methodName = Node.MethodName.REJECT_INSTALL;
-
   protected async enqueueByShard(
     requestHandler: RequestHandler,
     params: Node.RejectInstallParams

--- a/packages/node/src/methods/app-instance/take-action/controller.ts
+++ b/packages/node/src/methods/app-instance/take-action/controller.ts
@@ -21,8 +21,6 @@ import {
 } from "../../errors";
 
 export default class TakeActionController extends NodeController {
-  public static readonly methodName = Node.MethodName.TAKE_ACTION;
-
   @jsonRpcMethod(Node.RpcMethodName.TAKE_ACTION)
   public executeMethod = super.executeMethod;
 

--- a/packages/node/src/methods/app-instance/uninstall-virtual/controller.ts
+++ b/packages/node/src/methods/app-instance/uninstall-virtual/controller.ts
@@ -16,8 +16,6 @@ import {
 import { uninstallVirtualAppInstanceFromChannel } from "./operation";
 
 export default class UninstallVirtualController extends NodeController {
-  public static readonly methodName = Node.MethodName.UNINSTALL_VIRTUAL;
-
   @jsonRpcMethod(Node.RpcMethodName.UNINSTALL_VIRTUAL)
   public executeMethod = super.executeMethod;
 

--- a/packages/node/src/methods/app-instance/uninstall/controller.ts
+++ b/packages/node/src/methods/app-instance/uninstall/controller.ts
@@ -14,8 +14,6 @@ import {
 import { uninstallAppInstanceFromChannel } from "./operation";
 
 export default class UninstallController extends NodeController {
-  public static readonly methodName = Node.MethodName.UNINSTALL;
-
   @jsonRpcMethod(Node.RpcMethodName.UNINSTALL)
   public executeMethod = super.executeMethod;
 

--- a/packages/node/src/methods/app-instance/update-state/controller.ts
+++ b/packages/node/src/methods/app-instance/update-state/controller.ts
@@ -19,8 +19,6 @@ import {
 } from "../../errors";
 
 export default class UpdateStateController extends NodeController {
-  public static readonly methodName = Node.MethodName.UPDATE_STATE;
-
   @jsonRpcMethod(Node.RpcMethodName.UPDATE_STATE)
   public executeMethod = super.executeMethod;
 

--- a/packages/node/src/methods/proposed-app-instance/get-all/controller.ts
+++ b/packages/node/src/methods/proposed-app-instance/get-all/controller.ts
@@ -5,9 +5,6 @@ import { RequestHandler } from "../../../request-handler";
 import { NodeController } from "../../controller";
 
 export default class GetProposedAppInstancesController extends NodeController {
-  public static readonly methodName =
-    Node.MethodName.GET_PROPOSED_APP_INSTANCES;
-
   @jsonRpcMethod(Node.RpcMethodName.GET_PROPOSED_APP_INSTANCES)
   protected async executeMethodImplementation(
     requestHandler: RequestHandler

--- a/packages/node/src/methods/state-channel/create/controller.ts
+++ b/packages/node/src/methods/state-channel/create/controller.ts
@@ -38,8 +38,6 @@ const CREATE_PROXY_AND_SETUP_GAS = 500_000;
  * to whoever subscribed to the `NODE_EVENTS.CREATE_CHANNEL` event on the Node.
  */
 export default class CreateChannelController extends NodeController {
-  public static readonly methodName = Node.MethodName.CREATE_CHANNEL;
-
   @jsonRpcMethod(Node.RpcMethodName.CREATE_CHANNEL)
   public executeMethod = super.executeMethod;
 

--- a/packages/node/src/methods/state-channel/deposit/controller.ts
+++ b/packages/node/src/methods/state-channel/deposit/controller.ts
@@ -24,8 +24,6 @@ import {
 } from "./operation";
 
 export default class DepositController extends NodeController {
-  public static readonly methodName = Node.MethodName.DEPOSIT;
-
   @jsonRpcMethod(Node.RpcMethodName.DEPOSIT)
   public executeMethod = super.executeMethod;
 

--- a/packages/node/src/methods/state-channel/get-state-deposit-holder-address/controller.ts
+++ b/packages/node/src/methods/state-channel/get-state-deposit-holder-address/controller.ts
@@ -15,9 +15,6 @@ import { RequestHandler } from "../../../request-handler";
 import { NodeController } from "../../controller";
 
 export default class GetStateDepositHolderAddressController extends NodeController {
-  public static readonly methodName =
-    Node.MethodName.GET_STATE_DEPOSIT_HOLDER_ADDRESS;
-
   @jsonRpcMethod(Node.RpcMethodName.GET_STATE_DEPOSIT_HOLDER_ADDRESS)
   public executeMethod = super.executeMethod;
 

--- a/packages/node/src/methods/state-channel/get/controller.ts
+++ b/packages/node/src/methods/state-channel/get/controller.ts
@@ -5,8 +5,6 @@ import { RequestHandler } from "../../../request-handler";
 import { NodeController } from "../../controller";
 
 export default class GetAllChannelAddressesController extends NodeController {
-  public static readonly methodName = Node.MethodName.GET_CHANNEL_ADDRESSES;
-
   @jsonRpcMethod(Node.RpcMethodName.GET_CHANNEL_ADDRESSES)
   public executeMethod = super.executeMethod;
 

--- a/packages/node/src/methods/state-channel/withdraw-commitment/controller.ts
+++ b/packages/node/src/methods/state-channel/withdraw-commitment/controller.ts
@@ -11,8 +11,6 @@ import { runWithdrawProtocol } from "../withdraw/operation";
 // Note: This can't extend `WithdrawController` because the `methodName` static
 // members of each class are incompatible.
 export default class WithdrawCommitmentController extends NodeController {
-  public static readonly methodName = Node.MethodName.WITHDRAW_COMMITMENT;
-
   @jsonRpcMethod(Node.RpcMethodName.WITHDRAW_COMMITMENT)
   public executeMethod = super.executeMethod;
 

--- a/packages/node/src/methods/state-channel/withdraw/controller.ts
+++ b/packages/node/src/methods/state-channel/withdraw/controller.ts
@@ -18,8 +18,6 @@ import {
 import { runWithdrawProtocol } from "./operation";
 
 export default class WithdrawController extends NodeController {
-  public static readonly methodName = Node.MethodName.WITHDRAW;
-
   @jsonRpcMethod(Node.RpcMethodName.WITHDRAW)
   public executeMethod = super.executeMethod;
 

--- a/packages/types/src/node.ts
+++ b/packages/types/src/node.ts
@@ -71,31 +71,8 @@ export namespace Node {
   // SOURCE: https://github.com/counterfactual/monorepo/blob/master/packages/cf.js/API_REFERENCE.md#public-methods
   export enum MethodName {
     ACCEPT_STATE = "acceptState",
-    CREATE_CHANNEL = "createChannel",
-    DEPOSIT = "deposit",
-    GET_APP_INSTANCE_DETAILS = "getAppInstanceDetails",
-    GET_APP_INSTANCES = "getAppInstances",
-    GET_CHANNEL_ADDRESSES = "getChannelAddresses",
-    GET_STATE_DEPOSIT_HOLDER_ADDRESS = "getStateDepositHolderAddress",
-    GET_FREE_BALANCE_STATE = "getFreeBalanceState",
-    GET_TOKEN_INDEXED_FREE_BALANCE_STATES = "getTokenIndexedFreeBalanceStates",
     GET_PROPOSED_APP_INSTANCE = "getProposedAppInstance",
-    GET_PROPOSED_APP_INSTANCES = "getProposedAppInstances",
-    GET_STATE = "getState",
-    GET_STATE_CHANNEL = "getStateChannel",
-    INSTALL = "install",
-    INSTALL_VIRTUAL = "installVirtual",
-    PROPOSE_INSTALL = "proposeInstall",
-    PROPOSE_INSTALL_VIRTUAL = "proposeInstallVirtual",
-    PROPOSE_STATE = "proposeState",
-    REJECT_INSTALL = "rejectInstall",
-    REJECT_STATE = "rejectState",
-    UPDATE_STATE = "updateState",
-    TAKE_ACTION = "takeAction",
-    UNINSTALL = "uninstall",
-    UNINSTALL_VIRTUAL = "uninstallVirtual",
-    WITHDRAW = "withdraw",
-    WITHDRAW_COMMITMENT = "withdrawCommitment"
+    GET_STATE_CHANNEL = "getStateChannel"
   }
 
   export enum RpcMethodName {


### PR DESCRIPTION
This PR deregisters most "legacy RPC endpoints" (i.e. that use the old routing mechanism)