### PR TITLE
Fix mistake in Deferred fix from #2387

### DIFF
--- a/packages/node/src/methods/queued-execution.ts
+++ b/packages/node/src/methods/queued-execution.ts
@@ -36,8 +36,8 @@ export async function addToManyQueues(queues: Queue[], task: Task<any>) {
    * create a promise that says "every queue has finished up until
    * the time that addToManyQueues was called".
    */
-  const deferreds = Array(queues.length).fill(new Deferred());
-  const waitForEveryQueueToFinish = Promise.all(deferreds);
+  const deferreds = [...Array(queues.length)].map(() => new Deferred());
+  const waitForEveryQueueToFinish = Promise.all(deferreds.map(d => d.promise));
 
   await Promise.all(
     queues.map((q, i) =>


### PR DESCRIPTION
Two mistakes:

1. Using `.fill` fills it with the same `Deferred`
2. `await`ing on a `Deferred` instantly resolves, need to use `.promise`