### PR TITLE
[node] Fix RPC router issue

### DIFF
--- a/packages/node/src/rpc-router.ts
+++ b/packages/node/src/rpc-router.ts
@@ -74,6 +74,8 @@ export default class RpcRouter extends Router {
   }
 
   eventListenerCount(event: string): number {
-    return this.requestHandler.outgoing.listenerCount(event);
+    return typeof this.requestHandler.outgoing.listenerCount === "function"
+      ? this.requestHandler.outgoing.listenerCount(event)
+      : 0;
   }
 }


### PR DESCRIPTION
When we run our stack with local CF code (i.e. not from NPM), we see an issue sometimes where this function is accessed before the class has been initialized. This should fix those cases.