### PR TITLE
Repro connext issue

### DIFF
--- a/packages/apps/contracts/UnidirectionalLinkedTransferApp.sol
+++ b/packages/apps/contracts/UnidirectionalLinkedTransferApp.sol
@@ -1,0 +1,185 @@
+pragma solidity 0.5.11;
+pragma experimental "ABIEncoderV2";
+
+import "openzeppelin-solidity/contracts/math/SafeMath.sol";
+
+/* solium-disable-next-line */
+import "@counterfactual/cf-adjudicator-contracts/contracts/interfaces/CounterfactualApp.sol";
+/* solium-disable-next-line */
+import "@counterfactual/cf-funding-protocol-contracts/contracts/libs/LibOutcome.sol";
+
+/// @title Unidirectional Linked Transfer App
+/// @notice This contract allows users to claim a payment locked in 
+///         the application if they provide the correct preimage
+
+contract UnidirectionalLinkedTransferApp is CounterfactualApp {
+
+  using SafeMath for uint256;
+
+  /**
+  * Assume the app is funded with the money already owed to receiver,
+  * as in the SimpleTwoPartySwapApp.
+  *
+  * This app can also not be used to send _multiple_ linked payments,
+  * only one can be redeemed with the preimage.
+  *
+  */
+
+  enum AppStage {
+    POST_FUND,
+    PAYMENT_CLAIMED,
+    CHANNEL_CLOSED
+  }
+
+  struct AppState {
+    AppStage stage;
+    LibOutcome.CoinTransfer[2] transfers;
+    bytes32 linkedHash;
+
+    // NOTE: These following parameters are soon
+    //       to be built in as framework-level
+    //       constants but for now must be app-level.
+    uint256 turnNum; // TODO: is this needed here?
+    bool finalized;
+  }
+
+  // theres really only one type of action here,
+  // the only reason to use the end channel action would
+  // be to allow the hub to uninstall the app to reclaim
+  // collateral. Since this can only be done while the recipient
+  // is online, you dont *need* an END_CHANNEL action type, you
+  // can just use an adjudicator.
+
+  // Questions: if the app is set up to have the transfers pre-assigned
+  // in the same way the swap app is atm, will the adjudicator know that
+  // if no correct preimage is included in the commitment, it should 0
+  // transfers?
+  // enum ActionType {
+  //   CLAIM_MONEY
+
+  //   // // NOTE: These following action will soon
+  //   // //       be built in as a framework-level
+  //   // //       constant but for now must be app-level.
+  //   // END_CHANNEL
+  // }
+
+  struct Action {
+    uint256 amount;
+    address assetId;
+    bytes32 paymentId;
+    bytes32 preImage;
+  }
+
+  function computeOutcome(bytes calldata encodedState)
+    external
+    pure
+    returns (bytes memory)
+  {
+    return abi.encode(abi.decode(encodedState, (AppState)).transfers);
+  }
+
+  function applyAction(
+    bytes calldata encodedState,
+    bytes calldata encodedAction
+  )
+    external
+    pure
+    returns (bytes memory)
+  {
+    AppState memory state = abi.decode(
+      encodedState,
+      (AppState)
+    );
+
+    Action memory action = abi.decode(
+      encodedAction,
+      (Action)
+    );
+
+    bytes32 generatedHash = keccak256(abi.encodePacked(
+      action.amount,
+      action.assetId,
+      action.paymentId,
+      action.preImage
+    ));
+    if (generatedHash == state.linkedHash) {
+      /**
+       * If the hash is correct, finalize the state with provided transfers.
+       */
+      return abi.encode(
+        AppState(
+          /* stage of app */
+          AppStage.PAYMENT_CLAIMED,
+          /* transfers */
+          LibOutcome.CoinTransfer[2]([
+            LibOutcome.CoinTransfer(
+              state.transfers[0].to,
+              /* should always be 0 */
+              state.transfers[1].amount
+            ),
+            LibOutcome.CoinTransfer(
+              state.transfers[1].to,
+              /* should always be full value of linked payment */
+              state.transfers[0].amount
+            )
+          ]),
+          /* link hash */
+          state.linkedHash,
+          /* turnNum */
+          state.turnNum + 1,
+          /* finalized */
+          true
+        )
+      );
+    } else {
+      /**
+       * If the hash is not correct, finalize the state with reverted transfers.
+       */
+      return abi.encode(
+        AppState(
+          /* stage of app */
+          AppStage.CHANNEL_CLOSED,
+          /* transfers */
+          LibOutcome.CoinTransfer[2]([
+            LibOutcome.CoinTransfer(
+              state.transfers[0].to,
+              state.transfers[0].amount
+            ),
+            LibOutcome.CoinTransfer(
+              state.transfers[1].to,
+              state.transfers[1].amount
+            )
+          ]),
+          /* link hash */
+          state.linkedHash,
+          /* turnNum */
+          state.turnNum + 1,
+          /* finalized */
+          true
+        )
+      );
+    }
+  }
+
+  function getTurnTaker(
+    bytes calldata encodedState,
+    address[] calldata participants
+  )
+    external
+    pure
+    returns (address)
+  {
+    return participants[
+      abi.decode(encodedState, (AppState)).turnNum % participants.length
+    ];
+  }
+
+  function isStateTerminal(bytes calldata encodedState)
+    external
+    pure
+    returns (bool)
+  {
+    return abi.decode(encodedState, (AppState)).finalized;
+  }
+
+}

