### PR TITLE
Add an ILockService concept to ProcessQueue

### DIFF
--- a/packages/node/src/lock/lock.ts
+++ b/packages/node/src/lock/lock.ts
@@ -1,0 +1,49 @@
+import Queue from "p-queue";
+import uuid from "uuid";
+
+import { Deferred } from "../deferred";
+
+export class Lock {
+  private currentLockHandle: Deferred<any> = new Deferred();
+  private unlockKey: string = "";
+  private readonly requestsForLock: Queue;
+
+  constructor(public readonly lockName: string) {
+    this.requestsForLock = new Queue({ concurrency: 1 });
+    this.currentLockHandle.resolve();
+  }
+
+  async acquireLock(timeout: number): Promise<string> {
+    const unlockKey = uuid.v1();
+    const lockAvailableNow = this.requestsForLock.add(() => {});
+    this.requestsForLock.add(() =>
+      this.acquireLockInternal(unlockKey, timeout)
+    );
+    await lockAvailableNow;
+    return unlockKey;
+  }
+
+  async releaseLock(unlockKey: string) {
+    this.verifyLockKey(unlockKey);
+    this.currentLockHandle.resolve();
+  }
+
+  private acquireLockInternal(
+    unlockKey: string,
+    timeout: number
+  ): Promise<any> {
+    const claim = new Deferred();
+    this.currentLockHandle = claim;
+    this.unlockKey = unlockKey;
+    setTimeout(() => claim.reject("Request timed out."), timeout);
+    return claim.promise;
+  }
+
+  private verifyLockKey(unlockKey: string) {
+    if (unlockKey !== this.unlockKey) {
+      throw new Error(
+        `Attempted to unlock ${this.lockName} with invalid key: ${unlockKey}`
+      );
+    }
+  }
+}

--- a/packages/node/src/lock/memory-lock-service.ts
+++ b/packages/node/src/lock/memory-lock-service.ts
@@ -1,0 +1,47 @@
+import { Lock } from "./lock";
+import { ILockInterface } from "./types";
+
+export class MemoryLockService implements ILockInterface {
+  public readonly locks: Map<string, Lock> = new Map<string, Lock>();
+
+  async acquireLock(
+    lockName: string,
+    callback: (...args: any[]) => any,
+    timeout: number
+  ): Promise<any> {
+    return new Promise(
+      async (
+        resolve: (value?: any) => void,
+        reject: (reason?: any) => void
+      ) => {
+        const lock = this.getOrCreateLock(lockName);
+
+        let retval = null;
+        let rejectReason = null;
+        let unlockKey = "";
+
+        try {
+          unlockKey = await lock.acquireLock(timeout);
+          retval = callback();
+        } catch (e) {
+          // TODO: check exception... if the lock failed
+          rejectReason = e;
+        } finally {
+          await lock.releaseLock(unlockKey);
+        }
+
+        if (rejectReason) reject(rejectReason);
+        else resolve(retval);
+      }
+    );
+  }
+
+  private getOrCreateLock(lockName: string) {
+    if (!this.locks.has(lockName)) {
+      this.locks.set(lockName, new Lock(lockName));
+    }
+    return this.locks.get(lockName)!;
+  }
+}
+
+export default MemoryLockService;

--- a/packages/node/src/lock/types.ts
+++ b/packages/node/src/lock/types.ts
@@ -1,0 +1,7 @@
+export interface ILockInterface {
+  acquireLock(
+    lockName: string,
+    callback: (...args: any[]) => any,
+    timeout: number
+  ): Promise<any>;
+}

--- a/packages/node/src/process-queue.ts
+++ b/packages/node/src/process-queue.ts
@@ -1,9 +1,38 @@
 import Queue, { Task } from "p-queue";
 
+import MemoryLockService from "./lock/memory-lock-service";
+import { ILockInterface } from "./lock/types";
 import { addToManyQueues } from "./methods/queued-execution";
 
