### PR TITLE
Bump node version

### DIFF
--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@counterfactual/node",
-  "version": "0.2.71",
+  "version": "0.2.72",
   "main": "dist/index.js",
   "iife": "dist/index.iife.js",
   "types": "dist/src/index.d.ts",

--- a/packages/simple-hub-server/package.json
+++ b/packages/simple-hub-server/package.json
@@ -39,7 +39,7 @@
   },
   "dependencies": {
     "@counterfactual/firebase-client": "0.0.6",
-    "@counterfactual/node": "0.2.71",
+    "@counterfactual/node": "0.2.72",
     "@counterfactual/types": "0.0.38",
     "@counterfactual/typescript-typings": "0.1.2",
     "@ebryn/jsonapi-ts": "0.1.17",


### PR DESCRIPTION
0.2.72 includes:

Fix incorrectly implemented queuing logic (#2336)
Correctly queue proposals received (#2335)
Remove unnecessary helper function (#2333)
Only touch DB for responding on virtual proposals (#2332)
Simplify test utility function (#2331)