--- a/packages/apps/test/linked-transfer-app.spec.ts
+++ b/packages/apps/test/linked-transfer-app.spec.ts
@@ -1,0 +1,293 @@
+import { Address, SolidityValueType } from "@counterfactual/types";
+import chai from "chai";
+import * as waffle from "ethereum-waffle";
+import { Contract } from "ethers";
+import { AddressZero, One, Zero } from "ethers/constants";
+import {
+  BigNumber,
+  defaultAbiCoder,
+  hexlify,
+  randomBytes,
+  solidityKeccak256
+} from "ethers/utils";
+
+import UnidirectionalLinkedTransferApp from "../build/UnidirectionalLinkedTransferApp.json";
+
+chai.use(waffle.solidity);
+
+const { expect } = chai;
+
+type CoinTransfer = {
+  to: string;
+  amount: BigNumber;
+};
+
+enum AppStage {
+  POST_FUND,
+  PAYMENT_CLAIMED,
+  CHANNEL_CLOSED
+}
+
+type UnidirectionalLinkedTransferAppState = {
+  stage: AppStage;
+  transfers: CoinTransfer[];
+  linkedHash: string;
+  turnNum: BigNumber;
+  finalized: boolean;
+};
+
+type UnidirectionalLinkedTransferAppAction = {
+  amount: BigNumber;
+  assetId: Address;
+  paymentId: string;
+  preImage: string;
+};
+
+const singleAssetTwoPartyCoinTransferEncoding = `
+  tuple(address to, uint256 amount)[2]
+`;
+
+const unidirectionalLinkedTransferAppStateEncoding = `
+  tuple(
+    uint8 stage,
+    ${singleAssetTwoPartyCoinTransferEncoding} transfers,
+    bytes32 linkedHash,
+    uint256 turnNum,
+    bool finalized
+  )
+`;
+
+const unidirectionalLinkedTransferAppActionEncoding = `
+  tuple(
+    uint256 amount,
+    address assetId,
+    bytes32 paymentId,
+    bytes32 preImage
+  )
+`;
+
+function mkAddress(prefix: string = "0xa"): string {
+  return prefix.padEnd(42, "0");
+}
+
+function decodeAppState(
+  encodedAppState: string
+): UnidirectionalLinkedTransferAppState {
+  return defaultAbiCoder.decode(
+    [unidirectionalLinkedTransferAppStateEncoding],
+    encodedAppState
+  )[0];
+}
+
+function encodeAppState(state: SolidityValueType): string {
+  return defaultAbiCoder.encode(
+    [unidirectionalLinkedTransferAppStateEncoding],
+    [state]
+  );
+}
+
+function encodeAppAction(state: SolidityValueType): string {
+  return defaultAbiCoder.encode(
+    [unidirectionalLinkedTransferAppActionEncoding],
+    [state]
+  );
+}
+
+function createLinkedHash(
+  action: UnidirectionalLinkedTransferAppAction
+): string {
+  return solidityKeccak256(
+    ["uint256", "address", "bytes32", "bytes32"],
+    [action.amount, action.assetId, action.paymentId, action.preImage]
+  );
+}
+
+function assertRedeemed(
+  state: UnidirectionalLinkedTransferAppState,
+  params: {
+    senderAddr: string;
+    redeemerAddr: string;
+    linkedHash: string;
+    amount: BigNumber;
+    turnNum: BigNumber;
+  },
+  valid: boolean = true
+): void {
+  const { senderAddr, redeemerAddr, linkedHash, amount, turnNum } = params;
+  // assert transfer addresses
+  expect(state.transfers[0].to.toLowerCase()).to.eq(senderAddr.toLowerCase());
+  expect(state.transfers[1].to.toLowerCase()).to.eq(redeemerAddr.toLowerCase());
+  // assert hash
+  expect(state.linkedHash).to.eq(linkedHash);
+  // assert finalized
+  expect(state.finalized).to.be.true;
+  // assert turnNum increase
+  expect(state.turnNum.toString()).to.eq(turnNum.toString());
+
+  // if payment was rejected, the transfers should be 0d out
+  if (!valid) {
+    // assert stage
+    expect(state.stage).to.eq(AppStage.CHANNEL_CLOSED);
+    // assert transfer amounts
+    expect(state.transfers[0].amount.toString()).to.eq(amount.toString()); // sender
+    expect(state.transfers[1].amount.toString()).to.eq("0"); // redeemer
+    return;
+  }
+
+  // otherwise, they should go through
+  expect(state.stage).to.eq(AppStage.PAYMENT_CLAIMED);
+  // assert transfer amounts
+  expect(state.transfers[0].amount.toString()).to.eq("0"); // sender
+  expect(state.transfers[1].amount.toString()).to.eq(amount.toString()); // redeemer
+}
+
+describe("LinkedUnidirectionalTransferApp", () => {
+  let unidirectionalLinkedTransferApp: Contract;
+
+  const applyAction = (
+    state: SolidityValueType,
+    action: SolidityValueType
+  ): any =>
+    unidirectionalLinkedTransferApp.functions.applyAction(
+      encodeAppState(state),
+      encodeAppAction(action)
+    );
+
+  const computeOutcome = (state: SolidityValueType): any =>
+    unidirectionalLinkedTransferApp.functions.computeOutcome(
+      encodeAppState(state)
+    );
+
+  before(async () => {
+    const provider = waffle.createMockProvider();
+    const wallet = await waffle.getWallets(provider)[0];
+    unidirectionalLinkedTransferApp = await waffle.deployContract(
+      wallet,
+      UnidirectionalLinkedTransferApp
+    );
+  });
+
+  it("can redeem a payment with correct hash", async () => {
+    const senderAddr = mkAddress("0xa"); // e.g node
+    const redeemerAddr = mkAddress("0xb");
+
+    const amount = new BigNumber(10);
+
+    const paymentId = hexlify(randomBytes(32));
+    const preImage = hexlify(randomBytes(32));
+
+    const action: UnidirectionalLinkedTransferAppAction = {
+      amount,
+      paymentId,
+      preImage,
+      assetId: AddressZero
+    };
+
+    const linkedHash = createLinkedHash(action);
+
+    /**
+     * This is the initial state supplied to the `ProposeInstall`
+     * function.
+     */
+    const prevState: UnidirectionalLinkedTransferAppState = {
+      linkedHash,
+      finalized: false,
+      stage: AppStage.POST_FUND,
+      transfers: [
+        {
+          amount,
+          to: senderAddr
+        },
+        {
+          amount: Zero,
+          to: redeemerAddr
+        }
+      ],
+      turnNum: Zero
+    };
+
+    const ret = await applyAction(prevState, action);
+
+    const state = decodeAppState(ret);
+
+    assertRedeemed(state, {
+      senderAddr,
+      redeemerAddr,
+      linkedHash,
+      amount,
+      turnNum: One
+    });
+
+    // verify outcome
+    const res = await computeOutcome(state);
+    expect(res).to.eq(
+      defaultAbiCoder.encode(
+        [singleAssetTwoPartyCoinTransferEncoding],
+        [[[senderAddr, Zero], [redeemerAddr, amount]]]
+      )
+    );
+  });
+
+  it("can revert the transfers if the provided secret is not correct", async () => {
+    const senderAddr = mkAddress("0xa"); // e.g node
+    const redeemerAddr = mkAddress("0xb");
+
+    const amount = new BigNumber(10);
+
+    const paymentId = hexlify(randomBytes(32));
+    const preImage = hexlify(randomBytes(32));
+
+    const action: UnidirectionalLinkedTransferAppAction = {
+      amount,
+      paymentId,
+      preImage,
+      assetId: AddressZero
+    };
+
+    const linkedHash = createLinkedHash(action);
+    const suppliedAction: UnidirectionalLinkedTransferAppAction = {
+      ...action,
+      preImage: hexlify(randomBytes(32))
+    };
+
+    /**
+     * This is the initial state supplied to the `ProposeInstall`
+     * function.
+     */
+    const prevState: UnidirectionalLinkedTransferAppState = {
+      linkedHash,
+      finalized: false,
+      stage: AppStage.POST_FUND,
+      transfers: [
+        {
+          amount,
+          to: senderAddr
+        },
+        {
+          amount: Zero,
+          to: redeemerAddr
+        }
+      ],
+      turnNum: Zero
+    };
+
+    const ret = await applyAction(prevState, suppliedAction);
+
+    const state = decodeAppState(ret);
+
+    assertRedeemed(
+      state,
+      { senderAddr, redeemerAddr, linkedHash, amount, turnNum: One },
+      false
+    );
+
+    // verify outcome
+    const res = await computeOutcome(state);
+    expect(res).to.eq(
+      defaultAbiCoder.encode(
+        [singleAssetTwoPartyCoinTransferEncoding],
+        [[[senderAddr, amount], [redeemerAddr, Zero]]]
+      )
+    );
+  });
+});

