### PR TITLE
[node] proposed app removal

### DIFF
--- a/packages/node/src/message-handling/handle-protocol-message.ts
+++ b/packages/node/src/message-handling/handle-protocol-message.ts
@@ -57,7 +57,9 @@ export async function handleReceivedProtocolMessage(
     outgoingEventData &&
     (protocol === Protocol.Install || protocol === Protocol.InstallVirtualApp)
   ) {
-    const appInstanceId = outgoingEventData!.data["appInstanceId"];
+    const appInstanceId =
+      outgoingEventData!.data["appInstanceId"] ||
+      (outgoingEventData!.data as any).params["appInstanceId"];
     if (appInstanceId) {
       let proposal;
       try {

--- a/packages/node/test/integration/install.spec.ts
+++ b/packages/node/test/integration/install.spec.ts
@@ -15,10 +15,10 @@ import {
   getAppContext,
   getBalances,
   getInstalledAppInstances,
+  getProposedAppInstances,
   makeAndSendProposeCall,
   makeInstallCall,
-  transferERC20Tokens,
-  getProposedAppInstances
+  transferERC20Tokens
 } from "./utils";
 
 expect.extend({ toBeLt });
@@ -63,7 +63,7 @@ describe("Node method follows spec - install", () => {
           makeInstallCall(nodeB, msg.data.appInstanceId);
         });
 
-        // FIXME: still no symmetric events -- nodeB will never emit an 
+        // FIXME: still no symmetric events -- nodeB will never emit an
         // `INSTALL` event
         // let installEvents = 0;
         // nodeB.once(NODE_EVENTS.INSTALL, async () => {

--- a/packages/node/test/integration/install.spec.ts
+++ b/packages/node/test/integration/install.spec.ts
@@ -17,7 +17,8 @@ import {
   getInstalledAppInstances,
   makeAndSendProposeCall,
   makeInstallCall,
-  transferERC20Tokens
+  transferERC20Tokens,
+  getProposedAppInstances
 } from "./utils";
 
 expect.extend({ toBeLt });
@@ -62,11 +63,26 @@ describe("Node method follows spec - install", () => {
           makeInstallCall(nodeB, msg.data.appInstanceId);
         });
 
+        // FIXME: still no symmetric events -- nodeB will never emit an 
+        // `INSTALL` event
+        // let installEvents = 0;
+        // nodeB.once(NODE_EVENTS.INSTALL, async () => {
+        //   const proposedAppsB = await getProposedAppInstances(nodeB);
+        //   expect(proposedAppsB.length).toEqual(0);
+        //   installEvents += 1;
+        //   if (installEvents === 2) {
+        //     done();
+        //   }
+        // });
+
         nodeA.on(NODE_EVENTS.INSTALL, async () => {
           const [appInstanceNodeA] = await getInstalledAppInstances(nodeA);
           const [appInstanceNodeB] = await getInstalledAppInstances(nodeB);
           expect(appInstanceNodeA).toBeDefined();
           expect(appInstanceNodeA).toEqual(appInstanceNodeB);
+
+          const proposedAppsA = await getProposedAppInstances(nodeA);
+          expect(proposedAppsA.length).toBe(0);
 
           [
             postInstallETHBalanceNodeA,
@@ -81,8 +97,13 @@ describe("Node method follows spec - install", () => {
           expect(postInstallETHBalanceNodeA).toBeLt(preInstallETHBalanceNodeA);
 
           expect(postInstallETHBalanceNodeB).toBeLt(preInstallETHBalanceNodeB);
-
           done();
+
+          // FIXME: add the below when there are symmetric events
+          // installEvents += 1;
+          // if (installEvents === 2) {
+          //   done();
+          // }
         });
 
         await makeAndSendProposeCall(


### PR DESCRIPTION
### Description

Apps were not being removed from the proposed apps list in the state channel when the protocol completed for the non-initiating party.

Fixed by defaulting to original accessing of `appInstanceId`, but adding another check in case it was in the `params` of the `data` obj.

May want to clean up the casting, or the added place for the test stubs, but functional