### PR TITLE
Remove unnecessary serialization type

### DIFF
--- a/packages/cf-funding-protocol-contracts/test/single-asset-two-party-coin-transfer-from-virtual-app-interpreter.spec.ts
+++ b/packages/cf-funding-protocol-contracts/test/single-asset-two-party-coin-transfer-from-virtual-app-interpreter.spec.ts
@@ -1,5 +1,3 @@
-import DolphinCoin from "../expected-build-artifacts/DolphinCoin.json";
-import SingleAssetTwoPartyCoinTransferFromVirtualAppInterpreter from "../expected-build-artifacts/SingleAssetTwoPartyCoinTransferFromVirtualAppInterpreter.json";
 import * as waffle from "ethereum-waffle";
 import { Contract, Wallet } from "ethers";
 import { AddressZero, One, Zero } from "ethers/constants";
@@ -11,6 +9,9 @@ import {
   hexlify,
   randomBytes
 } from "ethers/utils";
+
+import DolphinCoin from "../expected-build-artifacts/DolphinCoin.json";
+import SingleAssetTwoPartyCoinTransferFromVirtualAppInterpreter from "../expected-build-artifacts/SingleAssetTwoPartyCoinTransferFromVirtualAppInterpreter.json";
 
 import { expect } from "./utils/index";
 

--- a/packages/node/src/models/state-channel.ts
+++ b/packages/node/src/models/state-channel.ts
@@ -43,15 +43,7 @@ function sortAddresses(addrs: string[]) {
 
 export type SingleAssetTwoPartyIntermediaryAgreement = {
   timeLockedPassThroughIdentityHash: string;
-  capitalProvided: BigNumber;
-  capitalProvider: string;
-  virtualAppUser: string;
-  tokenAddress: string;
-};
-
-type SingleAssetTwoPartyIntermediaryAgreementJSON = {
-  timeLockedPassThroughIdentityHash: string;
-  capitalProvided: { _hex: string };
+  capitalProvided: string;
   capitalProvider: string;
   virtualAppUser: string;
   tokenAddress: string;
@@ -64,7 +56,7 @@ export type StateChannelJSON = {
   readonly appInstances: [string, AppInstanceJson][];
   readonly singleAssetTwoPartyIntermediaryAgreements: [
     string,
-    SingleAssetTwoPartyIntermediaryAgreementJSON
+    SingleAssetTwoPartyIntermediaryAgreement
   ][];
   readonly freeBalanceAppInstance: AppInstanceJson | undefined;
   readonly monotonicNumProposedApps: number;
@@ -549,13 +541,7 @@ export class StateChannel {
       monotonicNumProposedApps: this.monotonicNumProposedApps,
       singleAssetTwoPartyIntermediaryAgreements: [
         ...this.singleAssetTwoPartyIntermediaryAgreements.entries()
-      ].map(([key, val]) => [
-        key,
-        {
-          ...val,
-          capitalProvided: { _hex: val.capitalProvided.toHexString() }
-        }
-      ]),
+      ],
       createdAt: this.createdAt
     };
   }
@@ -583,17 +569,7 @@ export class StateChannel {
           ];
         })
       ),
-      new Map(
-        (json.singleAssetTwoPartyIntermediaryAgreements || []).map(
-          ([key, val]) => [
-            key,
-            {
-              ...val,
-              capitalProvided: bigNumberify(val.capitalProvided._hex)
-            }
-          ]
-        )
-      ),
+      new Map(json.singleAssetTwoPartyIntermediaryAgreements || []),
       json.freeBalanceAppInstance
         ? AppInstance.fromJson(json.freeBalanceAppInstance)
         : undefined,

--- a/packages/node/src/protocol/install-virtual-app.ts
+++ b/packages/node/src/protocol/install-virtual-app.ts
@@ -1130,9 +1130,9 @@ async function getUpdatedStateChannelAndVirtualAppObjectsForInitiating(
       tokenAddress,
       timeLockedPassThroughIdentityHash:
         timeLockedPassThroughAppInstance.identityHash,
-      capitalProvided: bigNumberify(initiatorBalanceDecrement).add(
-        responderBalanceDecrement
-      ),
+      capitalProvided: bigNumberify(initiatorBalanceDecrement)
+        .add(responderBalanceDecrement)
+        .toHexString(),
       capitalProvider: intermediaryAddress,
       virtualAppUser: initiatorAddress
     },
