### PR TITLE
Remove a JSON class to simplify codebase

### DIFF
--- a/packages/cf-wallet.js/src/provider.ts
+++ b/packages/cf-wallet.js/src/provider.ts
@@ -1,6 +1,7 @@
 import {
   AppInstanceInfo,
   AppInstanceJson,
+  AppInstanceProposal,
   IRpcNodeProvider,
   Node
 } from "@counterfactual/types";
@@ -341,7 +342,7 @@ export class Provider {
    */
   async getOrCreateAppInstance(
     id: string,
-    info?: AppInstanceInfo | AppInstanceJson
+    info?: AppInstanceInfo | AppInstanceJson | AppInstanceProposal
   ): Promise<AppInstance> {
     if (!(id in this.appInstances)) {
       let newInfo;

--- a/packages/cf.js/src/provider.ts
+++ b/packages/cf.js/src/provider.ts
@@ -1,6 +1,7 @@
 import {
   AppInstanceInfo,
   AppInstanceJson,
+  AppInstanceProposal,
   IRpcNodeProvider,
   Node
 } from "@counterfactual/types";
@@ -254,7 +255,7 @@ export class Provider {
    */
   async getOrCreateAppInstance(
     id: string,
-    info?: AppInstanceInfo | AppInstanceJson
+    info?: AppInstanceInfo | AppInstanceJson | AppInstanceProposal
   ): Promise<AppInstance> {
     if (!(id in this.appInstances)) {
       let newInfo;

--- a/packages/node/src/methods/app-instance/install-virtual/operation.ts
+++ b/packages/node/src/methods/app-instance/install-virtual/operation.ts
@@ -6,6 +6,7 @@ import {
   NO_APP_INSTANCE_ID_TO_INSTALL,
   VIRTUAL_APP_INSTALLATION_FAIL
 } from "../../errors";
+import { bigNumberify } from "ethers/utils";
 
 export async function installVirtual(
   store: Store,
@@ -48,11 +49,11 @@ export async function installVirtual(
         initiatorXpub: proposedToIdentifier,
         responderXpub: proposedByIdentifier,
         intermediaryXpub: intermediaryIdentifier,
-        defaultTimeout: timeout.toNumber(),
+        defaultTimeout: bigNumberify(timeout).toNumber(),
         appInterface: { addr: appDefinition, ...abiEncodings },
         appSeqNo: proposal.appSeqNo,
-        initiatorBalanceDecrement: initiatorDeposit,
-        responderBalanceDecrement: responderDeposit,
+        initiatorBalanceDecrement: bigNumberify(initiatorDeposit),
+        responderBalanceDecrement: bigNumberify(responderDeposit),
         tokenAddress: initiatorDepositTokenAddress
       }
     );

--- a/packages/node/src/methods/app-instance/install/operation.ts
+++ b/packages/node/src/methods/app-instance/install/operation.ts
@@ -1,4 +1,5 @@
 import { AppInstanceProposal, Node } from "@counterfactual/types";
+import { bigNumberify } from "ethers/utils";
 
 import { Protocol, ProtocolRunner } from "../../../machine";
 import { StateChannel } from "../../../models";
@@ -31,8 +32,8 @@ export async function install(
     {
       initiatorXpub: proposal.proposedToIdentifier,
       responderXpub: proposal.proposedByIdentifier,
-      initiatorBalanceDecrement: proposal.initiatorDeposit,
-      responderBalanceDecrement: proposal.responderDeposit,
+      initiatorBalanceDecrement: bigNumberify(proposal.initiatorDeposit),
+      responderBalanceDecrement: bigNumberify(proposal.responderDeposit),
       multisigAddress: stateChannel.multisigAddress,
       participants: stateChannel.getSigningKeysFor(proposal.appSeqNo),
       initialState: proposal.initialState,
@@ -41,7 +42,7 @@ export async function install(
         addr: proposal.appDefinition
       },
       appSeqNo: proposal.appSeqNo,
-      defaultTimeout: proposal.timeout.toNumber(),
+      defaultTimeout: bigNumberify(proposal.timeout).toNumber(),
       outcomeType: proposal.outcomeType,
       initiatorDepositTokenAddress: proposal.initiatorDepositTokenAddress,
       responderDepositTokenAddress: proposal.responderDepositTokenAddress,

--- a/packages/node/src/methods/app-instance/propose-install/operation.ts
+++ b/packages/node/src/methods/app-instance/propose-install/operation.ts
@@ -1,6 +1,8 @@
 import { Node } from "@counterfactual/types";
+import { bigNumberify } from "ethers/utils";
 
 import { CONVENTION_FOR_ETH_TOKEN_ADDRESS } from "../../../constants";
+import { appIdentityToHash, xkeysToSortedKthSigningKeys } from "../../../machine";
 import { AppInstanceProposal } from "../../../models";
 import { Store } from "../../../store";
 import { getCreate2MultisigAddress } from "../../../utils";
@@ -18,7 +20,18 @@ export async function createProposedAppInstance(
   networkContext,
   params: Node.ProposeInstallParams
 ): Promise<string> {
-  const { proposedToIdentifier } = params;
+  const {
+    abiEncodings,
+    appDefinition,
+    initialState,
+    initiatorDeposit,
+    initiatorDepositTokenAddress,
+    outcomeType,
+    proposedToIdentifier,
+    responderDeposit,
+    responderDepositTokenAddress,
+    timeout
+  } = params;
 
   const multisigAddress = getCreate2MultisigAddress(
     [myIdentifier, proposedToIdentifier],
@@ -32,17 +45,30 @@ export async function createProposedAppInstance(
     proposedToIdentifier
   );
 
-  const appInstanceProposal = new AppInstanceProposal(
-    {
-      ...params,
-      proposedByIdentifier: myIdentifier,
-      initiatorDepositTokenAddress:
-        params.initiatorDepositTokenAddress || CONVENTION_FOR_ETH_TOKEN_ADDRESS,
-      responderDepositTokenAddress:
-        params.responderDepositTokenAddress || CONVENTION_FOR_ETH_TOKEN_ADDRESS
-    },
-    stateChannel
-  );
+  const appInstanceProposal: AppInstanceProposal = {
+    identityHash: appIdentityToHash({
+      appDefinition,
+      channelNonce: stateChannel.numProposedApps,
+      participants: stateChannel.getSigningKeysFor(
+        stateChannel.numProposedApps
+      ),
+      defaultTimeout: timeout.toNumber()
+    }),
+    abiEncodings: abiEncodings,
+    appDefinition: appDefinition,
+    appSeqNo: stateChannel.numProposedApps,
+    initialState: initialState,
+    initiatorDeposit: bigNumberify(initiatorDeposit),
+    initiatorDepositTokenAddress:
+      initiatorDepositTokenAddress || CONVENTION_FOR_ETH_TOKEN_ADDRESS,
+    outcomeType: outcomeType,
+    proposedByIdentifier: myIdentifier,
+    proposedToIdentifier: proposedToIdentifier,
+    responderDeposit: bigNumberify(responderDeposit),
+    responderDepositTokenAddress:
+      responderDepositTokenAddress || CONVENTION_FOR_ETH_TOKEN_ADDRESS,
+    timeout: bigNumberify(timeout)
+  };
 
   await store.saveStateChannel(stateChannel.addProposal(appInstanceProposal));
 

--- a/packages/node/src/models/app-instance-proposal.ts
+++ b/packages/node/src/models/app-instance-proposal.ts
@@ -3,12 +3,10 @@ import {
   OutcomeType,
   SolidityValueType
 } from "@counterfactual/types";
-import { BigNumber, bigNumberify, BigNumberish } from "ethers/utils";
+import { BigNumberish } from "ethers/utils";
 
-import { AppInstance } from "./app-instance";
-import { StateChannel } from "./state-channel";
-
-export interface IAppInstanceProposal {
+export interface AppInstanceProposal {
+  identityHash: string;
   appDefinition: string;
   abiEncodings: AppABIEncodings;
   initiatorDeposit: BigNumberish;
@@ -17,146 +15,9 @@ export interface IAppInstanceProposal {
   responderDepositTokenAddress: string;
   timeout: BigNumberish;
   initialState: SolidityValueType;
-  appSeqNo?: number;
-  proposedByIdentifier: string;
-  proposedToIdentifier: string;
-  intermediaryIdentifier?: string;
-  outcomeType: OutcomeType;
-}
-
-export interface AppInstanceProposalJSON {
-  identityHash: string;
-  appDefinition: string;
-  abiEncodings: AppABIEncodings;
-  initiatorDeposit: { _hex: string };
-  initiatorDepositTokenAddress: string;
-  responderDeposit: { _hex: string };
-  responderDepositTokenAddress: string;
-  timeout: { _hex: string };
-  initialState: SolidityValueType;
   appSeqNo: number;
   proposedByIdentifier: string;
   proposedToIdentifier: string;
   intermediaryIdentifier?: string;
   outcomeType: OutcomeType;
-}
-
-/**
- * The @counterfactual/cf.js package has a concept of an `AppInstanceInfo`:
- * https://github.com/counterfactual/monorepo/blob/master/packages/cf.js/API_REFERENCE.md#data-type-appinstanceinfo.
- * This is a simplified, client-side representation of what the machine calls an `AppInstance`.
- *
- * When an `AppInstanceInfo` is proposed to be installed by a client running the `cf.js`
- * package, the Node receives some state indicating the parameters of the proposal.
- * This class captures said state for the duration of the proposal being made and
- * the respecting `AppInstance` is installed.
- */
-export class AppInstanceProposal {
-  identityHash: string;
-  appDefinition: string;
-  abiEncodings: AppABIEncodings;
-  initiatorDeposit: BigNumber;
-  initiatorDepositTokenAddress: string;
-  responderDeposit: BigNumber;
-  responderDepositTokenAddress: string;
-  timeout: BigNumber;
-  initialState: SolidityValueType;
-  appSeqNo: number;
-  proposedByIdentifier: string;
-  proposedToIdentifier: string;
-  intermediaryIdentifier?: string;
-  outcomeType: OutcomeType;
-
-  constructor(
-    proposeParams: IAppInstanceProposal,
-    channel?: StateChannel,
-    overrideId?: string
-  ) {
-    this.appDefinition = proposeParams.appDefinition;
-    this.abiEncodings = proposeParams.abiEncodings;
-    this.initiatorDeposit = bigNumberify(proposeParams.initiatorDeposit);
-    this.initiatorDepositTokenAddress =
-      proposeParams.initiatorDepositTokenAddress;
-    this.responderDeposit = bigNumberify(proposeParams.responderDeposit);
-    this.responderDepositTokenAddress =
-      proposeParams.responderDepositTokenAddress;
-    this.timeout = bigNumberify(proposeParams.timeout);
-    this.proposedByIdentifier = proposeParams.proposedByIdentifier;
-    this.proposedToIdentifier = proposeParams.proposedToIdentifier;
-    this.initialState = proposeParams.initialState;
-    this.appSeqNo =
-      proposeParams.appSeqNo || (channel ? channel.numProposedApps : 0);
-    this.intermediaryIdentifier = proposeParams.intermediaryIdentifier;
-    this.outcomeType = proposeParams.outcomeType;
-    this.identityHash = overrideId || this.getIdentityHashFor(channel!);
-  }
-
-  getIdentityHashFor(stateChannel: StateChannel) {
-    return this.toAppInstanceFor(stateChannel).identityHash;
-  }
-
-  toAppInstanceFor(stateChannel: StateChannel) {
-    return new AppInstance(
-      stateChannel.getSigningKeysFor(this.appSeqNo),
-      bigNumberify(this.timeout).toNumber(),
-      {
-        addr: this.appDefinition,
-        ...this.abiEncodings
-      },
-      (this.intermediaryIdentifier || []).length > 0,
-      this.appSeqNo,
-      this.initialState,
-      0,
-      bigNumberify(this.timeout).toNumber(),
-      // the below two arguments are not currently used in app identity
-      // computation
-      ("" as unknown) as OutcomeType,
-      undefined,
-      // this is not relevant here as it gets set properly later in the context
-      // of the channel during an install, and it's not used to calculate
-      // the AppInstance ID so there won't be a possible mismatch between
-      // a proposed AppInstance ID and an installed AppInstance ID
-      undefined,
-      undefined
-    );
-  }
-
-  toJson(): AppInstanceProposalJSON {
-    return {
-      identityHash: this.identityHash,
-      appDefinition: this.appDefinition,
-      abiEncodings: this.abiEncodings,
-      initiatorDeposit: { _hex: this.initiatorDeposit.toHexString() },
-      initiatorDepositTokenAddress: this.initiatorDepositTokenAddress,
-      responderDeposit: { _hex: this.responderDeposit.toHexString() },
-      responderDepositTokenAddress: this.responderDepositTokenAddress,
-      initialState: this.initialState,
-      appSeqNo: this.appSeqNo,
-      timeout: { _hex: this.timeout.toHexString() },
-      proposedByIdentifier: this.proposedByIdentifier,
-      proposedToIdentifier: this.proposedToIdentifier,
-      intermediaryIdentifier: this.intermediaryIdentifier,
-      outcomeType: this.outcomeType
-    };
-  }
-
-  static fromJson(json: AppInstanceProposalJSON): AppInstanceProposal {
-    const proposeParams = {
-      appDefinition: json.appDefinition,
-      abiEncodings: json.abiEncodings,
-      initiatorDeposit: bigNumberify(json.initiatorDeposit._hex),
-      initiatorDepositTokenAddress: json.initiatorDepositTokenAddress,
-      responderDeposit: bigNumberify(json.responderDeposit._hex),
-      responderDepositTokenAddress: json.responderDepositTokenAddress,
-      timeout: bigNumberify(json.timeout._hex),
-      initialState: json.initialState,
-      appSeqNo: json.appSeqNo,
-      proposedByIdentifier: json.proposedByIdentifier,
-      proposedToIdentifier: json.proposedToIdentifier,
-      intermediaryIdentifier: json.intermediaryIdentifier,
-      outcomeType: json.outcomeType
-    };
-
-    return new AppInstanceProposal(proposeParams, undefined, json.identityHash);
-  }
-}
+};

--- a/packages/node/src/models/index.ts
+++ b/packages/node/src/models/index.ts
@@ -1,14 +1,5 @@
 import { AppInstance } from "./app-instance";
-import {
-  AppInstanceProposal,
-  AppInstanceProposalJSON
-} from "./app-instance-proposal";
+import { AppInstanceProposal } from "./app-instance-proposal";
 import { StateChannel, StateChannelJSON } from "./state-channel";
 
-export {
-  AppInstance,
-  AppInstanceProposal,
-  AppInstanceProposalJSON,
-  StateChannel,
-  StateChannelJSON
-};
+export { AppInstance, AppInstanceProposal, StateChannel, StateChannelJSON };

--- a/packages/node/src/models/state-channel.ts
+++ b/packages/node/src/models/state-channel.ts
@@ -9,7 +9,7 @@ import { xkeyKthAddress } from "../machine/xkeys";
 import { Store } from "../store";
 import { prettyPrintObject } from "../utils";
 
-import { AppInstanceProposal, AppInstanceProposalJSON } from ".";
+import { AppInstanceProposal } from ".";
 import { AppInstance } from "./app-instance";
 import {
   CoinTransferMap,
@@ -60,7 +60,7 @@ type SingleAssetTwoPartyIntermediaryAgreementJSON = {
 export type StateChannelJSON = {
   readonly multisigAddress: string;
   readonly userNeuteredExtendedKeys: string[];
-  readonly proposedAppInstances: [string, AppInstanceProposalJSON][];
+  readonly proposedAppInstances: [string, AppInstanceProposal][];
   readonly appInstances: [string, AppInstanceJson][];
   readonly singleAssetTwoPartyIntermediaryAgreements: [
     string,
@@ -530,11 +530,7 @@ export class StateChannel {
     return {
       multisigAddress: this.multisigAddress,
       userNeuteredExtendedKeys: this.userNeuteredExtendedKeys,
-      proposedAppInstances: [...this.proposedAppInstances.entries()].map(
-        (proposal): [string, AppInstanceProposalJSON] => {
-          return [proposal[0], proposal[1].toJson()];
-        }
-      ),
+      proposedAppInstances: [...this.proposedAppInstances.entries()],
       appInstances: [...this.appInstances.entries()].map((appInstanceEntry): [
         string,
         AppInstanceJson
@@ -569,7 +565,7 @@ export class StateChannel {
           string,
           AppInstanceProposal
         ] => {
-          return [proposal[0], AppInstanceProposal.fromJson(proposal[1])];
+          return [proposal[0], proposal[1]];
         })
       ),
       new Map(

--- a/packages/node/src/protocol/propose.ts
+++ b/packages/node/src/protocol/propose.ts
@@ -1,5 +1,5 @@
 import { CONVENTION_FOR_ETH_TOKEN_ADDRESS } from "../constants";
-import { ProtocolExecutionFlow } from "../machine";
+import { appIdentityToHash, ProtocolExecutionFlow } from "../machine";
 import { Opcode, Protocol } from "../machine/enums";
 import {
   Context,
@@ -47,25 +47,30 @@ export const PROPOSE_PROTOCOL: ProtocolExecutionFlow = {
         responderXpub
       ]);
 
-    const appInstanceProposal = new AppInstanceProposal(
-      {
+    const appInstanceProposal: AppInstanceProposal = {
+      appDefinition,
+      abiEncodings,
+      initiatorDeposit,
+      responderDeposit,
+      timeout,
+      initialState,
+      outcomeType,
+      identityHash: appIdentityToHash({
         appDefinition,
-        abiEncodings,
-        initiatorDeposit,
-        responderDeposit,
-        timeout,
-        initialState,
-        outcomeType,
-        proposedByIdentifier: initiatorXpub,
-        proposedToIdentifier: responderXpub,
-        appSeqNo: preProtocolStateChannel.numProposedApps + 1,
-        initiatorDepositTokenAddress:
-          initiatorDepositTokenAddress || CONVENTION_FOR_ETH_TOKEN_ADDRESS,
-        responderDepositTokenAddress:
-          responderDepositTokenAddress || CONVENTION_FOR_ETH_TOKEN_ADDRESS
-      },
-      preProtocolStateChannel
-    );
+        channelNonce: preProtocolStateChannel.numProposedApps + 1,
+        participants: preProtocolStateChannel.getSigningKeysFor(
+          preProtocolStateChannel.numProposedApps + 1
+        ),
+        defaultTimeout: timeout.toNumber()
+      }),
+      proposedByIdentifier: initiatorXpub,
+      proposedToIdentifier: responderXpub,
+      appSeqNo: preProtocolStateChannel.numProposedApps + 1,
+      initiatorDepositTokenAddress:
+        initiatorDepositTokenAddress || CONVENTION_FOR_ETH_TOKEN_ADDRESS,
+      responderDepositTokenAddress:
+        responderDepositTokenAddress || CONVENTION_FOR_ETH_TOKEN_ADDRESS
+    };
 
     const postProtocolStateChannel = preProtocolStateChannel.addProposal(
       appInstanceProposal
@@ -122,25 +127,30 @@ export const PROPOSE_PROTOCOL: ProtocolExecutionFlow = {
         responderXpub
       ]);
 
-    const appInstanceProposal = new AppInstanceProposal(
-      {
+    const appInstanceProposal: AppInstanceProposal = {
+      appDefinition,
+      abiEncodings,
+      timeout,
+      initialState,
+      outcomeType,
+      identityHash: appIdentityToHash({
         appDefinition,
-        abiEncodings,
-        timeout,
-        initialState,
-        outcomeType,
-        initiatorDeposit: responderDeposit,
-        responderDeposit: initiatorDeposit,
-        proposedByIdentifier: initiatorXpub,
-        proposedToIdentifier: responderXpub,
-        appSeqNo: preProtocolStateChannel.numProposedApps + 1,
-        initiatorDepositTokenAddress:
-          responderDepositTokenAddress || CONVENTION_FOR_ETH_TOKEN_ADDRESS,
-        responderDepositTokenAddress:
-          initiatorDepositTokenAddress || CONVENTION_FOR_ETH_TOKEN_ADDRESS
-      },
-      preProtocolStateChannel
-    );
+        channelNonce: preProtocolStateChannel.numProposedApps + 1,
+        participants: preProtocolStateChannel.getSigningKeysFor(
+          preProtocolStateChannel.numProposedApps + 1
+        ),
+        defaultTimeout: timeout.toNumber()
+      }),
+      initiatorDeposit: responderDeposit,
+      responderDeposit: initiatorDeposit,
+      proposedByIdentifier: initiatorXpub,
+      proposedToIdentifier: responderXpub,
+      appSeqNo: preProtocolStateChannel.numProposedApps + 1,
+      initiatorDepositTokenAddress:
+        responderDepositTokenAddress || CONVENTION_FOR_ETH_TOKEN_ADDRESS,
+      responderDepositTokenAddress:
+        initiatorDepositTokenAddress || CONVENTION_FOR_ETH_TOKEN_ADDRESS
+    };
 
     const postProtocolStateChannel = preProtocolStateChannel.addProposal(
       appInstanceProposal

--- a/packages/node/test/integration/utils.ts
+++ b/packages/node/test/integration/utils.ts
@@ -123,9 +123,9 @@ export async function getAppInstanceProposal(
   node: Node,
   appInstanceId: string
 ): Promise<AppInstanceProposal> {
-  const candidates = (await getProposedAppInstances(node)).filter(proposal => {
-    return proposal.identityHash === appInstanceId;
-  });
+  const candidates = (await getProposedAppInstances(node)).filter(
+    proposal => proposal.identityHash === appInstanceId
+  );
 
   if (candidates.length === 0) {
     throw new Error("Could not find proposal");

--- a/packages/node/test/unit/utils.ts
+++ b/packages/node/test/unit/utils.ts
@@ -14,30 +14,30 @@ import {
   StateChannel
 } from "../../src/models";
 
-export function createAppInstanceProposalForTest(appInstanceId: string) {
-  return new AppInstanceProposal(
-    {
-      proposedByIdentifier: computeRandomExtendedPrvKey(),
-      proposedToIdentifier: computeRandomExtendedPrvKey(),
-      appDefinition: AddressZero,
-      abiEncodings: {
-        stateEncoding: "tuple(address foo, uint256 bar)",
-        actionEncoding: undefined
-      } as AppABIEncodings,
-      initiatorDeposit: Zero,
-      responderDeposit: Zero,
-      timeout: One,
-      initialState: {
-        foo: AddressZero,
-        bar: 0
-      } as SolidityValueType,
-      outcomeType: OutcomeType.TWO_PARTY_FIXED_OUTCOME,
-      initiatorDepositTokenAddress: CONVENTION_FOR_ETH_TOKEN_ADDRESS,
-      responderDepositTokenAddress: CONVENTION_FOR_ETH_TOKEN_ADDRESS
-    },
-    undefined,
-    appInstanceId
-  );
+export function createAppInstanceProposalForTest(
+  appInstanceId: string
+): AppInstanceProposal {
+  return {
+    identityHash: appInstanceId,
+    proposedByIdentifier: computeRandomExtendedPrvKey(),
+    proposedToIdentifier: computeRandomExtendedPrvKey(),
+    appDefinition: AddressZero,
+    abiEncodings: {
+      stateEncoding: "tuple(address foo, uint256 bar)",
+      actionEncoding: undefined
+    } as AppABIEncodings,
+    initiatorDeposit: Zero,
+    responderDeposit: Zero,
+    timeout: One,
+    initialState: {
+      foo: AddressZero,
+      bar: 0
+    } as SolidityValueType,
+    appSeqNo: 0,
+    outcomeType: OutcomeType.TWO_PARTY_FIXED_OUTCOME,
+    initiatorDepositTokenAddress: CONVENTION_FOR_ETH_TOKEN_ADDRESS,
+    responderDepositTokenAddress: CONVENTION_FOR_ETH_TOKEN_ADDRESS
+  };
 }
 
 export function createAppInstanceForTest(stateChannel?: StateChannel) {

--- a/packages/types/src/data-types.ts
+++ b/packages/types/src/data-types.ts
@@ -1,5 +1,5 @@
 // https://github.com/counterfactual/monorepo/blob/master/packages/cf.js/API_REFERENCE.md#data-types
-import { BigNumber } from "ethers/utils";
+import { BigNumber, BigNumberish } from "ethers/utils";
 
 import { AppInterface, SolidityValueType } from ".";
 
@@ -114,17 +114,20 @@ export type AppInstanceInfo = {
 };
 
 export type AppInstanceProposal = {
-  identityHash: string;
-  appDefinition: string;
   abiEncodings: AppABIEncodings;
-  initiatorDeposit: BigNumber;
+  appDefinition: string;
+  appSeqNo: number;
+  identityHash: string;
+  initialState: SolidityValueType;
+  initiatorDeposit: BigNumberish;
   initiatorDepositTokenAddress: string;
-  responderDeposit: BigNumber;
-  responderDepositTokenAddress: string;
-  timeout: BigNumber;
-  proposedByIdentifier: string; // xpub
-  proposedToIdentifier: string; // xpub
   intermediaryIdentifier?: string;
+  outcomeType: OutcomeType;
+  proposedByIdentifier: string;
+  proposedToIdentifier: string;
+  responderDeposit: BigNumberish;
+  responderDepositTokenAddress: string;
+  timeout: BigNumberish;
 
   /**
    * Interpreter-related Fields
@@ -133,6 +136,8 @@ export type AppInstanceProposal = {
   multiAssetMultiPartyCoinTransferInterpreterParams?: MultiAssetMultiPartyCoinTransferInterpreterParams;
   singleAssetTwoPartyCoinTransferInterpreterParams?: SingleAssetTwoPartyCoinTransferInterpreterParams;
 };
+
+
 
 export type AppABIEncodings = {
   stateEncoding: string;


### PR DESCRIPTION
Another brick in the wall of trying to remove `class` instances in the codebase to represent data structures that don't need to be serialized individually before being put onto the disk. 