### PR TITLE
Bump node version and deploy contracts

### DIFF
--- a/packages/cf-funding-protocol-contracts/manual-deploy.js
+++ b/packages/cf-funding-protocol-contracts/manual-deploy.js
@@ -2,13 +2,13 @@ const ProxyFactory = require("./build/ProxyFactory.json");
 
 const ethers = require("ethers");
 
-const Contract = ethers.Contract;
+require("dotenv-safe").config();
+
 const ContractFactory = ethers.ContractFactory
 const Wallet = ethers.Wallet;
 const InfuraProvider = ethers.providers.InfuraProvider;
-const getContractAddress = ethers.utils.getContractAddress;
 
-const provider = new InfuraProvider("kovan", process.env.INFURA_API_KEY);
+const provider = new InfuraProvider("mainnet", process.env.INFURA_API_KEY);
 const wallet = Wallet.fromMnemonic(process.env.ETH_ACCOUNT_MNENOMIC).connect(provider);
 
 new ContractFactory(ProxyFactory.abi, ProxyFactory.evm.bytecode.object, wallet)

--- a/packages/cf-funding-protocol-contracts/networks/1.json
+++ b/packages/cf-funding-protocol-contracts/networks/1.json
@@ -61,7 +61,7 @@
   },
   {
     "contractName": "ProxyFactory",
-    "address": "0xc756Bf6A685573C6879D4363401940f02B4E27a1",
-    "transactionHash": "0x0342da8e73491bff8590b8e1799a51077531aeaed5c853f9d73519f0f51ab95c"
+    "address": "0x6CF0c4Ab3F1e66913c0983DC0bb1202d958ABb8f",
+    "transactionHash": "0xbddceef8254bb9bff48130df63a1993961c654ba2b868ebfb2e4c0699c663884"
   }
 ]

--- a/packages/cf-funding-protocol-contracts/networks/4.json
+++ b/packages/cf-funding-protocol-contracts/networks/4.json
@@ -21,8 +21,8 @@
   },
   {
     "contractName": "ProxyFactory",
-    "address": "0x6CF0c4Ab3F1e66913c0983DC0bb1202d958ABb8f",
-    "transactionHash": "0xc096060ab0a2310ac08af74a0b289c4f8bef63cf99d0a380216aae3a10d3164c"
+    "address": "0xc8d7Cf5638dfa5b79A070c5aC983716575bEF4B0",
+    "transactionHash": "0xaf565cca14e8b5b66d5ec3552ec8ed5135b9e27518d6a8838e48ada7a643f003"
   },
   {
     "contractName": "SingleAssetTwoPartyCoinTransferFromVirtualAppInterpreter",

--- a/packages/cf-funding-protocol-contracts/package.json
+++ b/packages/cf-funding-protocol-contracts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@counterfactual/cf-funding-protocol-contracts",
-  "version": "0.0.7",
+  "version": "0.0.8",
   "description": "Smart contracts for the Counterfactual multisig funding protocol",
   "license": "MIT",
   "engines": {

--- a/packages/local-ganache-server/package.json
+++ b/packages/local-ganache-server/package.json
@@ -21,7 +21,7 @@
   "dependencies": {
     "@counterfactual/apps": "0.1.9",
     "@counterfactual/cf-adjudicator-contracts": "0.0.4",
-    "@counterfactual/cf-funding-protocol-contracts": "0.0.7",
+    "@counterfactual/cf-funding-protocol-contracts": "0.0.8",
     "@counterfactual/types": "0.0.38",
     "ethers": "4.0.36",
     "ganache-core": "2.7.0"

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@counterfactual/node",
-  "version": "0.2.67",
+  "version": "0.2.68",
   "main": "dist/index.js",
   "iife": "dist/index.iife.js",
   "types": "dist/src/index.d.ts",
@@ -55,7 +55,7 @@
   },
   "dependencies": {
     "@counterfactual/cf-adjudicator-contracts": "0.0.4",
-    "@counterfactual/cf-funding-protocol-contracts": "0.0.7",
+    "@counterfactual/cf-funding-protocol-contracts": "0.0.8",
     "@counterfactual/cf.js": "0.2.6",
     "@counterfactual/firebase-client": "0.0.6",
     "@counterfactual/types": "0.0.38",

--- a/packages/simple-hub-server/package.json
+++ b/packages/simple-hub-server/package.json
@@ -39,7 +39,7 @@
   },
   "dependencies": {
     "@counterfactual/firebase-client": "0.0.6",
-    "@counterfactual/node": "0.2.67",
+    "@counterfactual/node": "0.2.68",
     "@counterfactual/types": "0.0.38",
     "@counterfactual/typescript-typings": "0.1.2",
     "@ebryn/jsonapi-ts": "0.1.17",


### PR DESCRIPTION
Deploys new contracts for `ProxyFactory` on Rinkeby and Mainnet.

Bumps `@cf/contracts`.

Bumps `@cf/node`.