--- a/packages/local-ganache-server/src/contract-deployments.jest.ts
+++ b/packages/local-ganache-server/src/contract-deployments.jest.ts
@@ -1,4 +1,6 @@
 import TicTacToeApp from "@counterfactual/apps/build/TicTacToeApp.json";
+import UnidirectionalLinkedTransferApp from "@counterfactual/apps/build/UnidirectionalLinkedTransferApp.json";
+import UnidirectionalTransferApp from "@counterfactual/apps/build/UnidirectionalTransferApp.json";
 import ChallengeRegistry from "@counterfactual/cf-adjudicator-contracts/build/ChallengeRegistry.json";
 import CoinBalanceRefundApp from "@counterfactual/cf-funding-protocol-contracts/build/CoinBalanceRefundApp.json";
 import ConditionalTransactionDelegateTarget from "@counterfactual/cf-funding-protocol-contracts/build/ConditionalTransactionDelegateTarget.json";
@@ -17,6 +19,8 @@ import { ContractFactory, Wallet } from "ethers";
 export type NetworkContextForTestSuite = NetworkContext & {
   TicTacToeApp: string;
   DolphinCoin: string;
+  UnidirectionalTransferApp: string;
+  UnidirectionalLinkedTransferApp: string;
 };
 
 export async function deployTestArtifactsToChain(wallet: Wallet) {
@@ -86,6 +90,18 @@ export async function deployTestArtifactsToChain(wallet: Wallet) {
     wallet
   ).deploy();
 
+  const transferContract = await new ContractFactory(
+    UnidirectionalTransferApp.abi,
+    UnidirectionalTransferApp.bytecode,
+    wallet
+  ).deploy();
+
+  const linkContract = await new ContractFactory(
+    UnidirectionalLinkedTransferApp.abi,
+    UnidirectionalLinkedTransferApp.bytecode,
+    wallet
+  ).deploy();
+
   const timeLockedPassThrough = await new ContractFactory(
     TimeLockedPassThrough.abi,
     TimeLockedPassThrough.bytecode,
@@ -115,6 +131,8 @@ export async function deployTestArtifactsToChain(wallet: Wallet) {
     TimeLockedPassThrough: timeLockedPassThrough.address,
     TwoPartyFixedOutcomeInterpreter: twoPartyFixedOutcomeInterpreter.address,
     TwoPartyFixedOutcomeFromVirtualAppInterpreter:
-      twoPartyFixedOutcomeFromVirtualAppETHInterpreter.address
+      twoPartyFixedOutcomeFromVirtualAppETHInterpreter.address,
+    UnidirectionalLinkedTransferApp: linkContract.address,
+    UnidirectionalTransferApp: transferContract.address
   } as NetworkContextForTestSuite;
 }

--- a/packages/node/test/integration/connext-issue.spec.ts
+++ b/packages/node/test/integration/connext-issue.spec.ts
@@ -362,7 +362,7 @@ describe("Can update and install multiple apps simultaneously", () => {
     const {
       linkStatesRedeemer,
       linkStatesSender
-    } = generateInitialLinkedTransferStates(1);
+    } = generateInitialLinkedTransferStates(2);
 
     // install all the linked apps on the sender side
     await installLinks(nodeA, nodeB, linkStatesSender);
@@ -370,11 +370,14 @@ describe("Can update and install multiple apps simultaneously", () => {
     expect((await getApps(nodeA)).length).toBe(linkStatesSender.length);
     // TODO: check for state
 
-    // begin redeeming apps as the receiver on an interval
-    redeemLinkPoller(nodeA, nodeB, nodeC, linkStatesRedeemer, done);
+    await delay(1000);
+    done();
 
-    // while links are redeeming, try to send receiver a
-    // direct transfer
-    await makeTransfer(nodeA, nodeB, nodeC);
+    // // begin redeeming apps as the receiver on an interval
+    // redeemLinkPoller(nodeA, nodeB, nodeC, linkStatesRedeemer, done);
+
+    // // while links are redeeming, try to send receiver a
+    // // direct transfer
+    // await makeTransfer(nodeA, nodeB, nodeC);
   });
 });

