### PR TITLE
[node] Bump node version

### DIFF
--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@counterfactual/node",
-  "version": "0.2.80",
+  "version": "0.2.81",
   "main": "dist/index.js",
   "iife": "dist/index.iife.js",
   "types": "dist/src/index.d.ts",

--- a/packages/simple-hub-server/package.json
+++ b/packages/simple-hub-server/package.json
@@ -39,7 +39,7 @@
   },
   "dependencies": {
     "@counterfactual/firebase-client": "0.0.6",
-    "@counterfactual/node": "0.2.80",
+    "@counterfactual/node": "0.2.81",
     "@counterfactual/types": "0.0.42",
     "@counterfactual/typescript-typings": "0.1.2",
     "@ebryn/jsonapi-ts": "0.1.17",


### PR DESCRIPTION
https://github.com/counterfactual/monorepo/pull/2456 forgot to bump the node version so this PR is doing that.