### PR TITLE
[node] Fix incorrectly implemented queuing logic

### DIFF
--- a/packages/node/src/methods/queued-execution.ts
+++ b/packages/node/src/methods/queued-execution.ts
@@ -12,17 +12,18 @@ export async function executeFunctionWithinQueues(
   queueList: Queue[],
   f: () => Promise<any>
 ) {
-  let promise;
+  let executionPromise;
 
   function executeCached() {
-    if (!promise) promise = f();
-    return promise;
+    if (!executionPromise) executionPromise = f();
+    return executionPromise;
   }
 
   if (queueList.length > 0) {
-    for (const queue of queueList) queue.add(executeCached);
-    for (const queue of queueList) await queue;
-    return promise;
+    const promiseList: Promise<any>[] = [];
+    for (const queue of queueList) promiseList.push(queue.add(executeCached));
+    for (const promise of promiseList) await promise;
+    return executionPromise;
   }
 
   return executeCached();

--- a/packages/node/test/integration/install-concurrent-virtual.spec.ts
+++ b/packages/node/test/integration/install-concurrent-virtual.spec.ts
@@ -47,7 +47,25 @@ describe("Concurrently installing virtual applications with same intermediary", 
     );
   });
 
-  it("can handle two TicTacToeApp proposals", async done => {
+  it("can handle two TicTacToeApp proposals syncronously made", done => {
+    let i = 0;
+
+    nodeA.on(NODE_EVENTS.INSTALL_VIRTUAL, () => {
+      i += 1;
+      if (i === 2) done();
+    });
+
+    for (const i of Array(2)) {
+      installVirtualApp(
+        nodeA,
+        nodeB,
+        nodeC,
+        (global["networkContext"] as NetworkContextForTestSuite).TicTacToeApp
+      );
+    }
+  });
+
+  it("can handle two TicTacToeApp proposals asyncronously made", async done => {
     let i = 0;
 
     nodeA.on(NODE_EVENTS.INSTALL_VIRTUAL, () => {


### PR DESCRIPTION
In `queued-execution.ts` there were two for loops. The first was intended to add the closure to the list of queued up closures to be executed. The second was to await on each one. Awaiting on each one is safe because there is a cache on the actual closure that ensures the actual method implementation only runs once.

The flaw was that in the second for loop, it was not awaiting on the list that included the updated closures but rather the initial list which did not include it.

This issue manifested itself when you ran two back-to-back (within the same second) requests to the `node` whereby two calls to `getShardedQueue` happened before the for loop that included `queue.add` finished executing per queue.