### PR TITLE
Rename verify-solc job in CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,7 +29,7 @@ restore_dep: &restore_dep
     key: dependency-cache-{{ checksum "yarn.lock" }}
 
 jobs:
-  verify-solc:
+  ensure-build-artifacts-match-solidity-code:
     <<: *defaults
     steps:
       - <<: *restore_code
@@ -43,9 +43,9 @@ jobs:
 
       - run: yarn run patch-package
 
-      - run: "cd packages/cf-funding-protocol-contracts && yarn run verify-solc"
-      - run: "cd packages/cf-adjudicator-contracts && yarn run verify-solc"
-      - run: "cd packages/apps && yarn run verify-solc"
+      - run: "cd packages/cf-funding-protocol-contracts && yarn run ensure-build-artifacts-match-solidity-code"
+      - run: "cd packages/cf-adjudicator-contracts && yarn run ensure-build-artifacts-match-solidity-code"
+      - run: "cd packages/apps && yarn run ensure-build-artifacts-match-solidity-code"
 
   build:
     <<: *defaults
@@ -158,7 +158,7 @@ workflows:
     jobs:
       - build
 
-      - verify-solc:
+      - ensure-build-artifacts-match-solidity-code:
           requires:
             - build
 

--- a/packages/apps/package.json
+++ b/packages/apps/package.json
@@ -15,7 +15,7 @@
   ],
   "scripts": {
     "build": "waffle waffle.js && cp build/*.json expected-build-artifacts",
-    "verify-solc": "waffle waffle.js && diff build expected-build-artifacts",
+    "ensure-build-artifacts-match-solidity-code": "waffle waffle.js && diff build expected-build-artifacts",
     "migrate": "truffle migrate",
     "test": "ts-mocha test/*",
     "lint:fix": "yarn lint:ts:fix && yarn lint:sol:fix",

--- a/packages/cf-adjudicator-contracts/package.json
+++ b/packages/cf-adjudicator-contracts/package.json
@@ -15,7 +15,7 @@
   ],
   "scripts": {
     "build": "waffle waffle.js && cp build/*.json expected-build-artifacts",
-    "verify-solc": "waffle waffle.js && diff build expected-build-artifacts",
+    "ensure-build-artifacts-match-solidity-code": "waffle waffle.js && diff build expected-build-artifacts",
     "migrate": "truffle migrate",
     "test": "ts-mocha test/*",
     "lint:fix": "yarn lint:ts:fix && yarn lint:sol:fix",

--- a/packages/cf-funding-protocol-contracts/package.json
+++ b/packages/cf-funding-protocol-contracts/package.json
@@ -15,7 +15,7 @@
   ],
   "scripts": {
     "build": "waffle waffle.js && cp build/*.json expected-build-artifacts",
-    "verify-solc": "waffle waffle.js && diff build expected-build-artifacts",
+    "ensure-build-artifacts-match-solidity-code": "waffle waffle.js && diff build expected-build-artifacts",
     "migrate": "truffle migrate",
     "test": "ts-mocha test/*",
     "lint:fix": "yarn lint:ts:fix && yarn lint:sol:fix",


### PR DESCRIPTION
I'm guessing the name `verify-solc` was confusing enough to not make @kthomas realize that in #2363 the job was failing because he didn't rebuild the artifacts. This new name is much more explicit: `ensure-build-artifacts-match-solidity-code`.