### PR TITLE
[contracts] Redeploy ProxyFactory contract

### DIFF
--- a/packages/cf-funding-protocol-contracts/manual-deploy.js
+++ b/packages/cf-funding-protocol-contracts/manual-deploy.js
@@ -3,15 +3,15 @@ const ProxyFactory = require("./build/ProxyFactory.json");
 const ethers = require("ethers");
 
 const Contract = ethers.Contract;
-const ContractFactory= ethers.ContractFactory
+const ContractFactory = ethers.ContractFactory
 const Wallet = ethers.Wallet;
 const InfuraProvider = ethers.providers.InfuraProvider;
 const getContractAddress = ethers.utils.getContractAddress;
 
-const provider = new InfuraProvider("rinkeby", process.env.INFURA_API_KEY);
+const provider = new InfuraProvider("kovan", process.env.INFURA_API_KEY);
 const wallet = Wallet.fromMnemonic(process.env.ETH_ACCOUNT_MNENOMIC).connect(provider);
 
-new ContractFactory(ProxyFactory.abi, ProxyFactory.bytecode, wallet)
+new ContractFactory(ProxyFactory.abi, ProxyFactory.evm.bytecode.object, wallet)
   .deploy({ gasLimit: 1500000 })
   .then(tx => {
     tx.deployed()

--- a/packages/cf-funding-protocol-contracts/networks/42.json
+++ b/packages/cf-funding-protocol-contracts/networks/42.json
@@ -61,7 +61,7 @@
   },
   {
     "contractName": "ProxyFactory",
-    "address": "0x6CF0c4Ab3F1e66913c0983DC0bb1202d958ABb8f",
-    "transactionHash": "0x3576fccaf822923864814c7ddc8a66effb32938a1bc7cbccf2aebbba7c1d4d1a"
+    "address": "0xC1F2105089ADE6A10001565F3C254c8B0c98c6b4",
+    "transactionHash": "0x899568e7ff8bc0f13163ed48d74025134b515838daa8b9f22755cca52daeae99"
   }
 ]

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@counterfactual/node",
-  "version": "0.2.65",
+  "version": "0.2.66",
   "main": "dist/index.js",
   "iife": "dist/index.iife.js",
   "types": "dist/src/index.d.ts",

--- a/packages/simple-hub-server/package.json
+++ b/packages/simple-hub-server/package.json
@@ -39,7 +39,7 @@
   },
   "dependencies": {
     "@counterfactual/firebase-client": "0.0.6",
-    "@counterfactual/node": "0.2.65",
+    "@counterfactual/node": "0.2.66",
     "@counterfactual/types": "0.0.38",
     "@counterfactual/typescript-typings": "0.1.2",
     "@ebryn/jsonapi-ts": "0.1.17",


### PR DESCRIPTION
Redeploys the `ProxyFactory` contract to ensure the deployed contract is using the same bytecode  for the `Proxy` as is being used to calculate the create2 address for a multisig deployment.

Resolves issue https://github.com/counterfactual/monorepo/issues/2275