+class QueueWithLockingServiceConnection extends Queue {
+  constructor(
+    private readonly queueName,
+    private readonly lockingService: ILockInterface,
+    ...args: any[]
+  ) {
+    super(...args);
+  }
+
+  async add(task: Task<any>) {
+    return super.add(() =>
+      this.lockingService.acquireLock(this.queueName, task, 30_000)
+    );
+  }
+}
+
 export default class ProcessQueue {
-  private readonly queues: Map<string, Queue> = new Map<string, Queue>();
+  private readonly queues: Map<
+    string,
+    QueueWithLockingServiceConnection
+  > = new Map<string, QueueWithLockingServiceConnection>();
+
+  constructor(
+    // NOTE: This hard-codes a LOCAL single lock service in any ProcessQueue,
+    // this means it is not acting as a centralized lock service right now; a
+    // further implementation should extend this primitive and pass in a global
+    // service into this constructor that also implements the interface.
+    private readonly lockingService: ILockInterface = new MemoryLockService()
+  ) {}
 
   addTask(queueKeys: string[], task: Task<any>) {
     return addToManyQueues(
@@ -12,9 +41,16 @@ export default class ProcessQueue {
     );
   }
 
-  private getOrCreateQueue(queueKey: string): Queue {
+  private getOrCreateQueue(
+    queueKey: string
+  ): QueueWithLockingServiceConnection {
     if (!this.queues.has(queueKey)) {
-      this.queues.set(queueKey, new Queue({ concurrency: 1 }));
+      this.queues.set(
+        queueKey,
+        new QueueWithLockingServiceConnection(queueKey, this.lockingService, {
+          concurrency: 1
+        })
+      );
     }
     return this.queues.get(queueKey)!;
   }

--- a/packages/node/test/unit/process-queue.spec.ts
+++ b/packages/node/test/unit/process-queue.spec.ts
@@ -1,0 +1,70 @@
+import ProcessQueue from "../../src/process-queue";
+
+describe("ProcessQueue", () => {
+  it("should be able to process a single task", async () => {
+    const processQueue = new ProcessQueue();
+    const ret = await processQueue.addTask(["queue1"], () => "abc");
+    expect(ret).toBe("abc");
+  });
+
+  it("should be able to process two syncronous tasks", async () => {
+    const processQueue = new ProcessQueue();
+    let i = 0;
+    const ret1 = await processQueue.addTask(["queue1"], () => (i += 1));
+    const ret2 = await processQueue.addTask(["queue1"], () => (i += 1));
+    expect(ret1).toBe(1);
+    expect(ret2).toBe(2);
+  });
+
+  it("should be able to process two asyncronous tasks, one queue (same)", async () => {
+    const processQueue = new ProcessQueue();
+    let i = 0;
+    let ret1;
+    let ret2;
+    await Promise.all([
+      processQueue.addTask(["queue1"], () => (ret1 = i += 1)),
+      processQueue.addTask(["queue1"], () => (ret2 = i += 1))
+    ]);
+    expect(ret1).toBe(1);
+    expect(ret2).toBe(2);
+  });
+
+  it("should be able to process two asyncronous tasks, one queue (mixed)", async () => {
+    const processQueue = new ProcessQueue();
+    let i = 0;
+    let ret1;
+    let ret2;
+    await Promise.all([
+      processQueue.addTask(["queue1"], () => (ret1 = i += 1)),
+      processQueue.addTask(["queue2"], () => (ret2 = i += 1))
+    ]);
+    expect(ret1).toBe(1);
+    expect(ret2).toBe(2);
+  });
+
+  it("should be able to process two asyncronous tasks, two queues (same)", async () => {
+    const processQueue = new ProcessQueue();
+    let i = 0;
+    let ret1;
+    let ret2;
+    await Promise.all([
+      processQueue.addTask(["queue1", "queue2"], () => (ret1 = i += 1)),
+      processQueue.addTask(["queue1", "queue2"], () => (ret2 = i += 1))
+    ]);
+    expect(ret1).toBe(1);
+    expect(ret2).toBe(2);
+  });
+
+  it("should be able to process two asyncronous tasks, two queues (mixed)", async () => {
+    const processQueue = new ProcessQueue();
+    let i = 0;
+    let ret1;
+    let ret2;
+    await Promise.all([
+      processQueue.addTask(["queue1", "queue3"], () => (ret1 = i += 1)),
+      processQueue.addTask(["queue1", "queue2"], () => (ret2 = i += 1))
+    ]);
+    expect(ret1).toBe(1);
+    expect(ret2).toBe(2);
+  });
+});


### PR DESCRIPTION
This is more of a Proof-of-Concept, I think.

It adds a locking mechanism to the `ProcessQueue` that adheres to the interface suggested by @kt. There is also an in-memory implementation of this interface that is default used by the `Node`. All the tests seem to pass which indicates to me it is a harmless addition to `master` now.

The next thing to try is to implement a version of `ILockService` that communicates to a central registry of locks, as this one is only using a local in-process registry like I mentioned. The central registry could just be an in-memory-of-the-jest-test-suite one for the next iteration. Eventually Connext intends to use Redis.

I'm not 100% confident this solves the issues we see with deadlock scenarios yet, as like I mentioned above, this is _not_ actually a central registry yet (i.e., it is just an elegant code change to the existing `ProcessQueue` object).

I think, also, that we can remove the call to `ProcessQueue::addTask` from the `handle-protocol-message.ts` file once we try to implement this in a central registry context.