### PR TITLE
[node] Add channel persistence, pt 1

### DIFF
--- a/packages/node/src/machine/enums.ts
+++ b/packages/node/src/machine/enums.ts
@@ -17,7 +17,13 @@ enum Opcode {
   /**
    * Middleware hook to both send and wait for a response from a ProtocolMessage
    */
-  IO_SEND_AND_WAIT
+  IO_SEND_AND_WAIT,
+
+  /**
+   * Middleware hook to write the state channel to store. Used to lock channel
+   * betweeen protocols.
+   */
+  PERSIST_STATE_CHANNEL
 }
 
 enum Protocol {

--- a/packages/node/src/machine/middleware.ts
+++ b/packages/node/src/machine/middleware.ts
@@ -6,7 +6,8 @@ export class MiddlewareContainer {
     [Opcode.IO_SEND]: [],
     [Opcode.IO_SEND_AND_WAIT]: [],
     [Opcode.OP_SIGN]: [],
-    [Opcode.WRITE_COMMITMENT]: []
+    [Opcode.WRITE_COMMITMENT]: [],
+    [Opcode.PERSIST_STATE_CHANNEL]: []
   };
 
   public add(scope: Opcode, method: Middleware) {

--- a/packages/node/src/node.ts
+++ b/packages/node/src/node.ts
@@ -223,10 +223,13 @@ export class Node {
 
     protocolRunner.register(
       Opcode.PERSIST_STATE_CHANNEL,
-      async (args: [StateChannel]) => {
+      async (args: [StateChannel[]]) => {
         const { store } = this.requestHandler;
-        const [channel] = args;
-        await store.saveStateChannel(channel);
+        const [stateChannels] = args;
+
+        for (const stateChannel of stateChannels) {
+          await store.saveStateChannel(stateChannel);
+        }
       }
     );
 

--- a/packages/node/src/node.ts
+++ b/packages/node/src/node.ts
@@ -176,7 +176,6 @@ export class Node {
       Opcode.IO_SEND_AND_WAIT,
       async (args: [ProtocolMessage]) => {
         const [data] = args;
-        const fromXpub = this.publicIdentifier;
         const to = data.toXpub;
 
         const deferral = new Deferred<NodeMessageWrappedProtocolMessage>();
@@ -187,7 +186,7 @@ export class Node {
 
         await this.messagingService.send(to, {
           data,
-          from: fromXpub,
+          from: this.publicIdentifier,
           type: NODE_EVENTS.PROTOCOL_MESSAGE_EVENT
         } as NodeMessageWrappedProtocolMessage);
 

--- a/packages/node/src/node.ts
+++ b/packages/node/src/node.ts
@@ -10,6 +10,7 @@ import { createRpcRouter } from "./api";
 import AutoNonceWallet from "./auto-nonce-wallet";
 import { Deferred } from "./deferred";
 import { Opcode, Protocol, ProtocolMessage, ProtocolRunner } from "./machine";
+import { StateChannel } from "./models";
 import { getFreeBalanceAddress } from "./models/free-balance";
 import {
   EthereumNetworkName,
@@ -220,6 +221,15 @@ export class Node {
         await store.setCommitment([protocol, ...key], commitment);
       }
     });
+
+    protocolRunner.register(
+      Opcode.PERSIST_STATE_CHANNEL,
+      async (args: [StateChannel]) => {
+        const { store } = this.requestHandler;
+        const [channel] = args;
+        await store.saveStateChannel(channel);
+      }
+    );
 
     return protocolRunner;
   }

--- a/packages/node/src/protocol/install.ts
+++ b/packages/node/src/protocol/install.ts
@@ -20,6 +20,9 @@ import { TokenIndexedCoinTransferMap } from "../models/free-balance";
 import { UNASSIGNED_SEQ_NO } from "./utils/signature-forwarder";
 import { assertIsValidSignature } from "./utils/signature-validator";
 
+const { OP_SIGN, IO_SEND, IO_SEND_AND_WAIT, WRITE_COMMITMENT } = Opcode;
+const { Update, Install } = Protocol;
+
 /**
  * @description This exchange is described at the following URL:
  *
@@ -61,7 +64,7 @@ export const INSTALL_PROTOCOL: ProtocolExecutionFlow = {
     );
 
     const mySignatureOnConditionalTransaction = yield [
-      Opcode.OP_SIGN,
+      OP_SIGN,
       conditionalTransactionData
     ];
 
@@ -71,11 +74,11 @@ export const INSTALL_PROTOCOL: ProtocolExecutionFlow = {
         signature2: counterpartySignatureOnFreeBalanceStateUpdate
       }
     } = yield [
-      Opcode.IO_SEND_AND_WAIT,
+      IO_SEND_AND_WAIT,
       {
         processID,
         params,
-        protocol: Protocol.Install,
+        protocol: Install,
         toXpub: responderXpub,
         customData: {
           signature: mySignatureOnConditionalTransaction
@@ -103,8 +106,8 @@ export const INSTALL_PROTOCOL: ProtocolExecutionFlow = {
     );
 
     yield [
-      Opcode.WRITE_COMMITMENT,
-      Protocol.Install,
+      WRITE_COMMITMENT,
+      Install,
       signedConditionalTransaction,
       newAppInstance.identityHash
     ];
@@ -124,7 +127,7 @@ export const INSTALL_PROTOCOL: ProtocolExecutionFlow = {
     );
 
     const mySignatureOnFreeBalanceStateUpdate = yield [
-      Opcode.OP_SIGN,
+      OP_SIGN,
       freeBalanceUpdateData
     ];
 
@@ -136,17 +139,17 @@ export const INSTALL_PROTOCOL: ProtocolExecutionFlow = {
     );
 
     yield [
-      Opcode.WRITE_COMMITMENT,
-      Protocol.Update,
+      WRITE_COMMITMENT,
+      Update,
       signedFreeBalanceStateUpdate,
       postProtocolStateChannel.freeBalance.identityHash
     ];
 
     yield [
-      Opcode.IO_SEND,
+      IO_SEND,
       {
         processID,
-        protocol: Protocol.Install,
+        protocol: Install,
         toXpub: responderXpub,
         customData: {
           signature: mySignatureOnFreeBalanceStateUpdate
@@ -202,7 +205,7 @@ export const INSTALL_PROTOCOL: ProtocolExecutionFlow = {
     );
 
     const mySignatureOnConditionalTransaction = yield [
-      Opcode.OP_SIGN,
+      OP_SIGN,
       conditionalTransactionData
     ];
 
@@ -219,8 +222,8 @@ export const INSTALL_PROTOCOL: ProtocolExecutionFlow = {
     );
 
     yield [
-      Opcode.WRITE_COMMITMENT,
-      Protocol.Install,
+      WRITE_COMMITMENT,
+      Install,
       signedConditionalTransaction,
       newAppInstance.identityHash
     ];
@@ -234,17 +237,17 @@ export const INSTALL_PROTOCOL: ProtocolExecutionFlow = {
     );
 
     const mySignatureOnFreeBalanceStateUpdate = yield [
-      Opcode.OP_SIGN,
+      OP_SIGN,
       freeBalanceUpdateData
     ];
 
     const {
       customData: { signature: counterpartySignatureOnFreeBalanceStateUpdate }
     } = yield [
-      Opcode.IO_SEND_AND_WAIT,
+      IO_SEND_AND_WAIT,
       {
         processID,
-        protocol: Protocol.Install,
+        protocol: Install,
         toXpub: initiatorXpub,
         customData: {
           signature: mySignatureOnConditionalTransaction,
@@ -268,8 +271,8 @@ export const INSTALL_PROTOCOL: ProtocolExecutionFlow = {
     );
 
     yield [
-      Opcode.WRITE_COMMITMENT,
-      Protocol.Update,
+      WRITE_COMMITMENT,
+      Update,
       signedFreeBalanceStateUpdate,
       postProtocolStateChannel.freeBalance.identityHash
     ];

--- a/packages/node/src/protocol/setup.ts
+++ b/packages/node/src/protocol/setup.ts
@@ -9,7 +9,7 @@ import { UNASSIGNED_SEQ_NO } from "./utils/signature-forwarder";
 import { assertIsValidSignature } from "./utils/signature-validator";
 
 const protocol = Protocol.Setup;
-const { OP_SIGN, IO_SEND, IO_SEND_AND_WAIT } = Opcode;
+const { OP_SIGN, IO_SEND, IO_SEND_AND_WAIT, PERSIST_STATE_CHANNEL } = Opcode;
 
 /**
  * @description This exchange is described at the following URL:
@@ -103,6 +103,8 @@ export const SETUP_PROTOCOL: ProtocolExecutionFlow = {
     );
 
     const responderSignature = yield [OP_SIGN, setupCommitment];
+
+    yield [PERSIST_STATE_CHANNEL, [stateChannel]];
 
     yield [
       IO_SEND,

--- a/packages/node/src/protocol/take-action.ts
+++ b/packages/node/src/protocol/take-action.ts
@@ -8,7 +8,7 @@ import { UNASSIGNED_SEQ_NO } from "./utils/signature-forwarder";
 import { assertIsValidSignature } from "./utils/signature-validator";
 
 const protocol = Protocol.TakeAction;
-const { OP_SIGN, IO_SEND, IO_SEND_AND_WAIT } = Opcode;
+const { OP_SIGN, IO_SEND, IO_SEND_AND_WAIT, PERSIST_STATE_CHANNEL } = Opcode;
 
 /**
  * @description This exchange is described at the following URL:
@@ -132,6 +132,8 @@ export const TAKE_ACTION_PROTOCOL: ProtocolExecutionFlow = {
       setStateCommitment,
       appInstance.appSeqNo
     ];
+
+    yield [PERSIST_STATE_CHANNEL, [postProtocolStateChannel]];
 
     yield [
       IO_SEND,

--- a/packages/node/src/protocol/uninstall-virtual-app.ts
+++ b/packages/node/src/protocol/uninstall-virtual-app.ts
@@ -27,7 +27,8 @@ function xkeyTo0thAddress(xpub: string) {
 const {
   OP_SIGN,
   IO_SEND_AND_WAIT,
-  IO_SEND
+  IO_SEND,
+  PERSIST_STATE_CHANNEL
   // WRITE_COMMITMENT // TODO: add calls to WRITE_COMMITMENT after sigs collected
 } = Opcode;
 
@@ -292,6 +293,15 @@ export const UNINSTALL_VIRTUAL_APP_PROTOCOL: ProtocolExecutionFlow = {
     ];
 
     yield [
+      PERSIST_STATE_CHANNEL,
+      [
+        stateChannelWithInitiating,
+        stateChannelWithAllThreeParties,
+        stateChannelWithResponding
+      ]
+    ];
+
+    yield [
       IO_SEND,
       {
         processID,
@@ -463,6 +473,15 @@ export const UNINSTALL_VIRTUAL_APP_PROTOCOL: ProtocolExecutionFlow = {
         signature: respondingSignatureOnIngridBobAppDisactivationCommitment
       }
     } as ProtocolMessage;
+
+    yield [
+      PERSIST_STATE_CHANNEL,
+      [
+        stateChannelWithInitiating,
+        stateChannelWithAllThreeParties,
+        stateChannelWithIntermediary
+      ]
+    ];
 
     yield [IO_SEND, m8];
 

--- a/packages/node/src/protocol/uninstall.ts
+++ b/packages/node/src/protocol/uninstall.ts
@@ -16,7 +16,13 @@ import { UNASSIGNED_SEQ_NO } from "./utils/signature-forwarder";
 import { assertIsValidSignature } from "./utils/signature-validator";
 
 const protocol = Protocol.Uninstall;
-const { OP_SIGN, IO_SEND, IO_SEND_AND_WAIT, WRITE_COMMITMENT } = Opcode;
+const {
+  OP_SIGN,
+  IO_SEND,
+  IO_SEND_AND_WAIT,
+  PERSIST_STATE_CHANNEL,
+  WRITE_COMMITMENT
+} = Opcode;
 
 /**
  * @description This exchange is described at the following URL:
@@ -117,6 +123,8 @@ export const UNINSTALL_PROTOCOL: ProtocolExecutionFlow = {
     ]);
 
     yield [WRITE_COMMITMENT, protocol, finalCommitment, appIdentityHash];
+
+    yield [PERSIST_STATE_CHANNEL, [postProtocolStateChannel]];
 
     yield [
       IO_SEND,

--- a/packages/node/src/protocol/update.ts
+++ b/packages/node/src/protocol/update.ts
@@ -8,7 +8,7 @@ import { UNASSIGNED_SEQ_NO } from "./utils/signature-forwarder";
 import { assertIsValidSignature } from "./utils/signature-validator";
 
 const protocol = Protocol.Update;
-const { OP_SIGN, IO_SEND, IO_SEND_AND_WAIT } = Opcode;
+const { OP_SIGN, IO_SEND, IO_SEND_AND_WAIT, PERSIST_STATE_CHANNEL } = Opcode;
 
 /**
  * @description This exchange is described at the following URL:
@@ -128,6 +128,8 @@ export const UPDATE_PROTOCOL: ProtocolExecutionFlow = {
       setStateCommitment,
       appInstance.appSeqNo
     ];
+
+    yield [PERSIST_STATE_CHANNEL, [postProtocolStateChannel]];
 
     yield [
       IO_SEND,

--- a/packages/node/src/protocol/withdraw.ts
+++ b/packages/node/src/protocol/withdraw.ts
@@ -22,6 +22,14 @@ import { AppInstance, StateChannel } from "../models";
 import { UNASSIGNED_SEQ_NO } from "./utils/signature-forwarder";
 import { assertIsValidSignature } from "./utils/signature-validator";
 
+const {
+  IO_SEND,
+  IO_SEND_AND_WAIT,
+  OP_SIGN,
+  PERSIST_STATE_CHANNEL,
+  WRITE_COMMITMENT
+} = Opcode;
+const { Install, Update, Withdraw } = Protocol;
 /**
  * @description This exchange is described at the following URL:
  * https://specs.counterfactual.com/11-withdraw-protocol *
@@ -83,7 +91,7 @@ export const WITHDRAW_PROTOCOL: ProtocolExecutionFlow = {
     );
 
     const mySignatureOnConditionalTransaction = yield [
-      Opcode.OP_SIGN,
+      OP_SIGN,
       conditionalTransactionData
     ];
 
@@ -93,11 +101,11 @@ export const WITHDRAW_PROTOCOL: ProtocolExecutionFlow = {
         signature2: counterpartySignatureOnFreeBalanceStateUpdate
       }
     } = yield [
-      Opcode.IO_SEND_AND_WAIT,
+      IO_SEND_AND_WAIT,
       {
         processID,
         params,
-        protocol: Protocol.Withdraw,
+        protocol: Withdraw,
         toXpub: responderXpub,
         customData: {
           signature: mySignatureOnConditionalTransaction
@@ -125,8 +133,8 @@ export const WITHDRAW_PROTOCOL: ProtocolExecutionFlow = {
     );
 
     yield [
-      Opcode.WRITE_COMMITMENT,
-      Protocol.Install, // NOTE: The WRITE_COMMITMENT API is awkward in this situation
+      WRITE_COMMITMENT,
+      Install, // NOTE: The WRITE_COMMITMENT API is awkward in this situation
       signedConditionalTransaction,
       refundApp.identityHash
     ];
@@ -146,7 +154,7 @@ export const WITHDRAW_PROTOCOL: ProtocolExecutionFlow = {
     );
 
     const mySignatureOnFreeBalanceStateUpdate = yield [
-      Opcode.OP_SIGN,
+      OP_SIGN,
       freeBalanceUpdateData
     ];
 
@@ -158,8 +166,8 @@ export const WITHDRAW_PROTOCOL: ProtocolExecutionFlow = {
     );
 
     yield [
-      Opcode.WRITE_COMMITMENT,
-      Protocol.Update, // NOTE: The WRITE_COMMITMENT API is awkward in this situation
+      WRITE_COMMITMENT,
+      Update, // NOTE: The WRITE_COMMITMENT API is awkward in this situation
       signedFreeBalanceStateUpdate,
       postInstallRefundAppStateChannel.freeBalance.identityHash
     ];
@@ -172,7 +180,7 @@ export const WITHDRAW_PROTOCOL: ProtocolExecutionFlow = {
     );
 
     const mySignatureOnWithdrawalCommitment = yield [
-      Opcode.OP_SIGN,
+      OP_SIGN,
       withdrawCommitment
     ];
 
@@ -182,10 +190,10 @@ export const WITHDRAW_PROTOCOL: ProtocolExecutionFlow = {
         signature2: counterpartySignatureOnUninstallCommitment
       }
     } = yield [
-      Opcode.IO_SEND_AND_WAIT,
+      IO_SEND_AND_WAIT,
       {
         processID,
-        protocol: Protocol.Withdraw,
+        protocol: Withdraw,
         toXpub: responderXpub,
         customData: {
           signature: mySignatureOnFreeBalanceStateUpdate,
@@ -226,14 +234,14 @@ export const WITHDRAW_PROTOCOL: ProtocolExecutionFlow = {
     );
 
     const mySignatureOnUninstallCommitment = yield [
-      Opcode.OP_SIGN,
+      OP_SIGN,
       uninstallRefundAppCommitment
     ];
 
     yield <[Opcode, ProtocolMessage]>[
-      Opcode.IO_SEND,
+      IO_SEND,
       {
-        protocol: Protocol.Withdraw,
+        protocol: Withdraw,
         processID: context.message.processID,
         toXpub: responderXpub,
         customData: {
@@ -249,8 +257,8 @@ export const WITHDRAW_PROTOCOL: ProtocolExecutionFlow = {
     ]);
 
     yield [
-      Opcode.WRITE_COMMITMENT,
-      Protocol.Withdraw,
+      WRITE_COMMITMENT,
+      Withdraw,
       signedWithdrawalCommitment,
       multisigAddress
     ];
@@ -263,8 +271,8 @@ export const WITHDRAW_PROTOCOL: ProtocolExecutionFlow = {
     );
 
     yield [
-      Opcode.WRITE_COMMITMENT,
-      Protocol.Update, // NOTE: The WRITE_COMMITMENT API is awkward in this situation
+      WRITE_COMMITMENT,
+      Update, // NOTE: The WRITE_COMMITMENT API is awkward in this situation
       signedUninstallCommitment,
       postUninstallRefundAppStateChannel.freeBalance.identityHash
     ];
@@ -329,7 +337,7 @@ export const WITHDRAW_PROTOCOL: ProtocolExecutionFlow = {
     );
 
     const mySignatureOnConditionalTransaction = yield [
-      Opcode.OP_SIGN,
+      OP_SIGN,
       conditionalTransactionData
     ];
 
@@ -346,8 +354,8 @@ export const WITHDRAW_PROTOCOL: ProtocolExecutionFlow = {
     );
 
     yield [
-      Opcode.WRITE_COMMITMENT,
-      Protocol.Install, // NOTE: The WRITE_COMMITMENT API is awkward in this situation
+      WRITE_COMMITMENT,
+      Install, // NOTE: The WRITE_COMMITMENT API is awkward in this situation
       signedConditionalTransaction,
       refundApp.identityHash
     ];
@@ -361,7 +369,7 @@ export const WITHDRAW_PROTOCOL: ProtocolExecutionFlow = {
     );
 
     const mySignatureOnFreeBalanceStateUpdate = yield [
-      Opcode.OP_SIGN,
+      OP_SIGN,
       freeBalanceUpdateData
     ];
 
@@ -371,10 +379,10 @@ export const WITHDRAW_PROTOCOL: ProtocolExecutionFlow = {
         signature2: counterpartySignatureOnWithdrawalCommitment
       }
     } = yield [
-      Opcode.IO_SEND_AND_WAIT,
+      IO_SEND_AND_WAIT,
       {
         processID,
-        protocol: Protocol.Withdraw,
+        protocol: Withdraw,
         toXpub: initiatorXpub,
         customData: {
           signature: mySignatureOnConditionalTransaction,
@@ -398,8 +406,8 @@ export const WITHDRAW_PROTOCOL: ProtocolExecutionFlow = {
     );
 
     yield [
-      Opcode.WRITE_COMMITMENT,
-      Protocol.Update, // NOTE: The WRITE_COMMITMENT API is awkward in this situation
+      WRITE_COMMITMENT,
+      Update, // NOTE: The WRITE_COMMITMENT API is awkward in this situation
       signedFreeBalanceStateUpdate,
       postInstallRefundAppStateChannel.freeBalance.identityHash
     ];
@@ -418,7 +426,7 @@ export const WITHDRAW_PROTOCOL: ProtocolExecutionFlow = {
     );
 
     const mySignatureOnWithdrawalCommitment = yield [
-      Opcode.OP_SIGN,
+      OP_SIGN,
       withdrawCommitment
     ];
 
@@ -428,8 +436,8 @@ export const WITHDRAW_PROTOCOL: ProtocolExecutionFlow = {
     ]);
 
     yield [
-      Opcode.WRITE_COMMITMENT,
-      Protocol.Withdraw,
+      WRITE_COMMITMENT,
+      Withdraw,
       signedWithdrawalCommitment,
       multisigAddress
     ];
@@ -453,17 +461,17 @@ export const WITHDRAW_PROTOCOL: ProtocolExecutionFlow = {
     );
 
     const mySignatureOnUninstallCommitment = yield [
-      Opcode.OP_SIGN,
+      OP_SIGN,
       uninstallRefundAppCommitment
     ];
 
     const {
       customData: { signature: counterpartySignatureOnUninstallCommitment }
     } = yield [
-      Opcode.IO_SEND_AND_WAIT,
+      IO_SEND_AND_WAIT,
       {
         processID,
-        protocol: Protocol.Withdraw,
+        protocol: Withdraw,
         toXpub: initiatorXpub,
         customData: {
           signature: mySignatureOnWithdrawalCommitment,
@@ -487,8 +495,8 @@ export const WITHDRAW_PROTOCOL: ProtocolExecutionFlow = {
     );
 
     yield [
-      Opcode.WRITE_COMMITMENT,
-      Protocol.Update, // NOTE: The WRITE_COMMITMENT API is awkward in this situation
+      WRITE_COMMITMENT,
+      Update, // NOTE: The WRITE_COMMITMENT API is awkward in this situation
       signedUninstallCommitment,
       postUninstallRefundAppStateChannel.freeBalance.identityHash
     ];


### PR DESCRIPTION
### Description

- adds a `PERSIST_STATE_CHANNEL` to OpCode, which saves a state channel to store
- ensures all state channels are persisted before sending final message to initiator and completing the protocol for all but: `withdraw`, `install-virtual-app`, `install` (protocols that don't end with message to initiator)