### PR TITLE
Fix node version lock

### DIFF
--- a/packages/cf-funding-protocol-contracts/package.json
+++ b/packages/cf-funding-protocol-contracts/package.json
@@ -4,8 +4,8 @@
   "description": "Smart contracts for the Counterfactual multisig funding protocol",
   "license": "MIT",
   "engines": {
-    "yarn": "^1.17.3",
-    "node": "^10.15.3"
+    "yarn": ">=1.17.3",
+    "node": "^10 || ^12"
   },
   "files": [
     "build",


### PR DESCRIPTION
Same as https://github.com/counterfactual/monorepo/pull/2492

It should fix this error:

```
git:(develop) yarn add @connext/client
yarn add v1.17.3
[1/4] 🔍  Resolving packages...
warning @connext/client > @counterfactual/node > typescript-memoize > core-js@2.4.1: core-js@<2.6.8 is no longer maintained. Please, upgrade to core-js@3 or at least to actual version of core-js@2.
[2/4] 🚚  Fetching packages...
error @counterfactual/cf-funding-protocol-contracts@0.0.11: The engine "node" is incompatible with this module. Expected version "10.15.3". Got "10.16.3"
error Found incompatible module.
info Visit https://yarnpkg.com/en/docs/cli/add for documentation about this command.
```