### PR TITLE
Add queue for the B-C channel on A-B-C interactions

### DIFF
--- a/packages/node/src/methods/app-instance/install-virtual/controller.ts
+++ b/packages/node/src/methods/app-instance/install-virtual/controller.ts
@@ -36,7 +36,17 @@ export default class InstallVirtualController extends NodeController {
       networkContext.MinimumViableMultisig
     );
 
-    return [multisigAddressWithHub, multisigAddressWithResponding];
+    const multisigAddressBetweenHubAndResponding = getCreate2MultisigAddress(
+      [intermediaryIdentifier, proposedByIdentifier],
+      networkContext.ProxyFactory,
+      networkContext.MinimumViableMultisig
+    );
+
+    return [
+      multisigAddressWithHub,
+      multisigAddressWithResponding,
+      multisigAddressBetweenHubAndResponding
+    ];
   }
 
   protected async beforeExecution(

--- a/packages/node/src/methods/app-instance/uninstall-virtual/controller.ts
+++ b/packages/node/src/methods/app-instance/uninstall-virtual/controller.ts
@@ -35,9 +35,21 @@ export default class UninstallVirtualController extends NodeController {
       appInstanceId
     );
 
+    const multisigAddressBetweenHubAndResponding = getCreate2MultisigAddress(
+      [
+        stateChannelWithResponding.userNeuteredExtendedKeys.filter(
+          x => x !== publicIdentifier
+        )[0],
+        intermediaryIdentifier
+      ],
+      networkContext.ProxyFactory,
+      networkContext.MinimumViableMultisig
+    );
+
     return [
       stateChannelWithResponding.multisigAddress,
       multisigAddressForStateChannelWithIntermediary,
+      multisigAddressBetweenHubAndResponding,
       appInstanceId
     ];
   }


### PR DESCRIPTION
It is possible that, at the same time A requests a virtual interaction through B to C, that C requests a direct interaction with B. This situation is not covered unless A queues on B-C in these cases. With a central lock this introduces a griefing vector.