@@ -1227,9 +1227,9 @@ async function getUpdatedStateChannelAndVirtualAppObjectsForIntermediary(
         tokenAddress,
         timeLockedPassThroughIdentityHash:
           timeLockedPassThroughAppInstance.identityHash,
-        capitalProvided: bigNumberify(initiatorBalanceDecrement).add(
-          responderBalanceDecrement
-        ),
+        capitalProvided: bigNumberify(initiatorBalanceDecrement)
+          .add(responderBalanceDecrement)
+          .toHexString(),
         capitalProvider: intermediaryAddress,
         virtualAppUser: initiatorAddress
       },
@@ -1246,9 +1246,9 @@ async function getUpdatedStateChannelAndVirtualAppObjectsForIntermediary(
         tokenAddress,
         timeLockedPassThroughIdentityHash:
           timeLockedPassThroughAppInstance.identityHash,
-        capitalProvided: bigNumberify(initiatorBalanceDecrement).add(
-          responderBalanceDecrement
-        ),
+        capitalProvided: bigNumberify(initiatorBalanceDecrement)
+          .add(responderBalanceDecrement)
+          .toHexString(),
         capitalProvider: intermediaryAddress,
         virtualAppUser: responderAddress
       },
@@ -1332,9 +1332,9 @@ async function getUpdatedStateChannelAndVirtualAppObjectsForResponding(
         tokenAddress,
         timeLockedPassThroughIdentityHash:
           timeLockedPassThroughAppInstance.identityHash,
-        capitalProvided: bigNumberify(initiatorBalanceDecrement).add(
-          responderBalanceDecrement
-        ),
+        capitalProvided: bigNumberify(initiatorBalanceDecrement)
+          .add(responderBalanceDecrement)
+          .toHexString(),
         capitalProvider: intermediaryAddress,
         virtualAppUser: responderAddress
       },

--- a/packages/node/test/machine/integration/install-virtual.spec.ts
+++ b/packages/node/test/machine/integration/install-virtual.spec.ts
@@ -18,6 +18,7 @@ import {
 import { xkeysToSortedKthSigningKeys } from "../../../src/machine/xkeys";
 import { AppInstance, StateChannel } from "../../../src/models";
 import { FreeBalanceClass } from "../../../src/models/free-balance";
+import { SingleAssetTwoPartyIntermediaryAgreement } from "../../../src/models/state-channel";
 import { encodeSingleAssetTwoPartyIntermediaryAgreementParams } from "../../../src/protocol/install-virtual-app";
 import { transferERC20Tokens } from "../../integration/utils";
 
@@ -269,10 +270,10 @@ describe("Scenario: Install virtual app with and put on-chain", () => {
 
       const targetAppInstance = createTargetAppInstance();
 
-      const agreement = {
+      const agreement: SingleAssetTwoPartyIntermediaryAgreement = {
         capitalProvider,
         virtualAppUser,
-        capitalProvided: parseEther("10"),
+        capitalProvided: parseEther("10").toHexString(),
         tokenAddress: erc20Contract.address,
         /**
          * Note that this test cases does _not_ use a TimeLockedPassThrough, contrary
@@ -340,10 +341,10 @@ describe("Scenario: Install virtual app with and put on-chain", () => {
 
       const targetAppInstance = createTargetAppInstance();
 
-      const agreement = {
+      const agreement: SingleAssetTwoPartyIntermediaryAgreement = {
         capitalProvider,
         virtualAppUser,
-        capitalProvided: parseEther("10"),
+        capitalProvided: parseEther("10").toHexString(),
         tokenAddress: CONVENTION_FOR_ETH_TOKEN_ADDRESS,
         timeLockedPassThroughIdentityHash: HashZero
       };


### PR DESCRIPTION
`capitalProvided` could be stored as a `string` 