### PR TITLE
[greenboard] small fixes

### DIFF
--- a/e2e-run.sh
+++ b/e2e-run.sh
@@ -42,7 +42,7 @@ cd packages/greenboard
 yarn start
 
 echo "(4/4) Shutting down..."
-killall -9 -q node
-killall -9 -q chromedriver
+killall -9 node
+killall -9 chromedriver
 
 echo "Finished!"

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "lint:fix": "lerna run lint:fix --parallel --no-bail",
     "run:server": "lerna run start --parallel --scope=**/simple-hub-server",
     "run:wallet": "lerna run start --parallel --scope=**/simple-hub-server --scope=**/wallet-ui",
-    "run:wallet:e2e": "lerna run start:e2e --parallel --scope=**/simple-hub-server --scope=**/wallet-ui > /dev/null",
+    "run:wallet:e2e": "lerna run start:e2e --parallel --scope=**/simple-hub-server --scope=**/wallet-ui > /tmp/hub.log",
     "publish": "lerna publish --yes from-package patch",
     "postinstall": "patch-package"
   },

--- a/packages/simple-hub-server/src/node.ts
+++ b/packages/simple-hub-server/src/node.ts
@@ -262,7 +262,7 @@ export class NodeWrapper {
     const { result } = await node.rpcRouter.dispatch(
       jsonRpcDeserialize({
         id: Date.now(),
-        method: "chan_create",
+        method: NodeTypes.RpcMethodName.CREATE_CHANNEL,
         params: {
           owners: [node.publicIdentifier, nodeAddress]
         },


### PR DESCRIPTION
- remove the `-q` flag which doesn't work on macos
- stream simple-hub-server logs to a temporary file
- use enumerated type