### PR TITLE
Remove legacy events from Node

### DIFF
--- a/packages/node/src/api.ts
+++ b/packages/node/src/api.ts
@@ -97,10 +97,3 @@ export const methodNameToImplementation = controllers.reduce(
 export const createRpcRouter = (requestHandler: RequestHandler) =>
   new RpcRouter({ controllers, requestHandler });
 
-export const eventNameToImplementation = {
-  [NODE_EVENTS.PROPOSE_INSTALL]: handleReceivedProposalMessage,
-  [NODE_EVENTS.PROPOSE_INSTALL_VIRTUAL]: handleReceivedProposeVirtualMessage,
-  [NODE_EVENTS.PROTOCOL_MESSAGE_EVENT]: handleReceivedProtocolMessage,
-  [NODE_EVENTS.REJECT_INSTALL]: handleRejectProposalMessage,
-  [NODE_EVENTS.REJECT_INSTALL_VIRTUAL]: handleRejectProposalMessage
-};

--- a/packages/node/src/node.ts
+++ b/packages/node/src/node.ts
@@ -314,8 +314,8 @@ export class Node {
    *     solely to the deffered promise's resolve callback.
    */
   private async handleReceivedMessage(msg: NodeTypes.NodeMessage) {
-    if (!this.requestHandler.isLegacyEvent(msg.type)) {
-      throw new Error(`Received message with unknown event type: ${msg.type}`);
+    if (!this.requestHandler.hasMessageHandler(msg.type)) {
+      throw new Error(`Received message with unknown type: ${msg.type}.}`);
     }
 
     const isProtocolMessage = (msg: NodeTypes.NodeMessage) =>
@@ -333,7 +333,7 @@ export class Node {
       );
     }
 
-    return await this.requestHandler.callEvent(msg.type, msg);
+    return await this.requestHandler.callMessageHandler(msg);
   }
 
   private async handleIoSendDeferral(msg: NodeMessageWrappedProtocolMessage) {

--- a/packages/node/src/node.ts
+++ b/packages/node/src/node.ts
@@ -314,8 +314,8 @@ export class Node {
    *     solely to the deffered promise's resolve callback.
    */
   private async handleReceivedMessage(msg: NodeTypes.NodeMessage) {
-    if (!Object.values(NODE_EVENTS).includes(msg.type)) {
-      console.error(`Received message with unknown event type: ${msg.type}`);
+    if (!this.requestHandler.isLegacyEvent(msg.type)) {
+      throw new Error(`Received message with unknown event type: ${msg.type}`);
     }
 
     const isProtocolMessage = (msg: NodeTypes.NodeMessage) =>
@@ -323,16 +323,17 @@ export class Node {
 
     const isExpectingResponse = (msg: NodeMessageWrappedProtocolMessage) =>
       this.ioSendDeferrals.has(msg.data.processID);
+
     if (
       isProtocolMessage(msg) &&
       isExpectingResponse(msg as NodeMessageWrappedProtocolMessage)
     ) {
-      await this.handleIoSendDeferral(msg as NodeMessageWrappedProtocolMessage);
-    } else if (this.requestHandler.isLegacyEvent(msg.type)) {
-      await this.requestHandler.callEvent(msg.type, msg);
-    } else {
-      await this.rpcRouter.emit(msg.type, msg);
+      return await this.handleIoSendDeferral(
+        msg as NodeMessageWrappedProtocolMessage
+      );
     }
+
+    return await this.requestHandler.callEvent(msg.type, msg);
   }
 
   private async handleIoSendDeferral(msg: NodeMessageWrappedProtocolMessage) {

--- a/packages/node/src/request-handler.ts
+++ b/packages/node/src/request-handler.ts
@@ -2,14 +2,28 @@ import { NetworkContext, Node } from "@counterfactual/types";
 import { Signer } from "ethers";
 import { BaseProvider, JsonRpcProvider } from "ethers/providers";
 import EventEmitter from "eventemitter3";
-import log from "loglevel";
 
-import { eventNameToImplementation, methodNameToImplementation } from "./api";
+import { methodNameToImplementation } from "./api";
 import { ProtocolRunner } from "./machine";
+import {
+  handleReceivedProposalMessage,
+  handleReceivedProposeVirtualMessage,
+  handleRejectProposalMessage
+} from "./message-handling/handle-node-message";
+import { handleReceivedProtocolMessage } from "./message-handling/handle-protocol-message";
 import ProcessQueue from "./process-queue";
 import RpcRouter from "./rpc-router";
 import { Store } from "./store";
-import { NODE_EVENTS, NodeEvents } from "./types";
+import {
+  InstallMessage,
+  InstallVirtualMessage,
+  NODE_EVENTS,
+  NodeEvents,
+  NodeMessageWrappedProtocolMessage,
+  ProposeMessage,
+  ProposeVirtualMessage,
+  RejectProposalMessage
+} from "./types";
 import { prettyPrintObject } from "./utils";
 
 /**
@@ -18,7 +32,6 @@ import { prettyPrintObject } from "./utils";
  */
 export class RequestHandler {
   private readonly methods = new Map();
-  private readonly events = new Map();
   public readonly processQueue = new ProcessQueue();
 
   store: Store;
@@ -43,7 +56,6 @@ export class RequestHandler {
   injectRouter(router: RpcRouter) {
     this.router = router;
     this.mapPublicApiMethods();
-    this.mapEventHandlers();
   }
 
   /**
@@ -86,51 +98,51 @@ export class RequestHandler {
     }
   }
 
-  /**
-   * This maps the Node event names to their respective handlers.
-   *
-   * These are the events being listened on to detect requests from peer Nodes.
-   * https://github.com/counterfactual/monorepo/blob/master/packages/cf.js/API_REFERENCE.md#events
-   */
-  private mapEventHandlers() {
-    for (const eventName of Object.values(NODE_EVENTS)) {
-      this.events.set(eventName, eventNameToImplementation[eventName]);
-    }
-  }
-
-  /**
-   * This is internally called when an event is received from a peer Node.
-   * Node consumers can separately setup their own callbacks for incoming events.
-   * @param event
-   * @param msg
-   */
-  public async callEvent(event: NodeEvents, msg: Node.NodeMessage) {
-    const controllerExecutionMethod = this.events.get(event);
-    const controllerCount = this.router.eventListenerCount(event);
-
-    if (!controllerExecutionMethod && controllerCount === 0) {
-      if (event === NODE_EVENTS.DEPOSIT_CONFIRMED) {
-        log.info(
-          `No event handler for counter depositing into channel: ${JSON.stringify(
-            msg,
-            undefined,
-            4
-          )}`
+  public async callMessageHandler(msg: Node.NodeMessage) {
+    switch (msg.type) {
+      case NODE_EVENTS.PROTOCOL_MESSAGE_EVENT:
+        await handleReceivedProtocolMessage(
+          this,
+          // TODO: Replace type cast with input validation
+          msg as NodeMessageWrappedProtocolMessage
         );
-      } else {
-        throw Error(`Recent ${event} which has no event handler`);
-      }
+        break;
+
+      case NODE_EVENTS.PROPOSE_INSTALL:
+        // TODO: Replace type cast with input validation
+        await handleReceivedProposalMessage(this, msg as ProposeMessage);
+        break;
+
+      case NODE_EVENTS.PROPOSE_INSTALL_VIRTUAL:
+        await handleReceivedProposeVirtualMessage(
+          this,
+          msg as ProposeVirtualMessage
+        );
+        break;
+
+      case NODE_EVENTS.REJECT_INSTALL:
+      case NODE_EVENTS.REJECT_INSTALL_VIRTUAL:
+        // TODO: Replace type cast with input validation
+        await handleRejectProposalMessage(this, msg as RejectProposalMessage);
+        break;
+
+      default:
+        throw new Error(`Received unknown message ${msg.type}`);
     }
 
-    if (controllerExecutionMethod) {
-      await controllerExecutionMethod(this, msg);
-    }
-
-    this.router.emit(event, msg);
+    this.router.emit(msg.type, msg);
   }
 
-  public async isLegacyEvent(event: NodeEvents) {
-    return this.events.has(event);
+  public async hasMessageHandler(event: NodeEvents) {
+    return [
+      NODE_EVENTS.PROTOCOL_MESSAGE_EVENT,
+      NODE_EVENTS.PROPOSE_INSTALL,
+      NODE_EVENTS.PROPOSE_INSTALL_VIRTUAL,
+      NODE_EVENTS.REJECT_INSTALL,
+      NODE_EVENTS.REJECT_INSTALL_VIRTUAL,
+      NODE_EVENTS.INSTALL,
+      NODE_EVENTS.INSTALL_VIRTUAL
+    ].includes(event);
   }
 
   public async getSigner(): Promise<Signer> {


### PR DESCRIPTION
Put this together very quickly on the plane. The event concept was introduced when the codebase was first started by @cf19drofxots but doesn't match the concept of what it really does very well.

This begins to fix it.

### TODO
- [ ] Handle the `DEPOSIT_CONFIRMED` event which atm is a message sent from the caller to the receiver. Doesn't automatically happen because there is no "deposit protocol"