### PR TITLE
[types, node, cf.js] clean enums

### DIFF
--- a/packages/cf.js/src/app-factory.ts
+++ b/packages/cf.js/src/app-factory.ts
@@ -126,7 +126,7 @@ export class AppFactory {
     );
 
     const response = await this.provider.callRawNodeMethod(
-      Node.RpcMethodName.PROPOSE_INSTALL_VIRTUAL,
+      Node.RpcMethodName.PROPOSE_INSTALL,
       {
         timeout,
         responderDeposit,

--- a/packages/cf.js/test/app-factory.spec.ts
+++ b/packages/cf.js/test/app-factory.spec.ts
@@ -80,9 +80,7 @@ describe("CF.js AppFactory", () => {
       nodeProvider.onMethodRequest(
         Node.RpcMethodName.PROPOSE_INSTALL,
         request => {
-          expect(request.methodName).toBe(
-            Node.RpcMethodName.PROPOSE_INSTALL
-          );
+          expect(request.methodName).toBe(Node.RpcMethodName.PROPOSE_INSTALL);
           const params = request.parameters as Node.ProposeInstallVirtualParams;
           expect(params.initialState).toBe(expectedState);
           expect(params.intermediaryIdentifier).toBe(expectedHubIdentifier);

--- a/packages/cf.js/test/app-factory.spec.ts
+++ b/packages/cf.js/test/app-factory.spec.ts
@@ -78,10 +78,10 @@ describe("CF.js AppFactory", () => {
       const expectedHubIdentifier = TEST_XPUBS[1];
 
       nodeProvider.onMethodRequest(
-        Node.RpcMethodName.PROPOSE_INSTALL_VIRTUAL,
+        Node.RpcMethodName.PROPOSE_INSTALL,
         request => {
           expect(request.methodName).toBe(
-            Node.RpcMethodName.PROPOSE_INSTALL_VIRTUAL
+            Node.RpcMethodName.PROPOSE_INSTALL
           );
           const params = request.parameters as Node.ProposeInstallVirtualParams;
           expect(params.initialState).toBe(expectedState);
@@ -90,7 +90,7 @@ describe("CF.js AppFactory", () => {
           nodeProvider.simulateMessageFromNode({
             jsonrpc: "2.0",
             result: {
-              type: Node.RpcMethodName.PROPOSE_INSTALL_VIRTUAL,
+              type: Node.RpcMethodName.PROPOSE_INSTALL,
               result: {
                 appInstanceId: expectedAppInstanceId
               }

--- a/packages/node/src/methods/app-instance/propose-install/controller.ts
+++ b/packages/node/src/methods/app-instance/propose-install/controller.ts
@@ -21,7 +21,6 @@ import {
  */
 export default class ProposeInstallController extends NodeController {
   @jsonRpcMethod(Node.RpcMethodName.PROPOSE_INSTALL)
-  @jsonRpcMethod(Node.RpcMethodName.PROPOSE_INSTALL_VIRTUAL)
   public executeMethod = super.executeMethod;
 
   protected async getRequiredLockNames(

--- a/packages/node/test/integration/install-concurrent-mixed.spec.ts
+++ b/packages/node/test/integration/install-concurrent-mixed.spec.ts
@@ -61,7 +61,7 @@ describe("Concurrently installing virtual and regular applications without issue
       makeInstallCall(nodeB, msg.data.appInstanceId);
     });
 
-    nodeC.on(NODE_EVENTS.PROPOSE_INSTALL_VIRTUAL, (msg: ProposeMessage) => {
+    nodeC.on(NODE_EVENTS.PROPOSE_INSTALL, (msg: ProposeMessage) => {
       installTTTVirtual(nodeC, msg.data.appInstanceId, nodeB.publicIdentifier);
     });
 

--- a/packages/node/test/integration/install-virtual.spec.ts
+++ b/packages/node/test/integration/install-virtual.spec.ts
@@ -51,7 +51,7 @@ describe("Node method follows spec - proposeInstallVirtual", () => {
         });
 
         nodeC.once(
-          NODE_EVENTS.PROPOSE_INSTALL_VIRTUAL,
+          NODE_EVENTS.PROPOSE_INSTALL,
           async ({ data: { params, appInstanceId } }: ProposeMessage) => {
             const [proposedAppNodeC] = await getProposedAppInstances(nodeC);
 

--- a/packages/node/test/integration/reject-install-virtual.spec.ts
+++ b/packages/node/test/integration/reject-install-virtual.spec.ts
@@ -41,7 +41,7 @@ describe("Node method follows spec - rejectInstallVirtual", () => {
         });
 
         nodeC.once(
-          NODE_EVENTS.PROPOSE_INSTALL_VIRTUAL,
+          NODE_EVENTS.PROPOSE_INSTALL,
           async ({ data: { params, appInstanceId } }: ProposeMessage) => {
             const [proposedAppInstanceC] = await getProposedAppInstances(nodeC);
 

--- a/packages/node/test/integration/utils.ts
+++ b/packages/node/test/integration/utils.ts
@@ -383,7 +383,7 @@ export function constructVirtualProposalRpc(
   return jsonRpcDeserialize({
     params: installVirtualParams,
     id: Date.now(),
-    method: NodeTypes.RpcMethodName.PROPOSE_INSTALL_VIRTUAL,
+    method: NodeTypes.RpcMethodName.PROPOSE_INSTALL,
     jsonrpc: "2.0"
   });
 }
@@ -591,7 +591,7 @@ export async function installVirtualApp(
   responderDeposit?: BigNumber
 ): Promise<string> {
   nodeC.on(
-    NODE_EVENTS.PROPOSE_INSTALL_VIRTUAL,
+    NODE_EVENTS.PROPOSE_INSTALL,
     async ({ data: { appInstanceId: eventAppInstanceId } }: ProposeMessage) => {
       const {
         appInstanceId,
@@ -704,7 +704,7 @@ export async function makeVirtualProposal(
     }
   } = await nodeA.rpcRouter.dispatch({
     parameters: params,
-    methodName: NodeTypes.RpcMethodName.PROPOSE_INSTALL_VIRTUAL,
+    methodName: NodeTypes.RpcMethodName.PROPOSE_INSTALL,
     id: Date.now()
   });
 

--- a/packages/types/src/node.ts
+++ b/packages/types/src/node.ts
@@ -105,7 +105,6 @@ export namespace Node {
     INSTALL = "chan_install",
     INSTALL_VIRTUAL = "chan_installVirtual",
     PROPOSE_INSTALL = "chan_proposeInstall",
-    PROPOSE_INSTALL_VIRTUAL = "chan_proposeInstallVirtual",
     PROPOSE_STATE = "chan_proposeState",
     REJECT_INSTALL = "chan_rejectInstall",
     REJECT_STATE = "chan_rejectState",
@@ -136,7 +135,6 @@ export namespace Node {
     WITHDRAWAL_FAILED = "withdrawalFailed",
     WITHDRAWAL_STARTED = "withdrawalStartedEvent",
     PROPOSE_INSTALL = "proposeInstallEvent",
-    PROPOSE_INSTALL_VIRTUAL = "proposeInstallEvent",
     PROTOCOL_MESSAGE_EVENT = "protocolMessageEvent",
     WITHDRAW_EVENT = "withdrawEvent",
     REJECT_INSTALL_VIRTUAL = "rejectInstallEvent"


### PR DESCRIPTION
remove all `PROPOSE_INSTALL_VIRTUAL`

this is a breaking API change, but leaving it in events specifically is weird.