--- a/packages/node/test/integration/connext-issue.spec.ts
+++ b/packages/node/test/integration/connext-issue.spec.ts
@@ -1,0 +1,309 @@
+import { NetworkContextForTestSuite } from "@counterfactual/local-ganache-server/src/contract-deployments.jest";
+import { Address, AppInstanceInfo } from "@counterfactual/types";
+import { Zero } from "ethers/constants";
+import { BigNumber, bigNumberify, BigNumberish } from "ethers/utils";
+
+import { Node } from "../../src";
+
+import { initialLinkedState } from "./linked-transfer";
+import { setup, SetupContext } from "./setup";
+import { initialTransferState } from "./unidirectional-transfer";
+import {
+  collateralizeChannel,
+  constructGetAppsRpc,
+  constructTakeActionRpc,
+  constructUninstallRpc,
+  constructUninstallVirtualRpc,
+  createChannel,
+  installApp,
+  installVirtualApp
+} from "./utils";
+
+type UnidirectionalLinkedTransferAppAction = {
+  amount: BigNumber;
+  assetId: Address;
+  paymentId: string;
+  preImage: string;
+};
+
+enum ActionType {
+  SEND_MONEY,
+  END_CHANNEL
+}
+
+type UnidirectionalTransferAppAction = {
+  actionType: ActionType;
+  amount: BigNumberish;
+};
+
+/**
+ * The connext team has seen some strange issues in production that
+ * only appear when multiple bots are running. This test suite will
+ * attempt to recreate them in the simplest context.
+ */
+describe("Can update and install multiple apps simultaneously", () => {
+  let nodeA: Node; // sending client
+  let nodeB: Node; // node
+  let nodeC: Node; // receiving client
+
+  ///////// Define helper fns for nodes
+
+  // creates a number of linked transfer states for redeemers and senders
+  function generateInitialLinkedTransferStates(numberApps: number = 3) {
+    // TODO: app typings
+    const linkStatesSender: { action: any; state: any }[] = [];
+    const linkStatesRedeemer: { action: any; state: any }[] = [];
+    for (let i = 0; i < numberApps; i += 1) {
+      // create new actions and apps for 1 wei of eth
+      // note: linked apps will be redeemed twice, once by the actual
+      // recipient, and once by the node trying to uninstall the app.
+      // the apps will have the same initial state, minus the transfer addresses
+      const { action, state } = initialLinkedState(
+        nodeA.freeBalanceAddress,
+        nodeC.freeBalanceAddress
+      );
+      linkStatesRedeemer.push({ action, state });
+      // update the transfer address for the sender states to be the hubs
+      // node
+      const hubTransfers = [
+        {
+          to: nodeA.freeBalanceAddress,
+          amount: action.amount
+        },
+        {
+          to: nodeB.freeBalanceAddress,
+          amount: 0
+        }
+      ];
+      // sender has initial state installed with hub
+      linkStatesSender.push({
+        action,
+        state: { ...state, transfers: hubTransfers }
+      });
+    }
+    return {
+      linkStatesRedeemer,
+      linkStatesSender
+    };
+  }
+
+  // installs an array of linked transfer apps between a
+  // "funder" node and a "redeemer" node
+  // TODO: fix typings
+  async function installLinks(
+    funder: Node,
+    redeemer: Node,
+    statesAndActions: any[]
+  ) {
+    const linkDef = (global["networkContext"] as NetworkContextForTestSuite)
+      .UnidirectionalLinkedTransferApp;
+    return statesAndActions.map(async ({ state, action }) => {
+      // initiator == sender, iniator deposit == sender.amount
+      return await installApp(
+        funder,
+        redeemer,
+        linkDef,
+        state,
+        action.amount,
+        action.assetId,
+        Zero,
+        action.assetId
+      );
+    });
+  }
+
+  async function takeAppAction(
+    node: Node,
+    appId: string,
+    action:
+      | UnidirectionalLinkedTransferAppAction
+      | UnidirectionalTransferAppAction
+  ) {
+    return (await node.rpcRouter.dispatch(
+      constructTakeActionRpc(appId, action)
+    )).result.result;
+  }
+
+  async function uninstallApp(node: Node, appId: string) {
+    return (await node.rpcRouter.dispatch(constructUninstallRpc(appId))).result
+      .result;
+  }
+
+  async function uninstallVirtualApp(
+    node: Node,
+    intermediaryPubId: string,
+    appId: string
+  ) {
+    const rpc = constructUninstallVirtualRpc(appId, intermediaryPubId);
+    return (await node.rpcRouter.dispatch(rpc)).result.result;
+  }
+
+  async function getApps(node: Node) {
+    return (await node.rpcRouter.dispatch(constructGetAppsRpc())).result.result;
+  }
+
+  // will uninstall an app between the intermediary and the funder
+  // after the redeemer installs an app and reveals a secret between
+  // the redeemer and the intermediary
+  async function redeemLink(
+    funder: Node,
+    intermediary: Node,
+    redeemer: Node,
+    stateAndAction: any
+  ) {
+    const linkDef = (global["networkContext"] as NetworkContextForTestSuite)
+      .UnidirectionalLinkedTransferApp;
+    const apps: AppInstanceInfo[] = await getApps(intermediary);
+    // NOTE: this may return more than one valid app, thats fine, just take
+    // the first.
+    const funderApp = apps.filter(a => {
+      a.appDefinition === linkDef &&
+        a.proposedByIdentifier === funder.publicIdentifier &&
+        a.proposedToIdentifier === intermediary.publicIdentifier;
+    })[0];
+    if (!funderApp) {
+      throw new Error(
+        `Could not find installed app with intermediary with desired properties`
+      );
+    }
+
+    // install app between the redeemer and the intermediary
+    const [redeemerAppId, redeemerParams] = await installLinks(
+      intermediary,
+      redeemer,
+      [stateAndAction]
+    )[0];
+    console.log("redeemer app installed with params:", redeemerParams);
+
+    // take action to finalize state and claim funds from intermediary
+    await takeAppAction(redeemer, redeemerAppId, stateAndAction.action);
+
+    // uninstall the app between the redeemer and the intermediary
+    await uninstallApp(redeemer, redeemerAppId);
+
+    // take action with funder and intermediary to finalize
+    // NOTE: this should already be installed
+    await takeAppAction(
+      intermediary,
+      funderApp.identityHash,
+      stateAndAction.action
+    );
+
+    // uninstall the app between the funder and intermediary to break even
+    await uninstallApp(intermediary, funderApp.identityHash);
+  }
+
+  // calls `redeemLink` every half second on a poller
+  function redeemLinkPoller(
+    funder: Node,
+    intermediary: Node,
+    redeemer: Node,
+    statesAndActions: any[]
+  ) {
+    setTimeout(async () => {
+      if (statesAndActions.length > 0) {
+        await redeemLink(
+          funder,
+          intermediary,
+          redeemer,
+          statesAndActions.pop()
+        );
+      }
+    }, 500);
+  }
+
+  // installs, updates, and uninstalls a virtual eth unidirectional
+  // transfer app
+  async function makeTransfer(
+    sender: Node,
+    intermediary: Node,
+    receiver: Node
+  ) {
+    // install a virtual transfer app
+    const transferDef = (global["networkContext"] as NetworkContextForTestSuite)
+      .UnidirectionalTransferApp;
+
+    // create transfer app with default transfer value of 1
+    const initialState = initialTransferState(
+      sender.freeBalanceAddress,
+      receiver.freeBalanceAddress
+    );
+
+    const appId = await installVirtualApp(
+      sender,
+      intermediary,
+      receiver,
+      transferDef,
+      initialState
+    );
+
+    // take action on the virtual transfer app to send money
+    await takeAppAction(sender, appId, {
+      actionType: ActionType.SEND_MONEY,
+      amount: 1
+    });
+
+    // take action on virtual transfer app to finalize state
+    await takeAppAction(sender, appId, {
+      actionType: ActionType.END_CHANNEL,
+      amount: 0
+    });
+
+    // uninstall the virtual transfer app
+    await uninstallVirtualApp(sender, intermediary.publicIdentifier, appId);
+  }
+
+  beforeAll(async () => {
+    const context: SetupContext = await setup(global, true, true);
+    nodeA = context["A"].node;
+    nodeB = context["B"].node;
+    nodeC = context["C"].node;
+  });
+
+  /**
+   * In production, this flow has resulted in several varying bugs including:
+   * - IO send and wait timed out
+   * - Validating a signature with expected signer 0xFFF but recovered 0xAAA
+   * - cannot find agreement with target hash 0xCCC
+   * - hanging on client or node
+   *
+   * These errors were successfully reproduced by connext in the `test-bot-farm`
+   * script, both with the postgres store and the memory store.
+   */
+  it("should be able to redeem a pregenerated linked payment while simultaneously receiving a direct transer", async () => {
+    const multisigAddressAB = await createChannel(nodeA, nodeB);
+    const multisigAddressBC = await createChannel(nodeB, nodeC);
+
+    // this deposits into both nodes. realistically, we want
+    // to have nodeA deposit into AB, and nodeB collateralize
+    // BC
+    await collateralizeChannel(
+      multisigAddressAB,
+      nodeA,
+      undefined, // choose not to fund nodeB
+      bigNumberify(15)
+    );
+    await collateralizeChannel(
+      multisigAddressBC,
+      nodeB,
+      undefined, // choose not to fund nodeC
+      bigNumberify(15)
+    );
+
+    // first, pregenerate several linked app initial states
+    const {
+      linkStatesRedeemer,
+      linkStatesSender
+    } = generateInitialLinkedTransferStates();
+
+    // install all the linked apps on the sender side
+    await installLinks(nodeA, nodeB, linkStatesSender);
+
+    // begin redeeming apps as the receiver on an interval
+    redeemLinkPoller(nodeA, nodeB, nodeC, linkStatesRedeemer);
+
+    // while links are redeeming, try to send receiver a
+    // direct transfer
+    await makeTransfer(nodeA, nodeB, nodeC);
+  });
+});

--- a/packages/node/test/integration/install-virtual.spec.ts
+++ b/packages/node/test/integration/install-virtual.spec.ts
@@ -35,8 +35,8 @@ describe("Node method follows spec - proposeInstallVirtual", () => {
         const multisigAddressAB = await createChannel(nodeA, nodeB);
         const multisigAddressBC = await createChannel(nodeB, nodeC);
 
-        await collateralizeChannel(nodeA, nodeB, multisigAddressAB);
-        await collateralizeChannel(nodeB, nodeC, multisigAddressBC);
+        await collateralizeChannel(multisigAddressAB, nodeA, nodeB);
+        await collateralizeChannel(multisigAddressBC, nodeB, nodeC);
 
         let proposalParams: NodeTypes.ProposeInstallVirtualParams;
         nodeA.once(NODE_EVENTS.INSTALL_VIRTUAL, async () => {

--- a/packages/node/test/integration/install.spec.ts
+++ b/packages/node/test/integration/install.spec.ts
@@ -41,7 +41,7 @@ describe("Node method follows spec - install", () => {
       });
 
       it("install app with ETH", async done => {
-        await collateralizeChannel(nodeA, nodeB, multisigAddress);
+        await collateralizeChannel(multisigAddress, nodeA, nodeB);
 
         let preInstallETHBalanceNodeA: BigNumber;
         let postInstallETHBalanceNodeA: BigNumber;
@@ -105,9 +105,9 @@ describe("Node method follows spec - install", () => {
         ] as NetworkContextForTestSuite).DolphinCoin;
 
         await collateralizeChannel(
+          multisigAddress,
           nodeA,
           nodeB,
-          multisigAddress,
           One,
           erc20TokenAddress
         );

--- a/packages/node/test/integration/linked-transfer.ts
+++ b/packages/node/test/integration/linked-transfer.ts
@@ -1,0 +1,82 @@
+import { AppABIEncodings } from "@counterfactual/types";
+import {
+  BigNumberish,
+  hexlify,
+  randomBytes,
+  solidityKeccak256
+} from "ethers/utils";
+
+import { CONVENTION_FOR_ETH_TOKEN_ADDRESS } from "../../src/constants";
+
+const singleAssetTwoPartyCoinTransferEncoding = `
+tuple(address to, uint256 amount)[2]
+`;
+
+export const linkedAbiEncodings: AppABIEncodings = {
+  stateEncoding: `
+    tuple(
+      uint8 stage,
+      ${singleAssetTwoPartyCoinTransferEncoding} transfers,
+      bytes32 linkedHash,
+      uint256 turnNum,
+      bool finalized
+    )`,
+  actionEncoding: `
+    tuple(
+      uint256 amount,
+      address assetId,
+      bytes32 paymentId,
+      bytes32 preImage
+    )`
+};
+
+export function validAction(
+  amount: BigNumberish = 1,
+  assetId: string = CONVENTION_FOR_ETH_TOKEN_ADDRESS
+) {
+  return {
+    amount,
+    assetId,
+    paymentId: hexlify(randomBytes(32)),
+    preImage: hexlify(randomBytes(32))
+  };
+}
+
+function createLinkedHash(
+  action: any // SolidityValueType <-- y no work
+  // SHOULD BE TYPE OF ABOVE, NOT SURE WHERE TO GET / PUT APP TYPES
+): string {
+  return solidityKeccak256(
+    ["uint256", "address", "bytes32", "bytes32"],
+    [action.amount, action.assetId, action.paymentId, action.preImage]
+  );
+}
+
+export function initialLinkedState(
+  senderAddr: string,
+  redeemerAddr: string,
+  amount: BigNumberish = 1,
+  assetId: string = CONVENTION_FOR_ETH_TOKEN_ADDRESS
+) {
+  const action = validAction(amount, assetId);
+  const linkedHash = createLinkedHash(action);
+  return {
+    action,
+    state: {
+      linkedHash,
+      stage: 0, // POST_FUND
+      finalized: false,
+      turnNum: 0,
+      transfers: [
+        {
+          amount,
+          to: senderAddr
+        },
+        {
+          amount: 0,
+          to: redeemerAddr
+        }
+      ]
+    }
+  };
+}

--- a/packages/node/test/integration/reject-install.spec.ts
+++ b/packages/node/test/integration/reject-install.spec.ts
@@ -32,7 +32,7 @@ describe("Node method follows spec - rejectInstall", () => {
     () => {
       it("sends proposal with non-null initial state", async done => {
         const multisigAddress = await createChannel(nodeA, nodeB);
-        await collateralizeChannel(nodeA, nodeB, multisigAddress);
+        await collateralizeChannel(multisigAddress, nodeA, nodeB);
 
         expect(await getInstalledAppInstances(nodeA)).toEqual([]);
         expect(await getInstalledAppInstances(nodeB)).toEqual([]);

--- a/packages/node/test/integration/take-action-virtual.spec.ts
+++ b/packages/node/test/integration/take-action-virtual.spec.ts
@@ -47,8 +47,8 @@ describe("Node method follows spec - takeAction virtual", () => {
         const multisigAddressAB = await createChannel(nodeA, nodeB);
         const multisigAddressBC = await createChannel(nodeB, nodeC);
 
-        await collateralizeChannel(nodeA, nodeB, multisigAddressAB);
-        await collateralizeChannel(nodeB, nodeC, multisigAddressBC);
+        await collateralizeChannel(multisigAddressAB, nodeA, nodeB);
+        await collateralizeChannel(multisigAddressBC, nodeB, nodeC);
 
         const appInstanceId = await installVirtualApp(
           nodeA,

--- a/packages/node/test/integration/unidirectional-transfer.ts
+++ b/packages/node/test/integration/unidirectional-transfer.ts
@@ -1,0 +1,50 @@
+import { AppABIEncodings } from "@counterfactual/types";
+import { BigNumberish } from "ethers/utils";
+
+const singleAssetTwoPartyCoinTransferEncoding = `
+tuple(address to, uint256 amount)[2]
+`;
+
+export const transferAbiEncodings: AppABIEncodings = {
+  stateEncoding: `
+    tuple(
+      uint8 stage,
+      ${singleAssetTwoPartyCoinTransferEncoding} transfers,
+      uint256 turnNum,
+      bool finalized
+    )`,
+  actionEncoding: `
+    tuple(
+      uint8 actionType,
+      uint256 amount
+    )`
+};
+
+export function validAction(actionType: number = 0, amount: BigNumberish = 1) {
+  return {
+    actionType, // SEND_MONEY = 0, END_CHANNEL = 1
+    amount
+  };
+}
+
+export function initialTransferState(
+  senderAddr: string,
+  receiverAddr: string,
+  amount: BigNumberish = 1
+) {
+  return {
+    stage: 0, // POST_FUND
+    transfers: [
+      {
+        amount,
+        to: senderAddr
+      },
+      {
+        to: receiverAddr,
+        amount: 0
+      }
+    ],
+    turnNum: 0,
+    finalized: false
+  };
+}

--- a/packages/node/test/integration/uninstall-virtual.spec.ts
+++ b/packages/node/test/integration/uninstall-virtual.spec.ts
@@ -40,8 +40,8 @@ describe("Node method follows spec - uninstall virtual", () => {
         const multisigAddressAB = await createChannel(nodeA, nodeB);
         const multisigAddressBC = await createChannel(nodeB, nodeC);
 
-        await collateralizeChannel(nodeA, nodeB, multisigAddressAB);
-        await collateralizeChannel(nodeB, nodeC, multisigAddressBC);
+        await collateralizeChannel(multisigAddressAB, nodeA, nodeB);
+        await collateralizeChannel(multisigAddressBC, nodeB, nodeC);
 
         const appInstanceId = await installVirtualApp(
           nodeA,

--- a/packages/node/test/integration/uninstall.spec.ts
+++ b/packages/node/test/integration/uninstall.spec.ts
@@ -45,7 +45,7 @@ describe("Node A and B install apps of different outcome types, then uninstall t
       expect(balancesBefore[nodeA.freeBalanceAddress]).toBeEq(Zero);
       expect(balancesBefore[nodeB.freeBalanceAddress]).toBeEq(Zero);
 
-      await collateralizeChannel(nodeA, nodeB, multisigAddress, depositAmount);
+      await collateralizeChannel(multisigAddress, nodeA, nodeB, depositAmount);
 
       const balancesAfter = await getFreeBalanceState(nodeA, multisigAddress);
       expect(balancesAfter[nodeA.freeBalanceAddress]).toBeEq(depositAmount);

--- a/packages/node/test/integration/utils.ts
+++ b/packages/node/test/integration/utils.ts
@@ -442,16 +442,19 @@ export function constructUninstallVirtualRpc(
 }
 
 export async function collateralizeChannel(
-  node1: Node,
-  node2: Node,
   multisigAddress: string,
+  node1: Node,
+  node2?: Node,
   amount: BigNumber = One,
   tokenAddress: string = CONVENTION_FOR_ETH_TOKEN_ADDRESS
 ): Promise<void> {
   const depositReq = constructDepositRpc(multisigAddress, amount, tokenAddress);
   node1.on(NODE_EVENTS.DEPOSIT_CONFIRMED, () => {});
-  node2.on(NODE_EVENTS.DEPOSIT_CONFIRMED, () => {});
   await node1.rpcRouter.dispatch(depositReq);
+  if (!node2) {
+    return;
+  }
+  node2.on(NODE_EVENTS.DEPOSIT_CONFIRMED, () => {});
   await node2.rpcRouter.dispatch(depositReq);
 }
 
@@ -632,7 +635,7 @@ export async function makeVirtualProposal(
   return { appInstanceId, params };
 }
 
-export function installTTTVirtual(
+export async function installTTTVirtual(
   node: Node,
   appInstanceId: string,
   intermediaryIdentifier: string
@@ -641,7 +644,7 @@ export function installTTTVirtual(
     appInstanceId,
     intermediaryIdentifier
   );
-  node.rpcRouter.dispatch(installVirtualReq);
+  await node.rpcRouter.dispatch(installVirtualReq);
 }
 
 export function makeInstallCall(node: Node, appInstanceId: string) {

--- a/packages/node/test/integration/utils.ts
+++ b/packages/node/test/integration/utils.ts
@@ -794,16 +794,15 @@ export function getAppContext(
 
   switch (appDefinition) {
     case (global["networkContext"] as NetworkContextForTestSuite).TicTacToeApp:
-      initialAppState = initialState ? initialState : initialEmptyTTTState();
+      initialAppState = initialState || initialEmptyTTTState();
       abiEncodings = tttAbiEncodings;
       break;
 
     case (global["networkContext"] as NetworkContextForTestSuite)
       .UnidirectionalTransferApp:
       checkForAddresses();
-      initialAppState = initialState
-        ? initialState
-        : initialTransferState(senderAddress!, receiverAddress!);
+      initialAppState =
+        initialState || initialTransferState(senderAddress!, receiverAddress!);
       abiEncodings = transferAbiEncodings;
       break;
 
@@ -813,7 +812,7 @@ export function getAppContext(
       // TODO: need a better way to return the action info that generated
       // the linked hash as well
       const { state } = initialLinkedState(senderAddress!, receiverAddress!);
-      initialAppState = initialState ? initialState : state;
+      initialAppState = initialState || state;
       abiEncodings = linkedAbiEncodings;
       break;
 

--- a/packages/node/test/integration/utils.ts
+++ b/packages/node/test/integration/utils.ts
@@ -27,7 +27,12 @@ import {
 } from "../../src";
 import { CONVENTION_FOR_ETH_TOKEN_ADDRESS } from "../../src/constants";
 
+import { initialLinkedState, linkedAbiEncodings } from "./linked-transfer";
 import { initialEmptyTTTState, tttAbiEncodings } from "./tic-tac-toe";
+import {
+  initialTransferState,
+  transferAbiEncodings
+} from "./unidirectional-transfer";
 
 interface AppContext {
   appDefinition: string;
@@ -748,15 +753,45 @@ export async function transferERC20Tokens(
 
 export function getAppContext(
   appDefinition: string,
-  initialState?: SolidityValueType
+  initialState?: SolidityValueType,
+  senderAddress?: string, // needed for both types of transfer apps
+  receiverAddress?: string // needed for both types of transfer apps
 ): AppContext {
   let abiEncodings: AppABIEncodings;
   let initialAppState: SolidityValueType;
+
+  const checkForAddresses = () => {
+    const missingAddr = !senderAddress || !receiverAddress;
+    if (missingAddr && !initialState) {
+      throw new Error(
+        "Must have sender and redeemer addresses to generate initial state for either transfer app context"
+      );
+    }
+  };
 
   switch (appDefinition) {
     case (global["networkContext"] as NetworkContextForTestSuite).TicTacToeApp:
       initialAppState = initialState ? initialState : initialEmptyTTTState();
       abiEncodings = tttAbiEncodings;
+      break;
+
+    case (global["networkContext"] as NetworkContextForTestSuite)
+      .UnidirectionalTransferApp:
+      checkForAddresses();
+      initialAppState = initialState
+        ? initialState
+        : initialTransferState(senderAddress!, receiverAddress!);
+      abiEncodings = transferAbiEncodings;
+      break;
+
+    case (global["networkContext"] as NetworkContextForTestSuite)
+      .UnidirectionalLinkedTransferApp:
+      checkForAddresses();
+      // TODO: need a better way to return the action info that generated
+      // the linked hash as well
+      const { state } = initialLinkedState(senderAddress!, receiverAddress!);
+      initialAppState = initialState ? initialState : state;
+      abiEncodings = linkedAbiEncodings;
       break;
 
     default:

--- a/packages/node/test/integration/utils.ts
+++ b/packages/node/test/integration/utils.ts
@@ -523,7 +523,7 @@ export async function installApp(
     nodeB.on(NODE_EVENTS.PROPOSE_INSTALL, async (msg: ProposeMessage) => {
       confirmProposedAppInstance(
         installationProposalRpc.parameters,
-        await getAppInstanceProposal(nodeA, appInstanceId)
+        await getAppInstanceProposal(nodeA, msg.data.appInstanceId)
       );
 
       const installRpc = constructInstallRpc(msg.data.appInstanceId);

--- a/packages/node/test/integration/utils.ts
+++ b/packages/node/test/integration/utils.ts
@@ -420,6 +420,15 @@ export function constructTakeActionRpc(
   });
 }
 
+export function constructGetAppsRpc(): Rpc {
+  return jsonRpcDeserialize({
+    params: {},
+    id: Date.now(),
+    method: NodeTypes.RpcMethodName.GET_APP_INSTANCES,
+    jsonrpc: "2.0"
+  });
+}
+
 export function constructUninstallRpc(appInstanceId: string): Rpc {
   return jsonRpcDeserialize({
     params: {

--- a/packages/node/test/integration/utils.ts
+++ b/packages/node/test/integration/utils.ts
@@ -96,7 +96,8 @@ export async function getAppInstance(
     }
   });
   const response = await node.rpcRouter.dispatch(req);
-  return (response.result.result as NodeTypes.GetAppInstanceDetailsResult).appInstance;
+  return (response.result.result as NodeTypes.GetAppInstanceDetailsResult)
+    .appInstance;
 }
 
 export async function getAppInstanceProposal(

--- a/packages/node/tsconfig.json
+++ b/packages/node/tsconfig.json
@@ -3,6 +3,8 @@
   "compilerOptions": {
     "declaration": true,
     "declarationDir": "dist/",
+    "noUnusedParameters": false,
+    "noUnusedLocals": false,
     "outDir": "dist/",
     "resolveJsonModule": true,
     "typeRoots": [

--- a/yarn.lock
+++ b/yarn.lock
@@ -832,6 +832,24 @@
     exec-sh "^0.3.2"
     minimist "^1.2.0"
 
+"@counterfactual/node@0.2.63":
+  version "0.2.63"
+  resolved "https://registry.yarnpkg.com/@counterfactual/node/-/node-0.2.63.tgz#26c4fe6a2845cc50bd6f0fe879ece8b4a2c3805a"
+  integrity sha512-E9eRsI+oQmxxPYC7oHYgVvLcX3vfkTqVngW0tC65nxpab0BDRGc9Xhu7N5lPwkDDa+Z/Ob1GaFzrOp25yWV7UA==
+  dependencies:
+    "@counterfactual/cf-adjudicator-contracts" "0.0.3"
+    "@counterfactual/cf-funding-protocol-contracts" "0.0.6"
+    "@counterfactual/cf.js" "0.2.5"
+    "@counterfactual/firebase-client" "0.0.5"
+    "@counterfactual/types" "0.0.37"
+    ethers "4.0.33"
+    eventemitter3 "^4.0.0"
+    loglevel "^1.6.1"
+    p-queue "^5.0.0"
+    rpc-server "0.0.1"
+    typescript-memoize "^1.0.0-alpha.3"
+    uuid "^3.3.2"
+
 "@counterfactual/types@0.0.36":
   version "0.0.36"
   resolved "https://registry.npmjs.org/@counterfactual/types/-/types-0.0.36.tgz#48523fdc44eae0d52d947661b7aca50f62eaa68e"
@@ -21282,7 +21300,6 @@ websocket@1.0.29, websocket@^1.0.28:
   dependencies:
     debug "^2.2.0"
     es5-ext "^0.10.50"
-    gulp "^4.0.2"
     nan "^2.14.0"
     typedarray-to-buffer "^3.1.5"
     yaeti "^0.0.6"


### PR DESCRIPTION
### Description

We have been seeing some really weird errors with the specific user flow of simultaneously receiving a direct payment while redeeming a linked payment.

The (hopefully singular) issue presents in several different ways, including:

```
Error: IO_SEND_AND_WAIT timed out after 30s waiting for counterparty reply in uninstall-virtual-app
    at instructionExecutor.register (/root/node_modules/@counterfactual/node/src/node.ts:204:17)
Error: IO_SEND_AND_WAIT timed out after 30s waiting for counterparty reply in uninstall-virtual-app
    at instructionExecutor.register (/root/node_modules/@counterfactual/node/src/node.ts:204:17)
bb3de37165b6
```

```
Error: cannot find agreement with target hash 0x52cba803517ae8a376ffe4d5b9d8a30a09b8a71b5ba7ba93384606b6bd8042a7
    at StateChannel.removeSingleAssetTwoPartyIntermediaryAgreement (/root/node_modules/@counterfactual/node/src/models/state-channel.ts:400:13)
    at getUpdatedStateChannelAndAppInstanceObjectsForIntermediary (/root/node_modules/@counterfactual/node/src/protocol/uninstall-virtual-app.ts:822:32)
    at process._tickCallback (internal/process/next_tick.js:68:7)
```

```
Error: Validating a signature with expected signer 0xF80fd6F5eF91230805508bB28d75248024E50F6F but recovered 0x3e8BcE154fAf2b1C20A03CE5d34B024B27d1f55C for commitment hash 0xa489df492bd9eca16e1b5079841f6937ec744a0c3851a9112612cad1083eea09
```

in addition to simply hanging. This PR hopes to recreate the flow within the monorepo integration tests context for simpler and faster debugging.

### Related issues

- [ ] Deploy preview is functional
